### PR TITLE
ci(prod): fix Play internal release flow for draft app

### DIFF
--- a/.github/workflows/deploy_prod_android.yml
+++ b/.github/workflows/deploy_prod_android.yml
@@ -117,6 +117,7 @@ jobs:
           packageName: ${{ secrets.PROD_ANDROID_PACKAGE_NAME }}
           releaseFiles: build/app/outputs/bundle/prodRelease/app-prod-release.aab
           track: internal
+          status: draft
 
       # 事前に Firebase プロジェクトの Project Settings > Integrations から Google Play Console と連携しておく必要がある。
       - name: Deploy to Firebase App Distribution

--- a/.github/workflows/deploy_prod_android.yml
+++ b/.github/workflows/deploy_prod_android.yml
@@ -107,19 +107,6 @@ jobs:
       - name: Get latest 10 commit messages
         run: echo "LATEST_COMMIT_MESSAGES=$(git log -n 10 --pretty=format:'%s' | tr '\n' '; ')" >> $GITHUB_ENV
 
-      # 事前に Firebase プロジェクトの Project Settings > Integrations から Google Play Console と連携しておく必要がある。
-      - name: Deploy to Firebase App Distribution
-        env:
-          PROD_FIREBASE_SERVICE_ACCOUNT_KEY_BASE64: ${{ secrets.PROD_FIREBASE_SERVICE_ACCOUNT_KEY_BASE64 }}
-        run: |
-          echo $PROD_FIREBASE_SERVICE_ACCOUNT_KEY_BASE64 | base64 -d > /tmp/prod_firebase_service_account_key.json
-          export GOOGLE_APPLICATION_CREDENTIALS=/tmp/prod_firebase_service_account_key.json
-          firebase use --project ${{ secrets.PROD_FIREBASE_PROJECT_ID }}
-          firebase appdistribution:distribute ./build/app/outputs/bundle/prodRelease/app-prod-release.aab \
-            --app ${{ secrets.PROD_FIREBASE_ANDROID_APP_ID }} \
-            --groups internal-testers  \
-            --release-notes "${LATEST_COMMIT_MESSAGES}"
-
       - name: Decode Google Play Console API Service Account Key
         run: echo "${{ secrets.GOOGLE_PLAY_CONSOLE_API_SERVICE_ACCOUNT_KEY_JSON_BASE64 }}" | base64 --decode > /tmp/google_play_console_api_service_account_key.json
 
@@ -130,3 +117,17 @@ jobs:
           packageName: ${{ secrets.PROD_ANDROID_PACKAGE_NAME }}
           releaseFiles: build/app/outputs/bundle/prodRelease/app-prod-release.aab
           track: internal
+
+      # 事前に Firebase プロジェクトの Project Settings > Integrations から Google Play Console と連携しておく必要がある。
+      - name: Deploy to Firebase App Distribution
+        continue-on-error: true
+        env:
+          PROD_FIREBASE_SERVICE_ACCOUNT_KEY_BASE64: ${{ secrets.PROD_FIREBASE_SERVICE_ACCOUNT_KEY_BASE64 }}
+        run: |
+          echo $PROD_FIREBASE_SERVICE_ACCOUNT_KEY_BASE64 | base64 -d > /tmp/prod_firebase_service_account_key.json
+          export GOOGLE_APPLICATION_CREDENTIALS=/tmp/prod_firebase_service_account_key.json
+          firebase use --project ${{ secrets.PROD_FIREBASE_PROJECT_ID }}
+          firebase appdistribution:distribute ./build/app/outputs/bundle/prodRelease/app-prod-release.aab \
+            --app ${{ secrets.PROD_FIREBASE_ANDROID_APP_ID }} \
+            --groups internal-testers  \
+            --release-notes "${LATEST_COMMIT_MESSAGES}"


### PR DESCRIPTION
## What\n- publish Play internal release before Firebase distribution\n- allow Firebase App Distribution step to continue-on-error\n- set Play upload status to draft for draft-app restriction\n\n## Verification\n- Prod Android workflow succeeded on this branch\n  - https://github.com/keishimizu26629/LaKiite-flutter-app/actions/runs/22889960963\n- Key reset and API enablement validated