### PR TITLE
fix: stabilize auth session transitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,8 @@ android/app/google-services.json
 # cursor
 .cursor/
 .cursorrules
+.serena/
+/test-worktree/
 
 # Test related
 coverage/

--- a/integration_test/auth_flow_integration_test.dart
+++ b/integration_test/auth_flow_integration_test.dart
@@ -79,7 +79,7 @@ void main() {
 
       // 段階的にスプラッシュ画面の待機を行い、状態を確認
       for (int i = 1; i <= 5; i++) {
-        print('⏳ [$testName] スプラッシュ画面待機 ${i}秒目...');
+        print('⏳ [$testName] スプラッシュ画面待機 $i秒目...');
         await Future.delayed(const Duration(seconds: 1));
         await tester.pumpAndSettle();
 

--- a/integration_test/login_signup_home_navigation_integration_test.dart
+++ b/integration_test/login_signup_home_navigation_integration_test.dart
@@ -1,0 +1,153 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:lakiite/config/app_config.dart';
+import 'package:lakiite/main.dart';
+
+import '../mock/providers/test_providers.dart';
+import '../test/utils/test_utils.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group('認証フロー統合テスト', () {
+    setUp(() {
+      TestProviders.reset();
+    });
+
+    tearDown(() {
+      TestProviders.reset();
+    });
+
+    testWidgets('ログイン成功後にカレンダー初期画面へ遷移する', (tester) async {
+      await startApp(
+        Environment.development,
+        TestProviders.forLoginForm,
+        true,
+      );
+      await _pumpUntilFound(
+        tester,
+        find.descendant(
+          of: find.byType(AppBar),
+          matching: find.text('ログイン'),
+        ),
+      );
+
+      expect(
+        find.descendant(
+          of: find.byType(AppBar),
+          matching: find.text('ログイン'),
+        ),
+        findsOneWidget,
+      );
+
+      await TestUtils.performLogin(tester: tester);
+
+      await _pumpUntilCalendarInitialScreen(tester);
+
+      _expectCalendarInitialScreen();
+    });
+
+    testWidgets('新規登録成功後にカレンダー初期画面へ遷移する', (tester) async {
+      await startApp(
+        Environment.development,
+        TestProviders.forSignupForm,
+        true,
+      );
+      await _pumpUntilFound(
+        tester,
+        find.text('アカウントをお持ちでない方は新規登録'),
+      );
+
+      final signupLink = find.text('アカウントをお持ちでない方は新規登録');
+      expect(signupLink, findsOneWidget);
+
+      await tester.tap(signupLink);
+      await _pumpUntilFound(
+        tester,
+        find.descendant(
+          of: find.byType(AppBar),
+          matching: find.text('新規登録'),
+        ),
+      );
+
+      expect(
+        find.descendant(
+          of: find.byType(AppBar),
+          matching: find.text('新規登録'),
+        ),
+        findsOneWidget,
+      );
+
+      await TestUtils.performSignUp(
+        tester: tester,
+        name: '統合テストユーザー',
+        displayName: '統合テスト表示名',
+        email: 'integration-signup@example.com',
+        password: 'password123',
+      );
+
+      await _pumpUntilCalendarInitialScreen(tester);
+
+      _expectCalendarInitialScreen();
+    });
+  });
+}
+
+Future<void> _pumpUntilCalendarInitialScreen(WidgetTester tester) async {
+  await _pumpUntil(
+    tester,
+    () =>
+        find.text('カレンダー').evaluate().isNotEmpty &&
+        find.text('タイムライン').evaluate().isNotEmpty &&
+        find
+            .descendant(
+              of: find.byType(AppBar),
+              matching: find.text('ホーム'),
+            )
+            .evaluate()
+            .isNotEmpty,
+  );
+}
+
+Future<void> _pumpUntilFound(
+  WidgetTester tester,
+  Finder finder, {
+  Duration timeout = const Duration(seconds: 10),
+}) async {
+  await _pumpUntil(
+    tester,
+    () => finder.evaluate().isNotEmpty,
+    timeout: timeout,
+  );
+}
+
+Future<void> _pumpUntil(
+  WidgetTester tester,
+  bool Function() predicate, {
+  Duration step = const Duration(milliseconds: 100),
+  Duration timeout = const Duration(seconds: 10),
+}) async {
+  final endAt = DateTime.now().add(timeout);
+
+  while (DateTime.now().isBefore(endAt)) {
+    await tester.pump(step);
+    if (predicate()) {
+      return;
+    }
+  }
+
+  fail('timeout waiting for expected UI');
+}
+
+void _expectCalendarInitialScreen() {
+  expect(find.text('カレンダー'), findsOneWidget);
+  expect(find.text('タイムライン'), findsOneWidget);
+  expect(
+    find.descendant(
+      of: find.byType(AppBar),
+      matching: find.text('ホーム'),
+    ),
+    findsOneWidget,
+  );
+}

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1545,12 +1545,12 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   abseil: a05cc83bf02079535e17169a73c5be5ba47f714b
   BoringSSL-GRPC: dded2a44897e45f28f08ae87a55ee4bcd19bc508
-  cloud_firestore: 56865cb5aaf44141583c4ee957be36f6af72178d
+  cloud_firestore: 7a6d8a533ec7418a7fe46b3a5dabf55661a5b298
   Firebase: f07b15ae5a6ec0f93713e30b923d9970d144af3e
-  firebase_auth: 4816610b91e98ca2f48df6c62e0247036e0856ff
-  firebase_core: e6b8bb503b7d1d9856e698d4f193f7b414e6bf1f
-  firebase_messaging: fc7b6af84f4cd885a4999f51ea69ef20f380d70d
-  firebase_storage: 0cb7ceae9496b643ffe734ba2645b8b7339b0cc4
+  firebase_auth: 9225db04db5d8e3b46dc8940e04bc6aec6833e27
+  firebase_core: f1aafb21c14f497e5498f7ffc4dc63cbb52b2594
+  firebase_messaging: c17a29984eafce4b2997fe078bb0a9e0b06f5dde
+  firebase_storage: d558bbfa99449fff39352db83c466c8515fa1afa
   FirebaseAppCheckInterop: f734c802f21fe1da0837708f0f9a27218c8a4ed0
   FirebaseAuth: 4a2aed737c84114a9d9b33d11ae1b147d6b94889
   FirebaseAuthInterop: 858e6b754966e70740a4370dd1503dfffe6dbb49
@@ -1564,19 +1564,19 @@ SPEC CHECKSUMS:
   FirebaseSharedSwift: 93426a1de92f19e1199fac5295a4f8df16458daa
   FirebaseStorage: 20d6b56fb8a40ebaa03d6a2889fe33dac64adb73
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  flutter_image_compress_common: ec1d45c362c9d30a3f6a0426c297f47c52007e3e
-  flutter_local_notifications: ff50f8405aaa0ccdc7dcfb9022ca192e8ad9688f
-  flutter_native_splash: f71420956eb811e6d310720fee915f1d42852e7a
+  flutter_image_compress_common: 1697a328fd72bfb335507c6bca1a65fa5ad87df1
+  flutter_local_notifications: a5a732f069baa862e728d839dd2ebb904737effb
+  flutter_native_splash: 6cad9122ea0fad137d23137dd14b937f3e90b145
   Google-Mobile-Ads-SDK: 14f57f2dc33532a24db288897e26494640810407
-  google_mobile_ads: fe0e2c1764ad95323dd0e3081d0bb2d58411f957
+  google_mobile_ads: 16ad301354fa6a7ea55770c6254bd4339bf8558b
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUserMessagingPlatform: befe603da6501006420c206222acd449bba45a9c
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
   "gRPC-C++": cc207623316fb041a7a3e774c252cf68a058b9e8
   gRPC-Core: 860978b7db482de8b4f5e10677216309b5ff6330
   GTMSessionFetcher: 02d6e866e90bc236f48a703a041dfe43e6221a29
-  image_picker_ios: c560581cceedb403a6ff17f2f816d7fea1421fc1
-  integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
+  image_picker_ios: 7fe1ff8e34c1790d6fff70a32484959f563a928a
+  integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
   leveldb-library: cc8b8f8e013647a295ad3f8cd2ddf49a6f19be19
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   Mantle: c5aa8794a29a022dfbbfc9799af95f477a69b62d
@@ -1585,8 +1585,8 @@ SPEC CHECKSUMS:
   RecaptchaInterop: 11e0b637842dfb48308d242afc3f448062325aba
   SDWebImage: 16309af6d214ba3f77a7c6f6fdda888cb313a50a
   SDWebImageWebPCoder: 0e06e365080397465cc73a7a9b472d8a3bd0f377
-  url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
-  webview_flutter_wkwebview: 2e2d318f21a5e036e2c3f26171342e95908bd60a
+  url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
+  webview_flutter_wkwebview: 75789e80e2ad25e78ac88a17e5c2f82019277c53
 
 PODFILE CHECKSUM: d1cdfba38d54546d4a9066da976b79cacf5a9e37
 

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -8,7 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
-		283F1587DA352FE6CD128870 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = E42A56873CE9DEC29F60D96E /* GoogleService-Info.plist */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
@@ -53,7 +52,6 @@
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9AA669E104F34E6D847703A8 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
-		E42A56873CE9DEC29F60D96E /* GoogleService-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "Runner/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		E4584817BB87B9314B4314FC /* Pods-Runner.release-prod.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release-prod.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release-prod.xcconfig"; sourceTree = "<group>"; };
 		ECB3281A2DE0554300EBAD4B /* Runner.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Runner.entitlements; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -87,7 +85,6 @@
 				9740EEB11CF90186004384FC /* Flutter */,
 				97C146F01CF9000F007C117D /* Runner */,
 				97C146EF1CF9000F007C117D /* Products */,
-				E42A56873CE9DEC29F60D96E /* GoogleService-Info.plist */,
 				9B4FF7A6E497DE360C99539D /* Pods */,
 				F53A988348D24B6A7F38CF66 /* Frameworks */,
 			);
@@ -153,6 +150,7 @@
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
+				5F31C95A4A5D4A9A8F2E9C10 /* Copy GoogleService-Info */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				702630DF86CC92C176C9170C /* [CP] Embed Pods Frameworks */,
@@ -209,7 +207,6 @@
 				3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */,
 				97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */,
 				97C146FC1CF9000F007C117D /* Main.storyboard in Resources */,
-				283F1587DA352FE6CD128870 /* GoogleService-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -269,6 +266,24 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		5F31C95A4A5D4A9A8F2E9C10 /* Copy GoogleService-Info */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PROJECT_DIR}/Runner/Firebase/Dev/GoogleService-Info.plist",
+				"${PROJECT_DIR}/Runner/Firebase/Prod/GoogleService-Info.plist",
+			);
+			name = "Copy GoogleService-Info";
+			outputPaths = (
+				"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app/GoogleService-Info.plist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -e\nDESTINATION=\"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app/GoogleService-Info.plist\"\ncase \"${CONFIGURATION}\" in\n  *-dev)\n    SOURCE=\"${PROJECT_DIR}/Runner/Firebase/Dev/GoogleService-Info.plist\"\n    ;;\n  *-prod)\n    SOURCE=\"${PROJECT_DIR}/Runner/Firebase/Prod/GoogleService-Info.plist\"\n    ;;\n  *)\n    SOURCE=\"${PROJECT_DIR}/Runner/GoogleService-Info.plist\"\n    ;;\nesac\ncp \"${SOURCE}\" \"${DESTINATION}\"\necho \"Copied GoogleService-Info.plist from ${SOURCE} to ${DESTINATION}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		702630DF86CC92C176C9170C /* [CP] Embed Pods Frameworks */ = {
@@ -383,7 +398,6 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
-				SUPPORTED_PLATFORMS = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 			};
@@ -406,7 +420,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.inoworl.lakiite;
+					PRODUCT_BUNDLE_IDENTIFIER = com.inoworl.lakiite.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
@@ -518,7 +532,6 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
-				SUPPORTED_PLATFORMS = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -571,7 +584,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.inoworl.lakiite;
+					PRODUCT_BUNDLE_IDENTIFIER = com.inoworl.lakiite.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
@@ -626,7 +639,6 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
-				SUPPORTED_PLATFORMS = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -651,7 +663,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.inoworl.lakiite;
+				PRODUCT_BUNDLE_IDENTIFIER = com.inoworl.lakiite.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
@@ -706,7 +718,6 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
-				SUPPORTED_PLATFORMS = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -786,7 +797,6 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
-				SUPPORTED_PLATFORMS = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -866,7 +876,6 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
-				SUPPORTED_PLATFORMS = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -946,7 +955,6 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
-				SUPPORTED_PLATFORMS = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1026,7 +1034,6 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
-				SUPPORTED_PLATFORMS = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -10,8 +10,6 @@ import UserNotifications
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
-    FirebaseApp.configure()
-
     // テスト時は通知許可をリクエストしない
     let isTestMode = ProcessInfo.processInfo.environment["TEST_MODE"] == "true"
     if isTestMode {

--- a/lib/application/auth/auth_notifier.dart
+++ b/lib/application/auth/auth_notifier.dart
@@ -1,17 +1,12 @@
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:firebase_auth/firebase_auth.dart';
-import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/services.dart';
 import 'dart:io';
 import '../../domain/interfaces/i_auth_repository.dart';
 import '../../domain/entity/user.dart';
 import '../../infrastructure/auth_repository.dart';
 import '../../infrastructure/user_fcm_token_service.dart';
-import '../../infrastructure/user_repository.dart';
-import '../../infrastructure/schedule_repository.dart';
 import '../../presentation/presentation_provider.dart';
-import '../../presentation/calendar/widgets/calendar_page_view.dart';
-import '../../presentation/my_page/my_page_view_model.dart';
 import '../../utils/logger.dart';
 import '../../utils/webview_monitor.dart';
 import 'auth_state.dart';
@@ -90,6 +85,8 @@ class AuthNotifier extends _$AuthNotifier {
   /// - 認証成功時は[AuthState.authenticated]
   /// - 失敗時は[AuthState.unauthenticated]
   Future<void> signIn(String email, String password) async {
+    AppLogger.debugOnly('signIn開始: email=$email');
+
     // ローディング状態に設定
     state = const AsyncLoading();
 
@@ -103,7 +100,7 @@ class AuthNotifier extends _$AuthNotifier {
         // FCMトークンを更新（リトライ付き）
         try {
           AppLogger.debug('サインイン: FCMトークン更新を開始');
-          await _fcmTokenService!.updateCurrentUserFcmToken();
+          await _fcmTokenService?.updateCurrentUserFcmToken();
           AppLogger.debug('サインイン: FCMトークン更新完了');
         } catch (e) {
           AppLogger.error('サインイン: FCMトークン更新エラー - $e');
@@ -115,6 +112,13 @@ class AuthNotifier extends _$AuthNotifier {
         return AuthState.unauthenticated();
       }
     });
+
+    state.whenOrNull(
+      data: (authState) => AppLogger.debugOnly(
+          'signIn完了: status=${authState.status}, userId=${authState.user?.id}'),
+      error: (error, stackTrace) =>
+          AppLogger.errorOnly('signIn失敗', error, stackTrace),
+    );
   }
 
   /// 新規ユーザー登録を行う
@@ -130,6 +134,9 @@ class AuthNotifier extends _$AuthNotifier {
   /// - 失敗時は[AuthState.unauthenticated]
   Future<void> signUp(String email, String password, String name,
       {String? displayName}) async {
+    AppLogger.debugOnly(
+        'signUp開始: email=$email, name=$name, displayName=${displayName ?? '(null)'}');
+
     // ローディング状態に設定
     state = const AsyncLoading();
 
@@ -146,15 +153,17 @@ class AuthNotifier extends _$AuthNotifier {
             displayName.isNotEmpty &&
             displayName != name) {
           finalUser = user.updateProfile(displayName: displayName);
-          await ref.read(userRepositoryProvider).updateUser(finalUser);
         }
+
+        await ref.read(userRepositoryProvider).updateUser(finalUser);
+        AppLogger.debugOnly('signUp後プロフィール更新完了: userId=${finalUser.id}');
 
         AppLogger.debug('サインアップ成功: ユーザーID=${finalUser.id}');
 
         // FCMトークンを更新（リトライ付き）
         try {
           AppLogger.debug('サインアップ: FCMトークン更新を開始');
-          await _fcmTokenService!.updateCurrentUserFcmToken();
+          await _fcmTokenService?.updateCurrentUserFcmToken();
           AppLogger.debug('サインアップ: FCMトークン更新完了');
         } catch (e) {
           AppLogger.error('サインアップ: FCMトークン更新エラー - $e');
@@ -166,6 +175,13 @@ class AuthNotifier extends _$AuthNotifier {
         return AuthState.unauthenticated();
       }
     });
+
+    state.whenOrNull(
+      data: (authState) => AppLogger.debugOnly(
+          'signUp完了: status=${authState.status}, userId=${authState.user?.id}'),
+      error: (error, stackTrace) =>
+          AppLogger.errorOnly('signUp失敗', error, stackTrace),
+    );
   }
 
   /// サインアウトを行う
@@ -183,50 +199,11 @@ class AuthNotifier extends _$AuthNotifier {
       try {
         AppLogger.debug('サインアウト処理を開始します');
 
-        // 1. 既存のリポジトリインスタンスのキャッシュを明示的にクリア
-        try {
-          final userRepo = ref.read(userRepositoryProvider);
-          if (userRepo is UserRepository) {
-            userRepo.clearCache();
-            AppLogger.debug('UserRepositoryキャッシュをクリアしました');
-          }
-        } catch (e) {
-          AppLogger.warning('UserRepositoryキャッシュクリアエラー（無視して続行）: $e');
-        }
+        // 1. 先に認証をサインアウトして、Router と認証状態を安定させる
+        await _authRepository.signOut();
+        AppLogger.debug('認証サインアウトが完了しました');
 
-        try {
-          final scheduleRepo = ref.read(scheduleRepositoryProvider);
-          if (scheduleRepo is ScheduleRepository) {
-            scheduleRepo.clearCache();
-            AppLogger.debug('ScheduleRepositoryキャッシュをクリアしました');
-          }
-        } catch (e) {
-          AppLogger.warning('ScheduleRepositoryキャッシュクリアエラー（無視して続行）: $e');
-        }
-
-        // 2. カレンダー関連のStateProviderキャッシュをクリア
-        try {
-          ref.invalidate(cachedHolidaysProvider);
-          ref.invalidate(cachedSchedulesProvider);
-          ref.invalidate(monthDataLoadingProvider);
-          ref.invalidate(calendarOptimizationProvider);
-          ref.invalidate(renderedMonthsProvider);
-          ref.invalidate(lastCleanupTimeProvider);
-          ref.invalidate(activeMonthIndicesProvider);
-          AppLogger.debug('カレンダー関連キャッシュをクリアしました');
-        } catch (e) {
-          AppLogger.warning('カレンダーキャッシュクリアエラー（無視して続行）: $e');
-        }
-
-        // 3. MyPageのキャッシュをクリア
-        try {
-          ref.invalidate(cachedUserProvider);
-          AppLogger.debug('MyPageキャッシュをクリアしました');
-        } catch (e) {
-          AppLogger.warning('MyPageキャッシュクリアエラー（無視して続行）: $e');
-        }
-
-        // 4. FCMトークンを削除
+        // 2. FCMトークンを削除
         try {
           if (_fcmTokenService != null) {
             await _fcmTokenService!.removeFcmToken();
@@ -238,7 +215,7 @@ class AuthNotifier extends _$AuthNotifier {
           AppLogger.warning('FCMトークン削除エラー（無視して続行）: $e');
         }
 
-        // 5. WebView 関連の強制クリーンアップ
+        // 3. WebView 関連の強制クリーンアップ
         try {
           // WebView インスタンスの状態を確認
           WebViewMonitor.printStatus();
@@ -259,99 +236,6 @@ class AuthNotifier extends _$AuthNotifier {
           AppLogger.warning('WebView キャッシュクリアエラー（無視して続行）: $e');
         }
 
-        // 6. Firestoreのキャッシュをクリア
-        try {
-          await FirebaseFirestore.instance.terminate();
-          await FirebaseFirestore.instance.clearPersistence();
-          AppLogger.debug('Firestoreキャッシュをクリアしました');
-        } catch (e) {
-          AppLogger.error('Firestoreキャッシュクリアエラー（無視して続行）: $e');
-          // キャッシュクリアに失敗しても処理を続行
-        }
-
-        // 6. 関連するRiverpodプロバイダーをリセット
-        try {
-          // 自身のプロバイダーを無効化
-          ref.invalidateSelf();
-
-          // ユーザー関連のプロバイダーを無効化
-          try {
-            ref.invalidate(userRepositoryProvider);
-          } catch (e) {
-            AppLogger.warning('userRepositoryProvider無効化エラー: $e');
-          }
-
-          // その他のプロバイダーを個別に無効化し、エラーを捕捉
-          try {
-            ref.invalidate(scheduleNotifierProvider);
-          } catch (e) {
-            // エラーは無視
-          }
-
-          try {
-            ref.invalidate(scheduleRepositoryProvider);
-          } catch (e) {
-            // エラーは無視
-          }
-
-          try {
-            ref.invalidate(groupNotifierProvider);
-          } catch (e) {
-            // エラーは無視
-          }
-
-          try {
-            ref.invalidate(groupRepositoryProvider);
-          } catch (e) {
-            // エラーは無視
-          }
-
-          try {
-            ref.invalidate(listNotifierProvider);
-          } catch (e) {
-            // エラーは無視
-          }
-
-          try {
-            ref.invalidate(listRepositoryProvider);
-          } catch (e) {
-            // エラーは無視
-          }
-
-          try {
-            ref.invalidate(userListsStreamProvider);
-          } catch (e) {
-            // エラーは無視
-          }
-
-          try {
-            ref.invalidate(userGroupsStreamProvider);
-          } catch (e) {
-            // エラーは無視
-          }
-
-          try {
-            ref.invalidate(userFriendsStreamProvider);
-          } catch (e) {
-            // エラーは無視
-          }
-
-          try {
-            ref.invalidate(userFriendsProvider);
-          } catch (e) {
-            // エラーは無視
-          }
-
-          AppLogger.debug('プロバイダーを無効化しました');
-        } catch (e) {
-          AppLogger.error('プロバイダー無効化エラー（無視して続行）: $e');
-          // プロバイダー無効化に失敗しても処理を続行
-        }
-
-        // 7. 最後に認証をサインアウト
-        await _authRepository.signOut();
-        AppLogger.debug('認証サインアウトが完了しました');
-
         AppLogger.debug('サインアウト処理が正常に完了しました');
         return AuthState.unauthenticated();
       } catch (e) {
@@ -367,10 +251,12 @@ class AuthNotifier extends _$AuthNotifier {
       // iOS の場合のみ実行
       if (Platform.isIOS) {
         // WKWebView のキャッシュを完全にクリア
-        const MethodChannel('flutter/webview')
+        await const MethodChannel('flutter/webview')
             .invokeMethod('clearWebViewCache');
         AppLogger.debug('WebViewキャッシュをクリアしました');
       }
+    } on MissingPluginException catch (e) {
+      AppLogger.warning('WebViewキャッシュクリアをスキップ: $e');
     } catch (e) {
       AppLogger.warning('WebView キャッシュクリア失敗: $e');
     }
@@ -408,51 +294,8 @@ class AuthNotifier extends _$AuthNotifier {
     // アカウント削除処理を実行
     try {
       AppLogger.debug('アカウント削除処理を開始します');
+      final success = await _authRepository.deleteAccount();
 
-      // 1. 既存のリポジトリインスタンスのキャッシュを明示的にクリア
-      try {
-        final userRepo = ref.read(userRepositoryProvider);
-        if (userRepo is UserRepository) {
-          userRepo.clearCache();
-          AppLogger.debug('UserRepositoryキャッシュをクリアしました');
-        }
-      } catch (e) {
-        AppLogger.warning('UserRepositoryキャッシュクリアエラー（無視して続行）: $e');
-      }
-
-      try {
-        final scheduleRepo = ref.read(scheduleRepositoryProvider);
-        if (scheduleRepo is ScheduleRepository) {
-          scheduleRepo.clearCache();
-          AppLogger.debug('ScheduleRepositoryキャッシュをクリアしました');
-        }
-      } catch (e) {
-        AppLogger.warning('ScheduleRepositoryキャッシュクリアエラー（無視して続行）: $e');
-      }
-
-      // 2. カレンダー関連のStateProviderキャッシュをクリア
-      try {
-        ref.invalidate(cachedHolidaysProvider);
-        ref.invalidate(cachedSchedulesProvider);
-        ref.invalidate(monthDataLoadingProvider);
-        ref.invalidate(calendarOptimizationProvider);
-        ref.invalidate(renderedMonthsProvider);
-        ref.invalidate(lastCleanupTimeProvider);
-        ref.invalidate(activeMonthIndicesProvider);
-        AppLogger.debug('カレンダー関連キャッシュをクリアしました');
-      } catch (e) {
-        AppLogger.warning('カレンダーキャッシュクリアエラー（無視して続行）: $e');
-      }
-
-      // 3. MyPageのキャッシュをクリア
-      try {
-        ref.invalidate(cachedUserProvider);
-        AppLogger.debug('MyPageキャッシュをクリアしました');
-      } catch (e) {
-        AppLogger.warning('MyPageキャッシュクリアエラー（無視して続行）: $e');
-      }
-
-      // 4. FCMトークンを削除
       try {
         if (_fcmTokenService != null) {
           await _fcmTokenService!.removeFcmToken();
@@ -464,48 +307,9 @@ class AuthNotifier extends _$AuthNotifier {
         AppLogger.warning('FCMトークン削除エラー（無視して続行）: $e');
       }
 
-      // 5. Firestoreのキャッシュをクリア
-      try {
-        await FirebaseFirestore.instance.terminate();
-        await FirebaseFirestore.instance.clearPersistence();
-        AppLogger.debug('Firestoreキャッシュをクリアしました');
-      } catch (e) {
-        AppLogger.error('Firestoreキャッシュクリアエラー: $e');
-      }
-
-      // 6. アカウントを削除
-      final success = await _authRepository.deleteAccount();
-
-      // 7. 認証状態を更新
       if (success) {
         state = AsyncData(AuthState.unauthenticated());
         AppLogger.debug('アカウント削除処理が正常に完了しました');
-
-        // 削除成功後に関連するRiverpodプロバイダーをリセット
-        try {
-          // ユーザー関連のプロバイダーを無効化
-          ref.invalidate(userRepositoryProvider);
-
-          // スケジュール関連のプロバイダーも無効化
-          ref.invalidate(scheduleNotifierProvider);
-          ref.invalidate(scheduleRepositoryProvider);
-
-          // グループとリスト関連のプロバイダーも無効化
-          ref.invalidate(groupNotifierProvider);
-          ref.invalidate(groupRepositoryProvider);
-          ref.invalidate(listNotifierProvider);
-          ref.invalidate(listRepositoryProvider);
-
-          // ストリームプロバイダーも無効化
-          ref.invalidate(userListsStreamProvider);
-          ref.invalidate(userGroupsStreamProvider);
-          ref.invalidate(userFriendsStreamProvider);
-          ref.invalidate(userFriendsProvider);
-
-          AppLogger.debug('プロバイダーを無効化しました');
-        } catch (e) {
-          AppLogger.warning('プロバイダー無効化エラー（無視して続行）: $e');
-        }
       }
 
       return success;
@@ -553,51 +357,8 @@ class AuthNotifier extends _$AuthNotifier {
     // アカウント削除処理を実行
     try {
       AppLogger.debug('再認証付きアカウント削除処理を開始します');
+      final success = await _authRepository.deleteAccountWithReauth(password);
 
-      // 1. 既存のリポジトリインスタンスのキャッシュを明示的にクリア
-      try {
-        final userRepo = ref.read(userRepositoryProvider);
-        if (userRepo is UserRepository) {
-          userRepo.clearCache();
-          AppLogger.debug('UserRepositoryキャッシュをクリアしました');
-        }
-      } catch (e) {
-        AppLogger.warning('UserRepositoryキャッシュクリアエラー（無視して続行）: $e');
-      }
-
-      try {
-        final scheduleRepo = ref.read(scheduleRepositoryProvider);
-        if (scheduleRepo is ScheduleRepository) {
-          scheduleRepo.clearCache();
-          AppLogger.debug('ScheduleRepositoryキャッシュをクリアしました');
-        }
-      } catch (e) {
-        AppLogger.warning('ScheduleRepositoryキャッシュクリアエラー（無視して続行）: $e');
-      }
-
-      // 2. カレンダー関連のStateProviderキャッシュをクリア
-      try {
-        ref.invalidate(cachedHolidaysProvider);
-        ref.invalidate(cachedSchedulesProvider);
-        ref.invalidate(monthDataLoadingProvider);
-        ref.invalidate(calendarOptimizationProvider);
-        ref.invalidate(renderedMonthsProvider);
-        ref.invalidate(lastCleanupTimeProvider);
-        ref.invalidate(activeMonthIndicesProvider);
-        AppLogger.debug('カレンダー関連キャッシュをクリアしました');
-      } catch (e) {
-        AppLogger.warning('カレンダーキャッシュクリアエラー（無視して続行）: $e');
-      }
-
-      // 3. MyPageのキャッシュをクリア
-      try {
-        ref.invalidate(cachedUserProvider);
-        AppLogger.debug('MyPageキャッシュをクリアしました');
-      } catch (e) {
-        AppLogger.warning('MyPageキャッシュクリアエラー（無視して続行）: $e');
-      }
-
-      // 4. FCMトークンを削除
       try {
         if (_fcmTokenService != null) {
           await _fcmTokenService!.removeFcmToken();
@@ -609,58 +370,12 @@ class AuthNotifier extends _$AuthNotifier {
         AppLogger.warning('FCMトークン削除エラー（無視して続行）: $e');
       }
 
-      // 5. Firestoreのキャッシュをクリア
-      try {
-        await FirebaseFirestore.instance.terminate();
-        await FirebaseFirestore.instance.clearPersistence();
-        AppLogger.debug('Firestoreキャッシュをクリアしました');
-      } catch (e) {
-        AppLogger.error('Firestoreキャッシュクリアエラー: $e');
+      if (success) {
+        state = AsyncData(AuthState.unauthenticated());
+        AppLogger.debug('再認証付きアカウント削除処理が正常に完了しました');
       }
 
-      // 6. 再認証付きでアカウントを削除（AuthRepositoryの新しいメソッドを使用）
-      final authRepo = _authRepository as dynamic;
-      if (authRepo.deleteAccountWithReauth != null) {
-        final success = await authRepo.deleteAccountWithReauth(password);
-
-        // 7. 認証状態を更新
-        if (success) {
-          state = AsyncData(AuthState.unauthenticated());
-          AppLogger.debug('再認証付きアカウント削除処理が正常に完了しました');
-
-          // 削除成功後に関連するRiverpodプロバイダーをリセット
-          try {
-            // ユーザー関連のプロバイダーを無効化
-            ref.invalidate(userRepositoryProvider);
-
-            // スケジュール関連のプロバイダーも無効化
-            ref.invalidate(scheduleNotifierProvider);
-            ref.invalidate(scheduleRepositoryProvider);
-
-            // グループとリスト関連のプロバイダーも無効化
-            ref.invalidate(groupNotifierProvider);
-            ref.invalidate(groupRepositoryProvider);
-            ref.invalidate(listNotifierProvider);
-            ref.invalidate(listRepositoryProvider);
-
-            // ストリームプロバイダーも無効化
-            ref.invalidate(userListsStreamProvider);
-            ref.invalidate(userGroupsStreamProvider);
-            ref.invalidate(userFriendsStreamProvider);
-            ref.invalidate(userFriendsProvider);
-
-            AppLogger.debug('プロバイダーを無効化しました');
-          } catch (e) {
-            AppLogger.warning('プロバイダー無効化エラー（無視して続行）: $e');
-          }
-        }
-
-        return success;
-      } else {
-        // フォールバック：先に再認証してから削除
-        await reauthenticateWithPassword(password);
-        return await deleteAccount();
-      }
+      return success;
     } catch (e) {
       AppLogger.error('再認証付きアカウント削除エラー: $e');
       state = AsyncError(e, StackTrace.current);

--- a/lib/application/auth/auth_state.dart
+++ b/lib/application/auth/auth_state.dart
@@ -15,8 +15,6 @@ part 'auth_state.freezed.dart';
 /// - 各状態に応じたファクトリーメソッドを提供
 @freezed
 class AuthState with _$AuthState {
-  const AuthState._();
-
   /// 認証状態を作成するファクトリーコンストラクタ
   ///
   /// パラメータ:
@@ -29,6 +27,7 @@ class AuthState with _$AuthState {
     required AuthStatus status,
     UserModel? user,
   }) = _AuthState;
+  const AuthState._();
 
   /// 認証済み状態を作成するファクトリーメソッド
   ///

--- a/lib/application/group/group_member_invite_notifier.dart
+++ b/lib/application/group/group_member_invite_notifier.dart
@@ -27,12 +27,6 @@ final groupMemberInviteViewModelProvider = StateNotifierProvider.family<
 
 /// グループメンバー招待画面のViewModel
 class GroupMemberInviteNotifier extends StateNotifier<GroupMemberInviteState> {
-  final IUserRepository _userRepository;
-  final NotificationRepository _notificationRepository;
-  final String _currentUserId;
-  final String _currentUserDisplayName;
-  final Group _group;
-
   GroupMemberInviteNotifier(
     this._userRepository,
     this._notificationRepository,
@@ -42,6 +36,11 @@ class GroupMemberInviteNotifier extends StateNotifier<GroupMemberInviteState> {
   ) : super(const GroupMemberInviteState()) {
     _initialize();
   }
+  final IUserRepository _userRepository;
+  final NotificationRepository _notificationRepository;
+  final String _currentUserId;
+  final String _currentUserDisplayName;
+  final Group _group;
 
   /// 初期化処理
   Future<void> _initialize() async {

--- a/lib/application/list/list_notifier.dart
+++ b/lib/application/list/list_notifier.dart
@@ -1,8 +1,12 @@
+import 'dart:async';
+
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:lakiite/application/auth/auth_state.dart';
 import 'package:lakiite/application/list/list_state.dart';
 import 'package:lakiite/domain/entity/list.dart';
 import 'package:lakiite/domain/service/service_provider.dart';
 import 'package:lakiite/presentation/presentation_provider.dart';
+import 'package:lakiite/utils/logger.dart';
 
 part 'list_notifier.g.dart';
 
@@ -17,9 +21,37 @@ part 'list_notifier.g.dart';
 /// アプリケーション全体でリスト状態を共有します。
 @riverpod
 class ListNotifier extends AutoDisposeAsyncNotifier<ListState> {
+  StreamSubscription<List<UserList>>? _listSubscription;
+
   @override
   Future<ListState> build() async {
+    ref.listen(authNotifierProvider, (_, next) {
+      next.whenOrNull(
+        data: (authState) {
+          if (authState.status != AuthStatus.authenticated ||
+              authState.user == null) {
+            unawaited(_stopWatchingLists(resetState: true));
+          }
+        },
+        loading: () => unawaited(_stopWatchingLists(resetState: true)),
+        error: (_, __) => unawaited(_stopWatchingLists(resetState: true)),
+      );
+    });
+
+    ref.onDispose(() {
+      _listSubscription?.cancel();
+    });
+
     return const ListState.initial();
+  }
+
+  Future<void> _stopWatchingLists({bool resetState = false}) async {
+    await _listSubscription?.cancel();
+    _listSubscription = null;
+
+    if (resetState) {
+      state = const AsyncValue.data(ListState.initial());
+    }
   }
 
   /// 新しいプライベートリストを作成する
@@ -136,12 +168,36 @@ class ListNotifier extends AutoDisposeAsyncNotifier<ListState> {
   ///
   /// リストの変更を[ListState.loaded]として通知し、
   /// エラー発生時は[ListState.error]を返します。
-  void watchUserLists(String ownerId) {
-    ref.read(listManagerProvider).watchAuthenticatedUserLists(ownerId).listen(
+  Future<void> watchUserLists(String ownerId) async {
+    await _stopWatchingLists();
+
+    final authState = ref.read(authNotifierProvider);
+    final isAuthenticated = authState.maybeWhen(
+      data: (state) =>
+          state.status == AuthStatus.authenticated && state.user?.id == ownerId,
+      orElse: () => false,
+    );
+    if (!isAuthenticated) {
+      AppLogger.debug('ListNotifier: 認証状態が一致しないためリスト監視を開始しません - ownerId: $ownerId');
+      state = const AsyncValue.data(ListState.initial());
+      return;
+    }
+
+    _listSubscription = ref
+        .read(listManagerProvider)
+        .watchAuthenticatedUserLists(ownerId)
+        .listen(
       (lists) {
         state = AsyncValue.data(ListState.loaded(lists));
       },
       onError: (error) {
+        final message = error.toString();
+        if (message.contains('permission-denied') ||
+            message.contains('User not authenticated')) {
+          AppLogger.warning('ListNotifier: 認証解除後のリスト監視エラーを無視します: $error');
+          unawaited(_stopWatchingLists(resetState: true));
+          return;
+        }
         state = AsyncValue.data(ListState.error(error.toString()));
       },
     );

--- a/lib/application/list/list_notifier.dart
+++ b/lib/application/list/list_notifier.dart
@@ -178,7 +178,8 @@ class ListNotifier extends AutoDisposeAsyncNotifier<ListState> {
       orElse: () => false,
     );
     if (!isAuthenticated) {
-      AppLogger.debug('ListNotifier: 認証状態が一致しないためリスト監視を開始しません - ownerId: $ownerId');
+      AppLogger.debug(
+          'ListNotifier: 認証状態が一致しないためリスト監視を開始しません - ownerId: $ownerId');
       state = const AsyncValue.data(ListState.initial());
       return;
     }

--- a/lib/application/notification/notification_notifier.dart
+++ b/lib/application/notification/notification_notifier.dart
@@ -6,7 +6,6 @@ import '../../infrastructure/firebase/push_notification_service.dart';
 import '../../utils/logger.dart';
 import '../../infrastructure/user_repository.dart';
 import '../../infrastructure/firebase/push_notification_sender.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'dart:async';
 import '../../presentation/presentation_provider.dart';
 
@@ -18,36 +17,27 @@ final notificationRepositoryProvider = Provider<INotificationRepository>((ref) {
   return NotificationRepository();
 });
 
-/// FirebaseAuthの状態変更を監視するStreamプロバイダー
-final firebaseAuthStateProvider = StreamProvider<User?>((ref) {
-  return FirebaseAuth.instance.authStateChanges();
-});
-
 /// 現在のユーザーIDを提供するプロバイダー
 final currentUserIdProvider = Provider<String?>((ref) {
-  // ログ出力を追加
   AppLogger.debug('currentUserIdProvider - 読み込み開始');
 
-  // まず直接FirebaseAuthからユーザーIDを取得
-  final firebaseAuth = FirebaseAuth.instance;
-  final currentUser = firebaseAuth.currentUser;
-  final directUserId = currentUser?.uid;
-
-  // 次にauthStateからユーザーIDを取得 (一般的にこちらの方が信頼性が高い)
   final authState = ref.watch(authNotifierProvider);
-  final stateUserId = authState.value?.user?.id;
-
-  // FirebaseAuthの状態変更も監視
-  final firebaseAuthState = ref.watch(firebaseAuthStateProvider);
-  final firebaseAuthUserId = firebaseAuthState.value?.uid;
-
-  // 優先順位: authState > firebaseAuthState > directUserId
-  final effectiveUserId = stateUserId ?? firebaseAuthUserId ?? directUserId;
-
-  AppLogger.debug(
-      'currentUserIdProvider - 取得結果比較: FirebaseAuth直接=$directUserId, authState=$stateUserId, firebaseAuthStream=$firebaseAuthUserId, 使用=$effectiveUserId');
-
-  return effectiveUserId;
+  return authState.when(
+    data: (state) {
+      final userId = state.user?.id;
+      AppLogger.debug('currentUserIdProvider - authState からユーザーIDを取得: $userId');
+      return userId;
+    },
+    loading: () {
+      AppLogger.debug('currentUserIdProvider - authState 読み込み中のためnullを返却');
+      return null;
+    },
+    error: (error, _) {
+      AppLogger.warning(
+          'currentUserIdProvider - authState エラーのためnullを返却: $error');
+      return null;
+    },
+  );
 });
 
 /// 未読の通知数を監視するプロバイダー

--- a/lib/application/schedule/schedule_notifier.dart
+++ b/lib/application/schedule/schedule_notifier.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:lakiite/application/auth/auth_state.dart';
 import 'package:lakiite/application/schedule/schedule_state.dart';
 import 'package:lakiite/domain/entity/schedule.dart';
 import 'package:lakiite/presentation/presentation_provider.dart';
@@ -22,9 +23,29 @@ class ScheduleNotifier extends AutoDisposeAsyncNotifier<ScheduleState> {
   // 先行読み込み中かどうかを示すフラグ
   final Set<String> _preloadingMonths = {};
 
+  void _stopWatchingSchedules({bool resetState = false}) {
+    _scheduleSubscription?.cancel();
+    _scheduleSubscription = null;
+    _currentUserId = null;
+    _currentDisplayMonth = null;
+
+    if (resetState && !_isDisposed) {
+      state = const AsyncValue.data(ScheduleState.initial());
+    }
+  }
+
   // 月のキャッシュキーを生成
   String _getMonthKey(DateTime month) {
     return '${month.year}-${month.month.toString().padLeft(2, '0')}';
+  }
+
+  bool _isAuthenticatedUserActive(String userId) {
+    final authState = ref.read(authNotifierProvider);
+    return authState.maybeWhen(
+      data: (state) =>
+          state.status == AuthStatus.authenticated && state.user?.id == userId,
+      orElse: () => false,
+    );
   }
 
   @override
@@ -33,8 +54,7 @@ class ScheduleNotifier extends AutoDisposeAsyncNotifier<ScheduleState> {
     ref.onDispose(() {
       AppLogger.debug('ScheduleNotifier: Disposing');
       _isDisposed = true;
-      _scheduleSubscription?.cancel();
-      _currentUserId = null;
+      _stopWatchingSchedules();
     });
 
     // 認証状態を監視して自動的にスケジュールの監視を開始
@@ -43,10 +63,14 @@ class ScheduleNotifier extends AutoDisposeAsyncNotifier<ScheduleState> {
         if (authState.user != null) {
           // 少し遅延させて認証完了後の安定した状態でスケジュール取得を開始
           Future.delayed(const Duration(milliseconds: 300), () {
-            if (!_isDisposed) {
+            if (!_isDisposed &&
+                _isAuthenticatedUserActive(authState.user!.id)) {
               watchUserSchedules(authState.user!.id);
             }
           });
+        } else {
+          AppLogger.debug('ScheduleNotifier: 認証解除を検知したため購読を停止します');
+          _stopWatchingSchedules(resetState: true);
         }
       });
     });
@@ -107,6 +131,17 @@ class ScheduleNotifier extends AutoDisposeAsyncNotifier<ScheduleState> {
           if (_isDisposed) return;
           AppLogger.error('ScheduleNotifier: Error watching schedules: $error');
 
+          final errorText = error.toString();
+          final isPermissionOrAuthError =
+              errorText.contains('permission-denied') ||
+                  errorText.contains('User not authenticated');
+
+          if (isPermissionOrAuthError) {
+            AppLogger.warning('ScheduleNotifier: 認証解除後の購読エラーとして処理を終了します');
+            _stopWatchingSchedules(resetState: true);
+            return;
+          }
+
           // エラー発生時に再試行する
           if (retryCount < maxRetries) {
             retryCount++;
@@ -134,6 +169,16 @@ class ScheduleNotifier extends AutoDisposeAsyncNotifier<ScheduleState> {
                     if (_isDisposed) return;
                     AppLogger.error(
                         'ScheduleNotifier: Retry failed: $retryError');
+                    final retryErrorText = retryError.toString();
+                    final isPermissionOrAuthRetryError =
+                        retryErrorText.contains('permission-denied') ||
+                            retryErrorText.contains('User not authenticated');
+                    if (isPermissionOrAuthRetryError) {
+                      AppLogger.warning(
+                          'ScheduleNotifier: 認証解除後の再試行エラーとして処理を終了します');
+                      _stopWatchingSchedules(resetState: true);
+                      return;
+                    }
                     if (retryCount >= maxRetries) {
                       if (!_isDisposed) {
                         state =
@@ -183,6 +228,13 @@ class ScheduleNotifier extends AutoDisposeAsyncNotifier<ScheduleState> {
 
     AppLogger.debug(
         'ScheduleNotifier: watchUserSchedulesForMonth called for user: $userId, month: $monthKey');
+
+    if (!_isAuthenticatedUserActive(userId)) {
+      AppLogger.debug(
+          'ScheduleNotifier: 認証状態が変化したため月別購読を開始しません userId=$userId, month=$monthKey');
+      _stopWatchingSchedules(resetState: true);
+      return;
+    }
 
     // 同じユーザーかつ同じ月の場合は重複購読を避ける
     if (_currentUserId == userId && _currentDisplayMonth != null) {
@@ -274,6 +326,17 @@ class ScheduleNotifier extends AutoDisposeAsyncNotifier<ScheduleState> {
           if (_isDisposed) return;
           AppLogger.error(
               'ScheduleNotifier: Error watching schedules for month: $error');
+
+          final errorText = error.toString();
+          final isPermissionOrAuthError =
+              errorText.contains('permission-denied') ||
+                  errorText.contains('User not authenticated');
+          if (isPermissionOrAuthError) {
+            AppLogger.warning('ScheduleNotifier: 認証解除後の月別購読エラーとして処理を終了します');
+            _stopWatchingSchedules(resetState: true);
+            return;
+          }
+
           Future(() {
             if (!_isDisposed) {
               state = AsyncValue.error(error, StackTrace.current);
@@ -314,6 +377,10 @@ class ScheduleNotifier extends AutoDisposeAsyncNotifier<ScheduleState> {
       return;
     }
 
+    if (!_isAuthenticatedUserActive(userId)) {
+      return;
+    }
+
     _preloadingMonths.add(monthKey);
 
     try {
@@ -344,7 +411,15 @@ class ScheduleNotifier extends AutoDisposeAsyncNotifier<ScheduleState> {
       }, onError: (error) {
         AppLogger.error(
             'ScheduleNotifier: Error preloading month $monthKey: $error');
+        final errorText = error.toString();
+        final isPermissionOrAuthError =
+            errorText.contains('permission-denied') ||
+                errorText.contains('User not authenticated');
         _preloadingMonths.remove(monthKey);
+        if (isPermissionOrAuthError) {
+          subscription?.cancel();
+          return;
+        }
         subscription?.cancel();
       }, onDone: () {
         _preloadingMonths.remove(monthKey);

--- a/lib/config/admob_config.dart
+++ b/lib/config/admob_config.dart
@@ -40,12 +40,12 @@ class AdMobConfig {
   /// 設定値が不正な場合は例外をスローします。
   ///
   /// テスト環境の場合は検証をスキップし、ダミー値を設定します。
-  static void initialize() {
+  static void initialize({bool forceTestMode = false}) {
     // テスト環境かどうかを確認
     const isTestEnvironment =
         bool.fromEnvironment('FLUTTER_TEST', defaultValue: false);
 
-    if (isTestEnvironment) {
+    if (isTestEnvironment || forceTestMode) {
       // テスト環境ではダミー値を設定
       _instance = AdMobConfig._(
         androidAppId: 'ca-app-pub-test-android',

--- a/lib/config/app_config.dart
+++ b/lib/config/app_config.dart
@@ -3,6 +3,10 @@ import '../firebase_options.dart';
 
 /// アプリケーションの環境設定を管理するクラス
 class AppConfig {
+  /// プライベートコンストラクタ
+  AppConfig._(this.environment, this.firebaseOptions, this.appName,
+      this.pushNotificationUrl);
+
   /// 環境の種類
   final Environment environment;
 
@@ -103,10 +107,6 @@ class AppConfig {
 
     _instance = AppConfig._(environment, options, appName, pushNotificationUrl);
   }
-
-  /// プライベートコンストラクタ
-  AppConfig._(this.environment, this.firebaseOptions, this.appName,
-      this.pushNotificationUrl);
 
   /// 開発環境かどうか
   bool get isDevelopment => environment == Environment.development;

--- a/lib/config/router/app_router.dart
+++ b/lib/config/router/app_router.dart
@@ -28,12 +28,13 @@ import '../../presentation/presentation_provider.dart';
 /// - [GoRouter] 設定されたルーターインスタンス
 final routerProvider = Provider<GoRouter>((ref) {
   final refreshNotifier = ref.watch(goRouterRefreshProvider);
-  final authState = ref.watch(authNotifierProvider);
 
   return GoRouter(
     refreshListenable: refreshNotifier,
     initialLocation: SplashScreen.path,
     redirect: (context, state) {
+      final authState = ref.read(authNotifierProvider);
+
       // スプラッシュ画面の場合はリダイレクトしない
       if (state.matchedLocation == SplashScreen.path) {
         return null;

--- a/lib/domain/entity/notification.dart
+++ b/lib/domain/entity/notification.dart
@@ -16,20 +16,7 @@ enum NotificationStatus {
 }
 
 class Notification {
-  final String id;
-  final NotificationType type;
-  final String sendUserId;
-  final String receiveUserId;
-  final String? sendUserDisplayName;
-  final String? receiveUserDisplayName;
-  final NotificationStatus status;
-  final DateTime createdAt;
-  final DateTime updatedAt;
-  final int rejectionCount;
-  final bool isRead;
-  final String? groupId; // グループ招待の場合に使用
-  final String? relatedItemId; // 投稿ID等の関連アイテムID
-  final String? interactionId; // リアクション・コメントのID
+  // リアクション・コメントのID
 
   const Notification({
     required this.id,
@@ -47,99 +34,6 @@ class Notification {
     this.relatedItemId,
     this.interactionId,
   });
-
-  factory Notification.createFriendRequest({
-    required String fromUserId,
-    required String toUserId,
-    String? fromUserDisplayName,
-    String? toUserDisplayName,
-  }) {
-    final now = DateTime.now();
-    return Notification(
-      id: '', // Firestoreで自動生成
-      type: NotificationType.friend,
-      sendUserId: fromUserId,
-      receiveUserId: toUserId,
-      sendUserDisplayName: fromUserDisplayName,
-      receiveUserDisplayName: toUserDisplayName,
-      status: NotificationStatus.pending,
-      createdAt: now,
-      updatedAt: now,
-      rejectionCount: 0,
-      isRead: false,
-    );
-  }
-
-  factory Notification.createGroupInvitation({
-    required String fromUserId,
-    required String toUserId,
-    required String groupId,
-    String? fromUserDisplayName,
-    String? toUserDisplayName,
-  }) {
-    final now = DateTime.now();
-    return Notification(
-      id: '', // Firestoreで自動生成
-      type: NotificationType.groupInvitation,
-      sendUserId: fromUserId,
-      receiveUserId: toUserId,
-      sendUserDisplayName: fromUserDisplayName,
-      receiveUserDisplayName: toUserDisplayName,
-      status: NotificationStatus.pending,
-      createdAt: now,
-      updatedAt: now,
-      rejectionCount: 0,
-      isRead: false,
-      groupId: groupId,
-    );
-  }
-
-  factory Notification.createReactionNotification({
-    required String fromUserId,
-    required String toUserId,
-    required String relatedItemId,
-    required String interactionId,
-    String? fromUserDisplayName,
-  }) {
-    final now = DateTime.now();
-    return Notification(
-      id: '', // Firestoreで自動生成
-      type: NotificationType.reaction,
-      sendUserId: fromUserId,
-      receiveUserId: toUserId,
-      sendUserDisplayName: fromUserDisplayName,
-      status: NotificationStatus.accepted, // リアクションは自動承認
-      createdAt: now,
-      updatedAt: now,
-      isRead: false,
-      relatedItemId: relatedItemId,
-      interactionId: interactionId,
-    );
-  }
-
-  factory Notification.createCommentNotification({
-    required String fromUserId,
-    required String toUserId,
-    required String relatedItemId,
-    required String interactionId,
-    String? fromUserDisplayName,
-  }) {
-    final now = DateTime.now();
-    return Notification(
-      id: '', // Firestoreで自動生成
-      type: NotificationType.comment,
-      sendUserId: fromUserId,
-      receiveUserId: toUserId,
-      sendUserDisplayName: fromUserDisplayName,
-      status: NotificationStatus.accepted, // コメントは自動承認
-      createdAt: now,
-      updatedAt: now,
-      isRead: false,
-      relatedItemId: relatedItemId,
-      interactionId: interactionId,
-    );
-  }
-
   factory Notification.fromJson(Map<String, dynamic> json) {
     // createdAtとupdatedAtのデバッグ出力
     final createdAtTimestamp = json['createdAt'] as Timestamp;
@@ -175,6 +69,112 @@ class Notification {
       interactionId: json['interactionId'] as String?,
     );
   }
+
+  factory Notification.createCommentNotification({
+    required String fromUserId,
+    required String toUserId,
+    required String relatedItemId,
+    required String interactionId,
+    String? fromUserDisplayName,
+  }) {
+    final now = DateTime.now();
+    return Notification(
+      id: '', // Firestoreで自動生成
+      type: NotificationType.comment,
+      sendUserId: fromUserId,
+      receiveUserId: toUserId,
+      sendUserDisplayName: fromUserDisplayName,
+      status: NotificationStatus.accepted, // コメントは自動承認
+      createdAt: now,
+      updatedAt: now,
+      isRead: false,
+      relatedItemId: relatedItemId,
+      interactionId: interactionId,
+    );
+  }
+
+  factory Notification.createReactionNotification({
+    required String fromUserId,
+    required String toUserId,
+    required String relatedItemId,
+    required String interactionId,
+    String? fromUserDisplayName,
+  }) {
+    final now = DateTime.now();
+    return Notification(
+      id: '', // Firestoreで自動生成
+      type: NotificationType.reaction,
+      sendUserId: fromUserId,
+      receiveUserId: toUserId,
+      sendUserDisplayName: fromUserDisplayName,
+      status: NotificationStatus.accepted, // リアクションは自動承認
+      createdAt: now,
+      updatedAt: now,
+      isRead: false,
+      relatedItemId: relatedItemId,
+      interactionId: interactionId,
+    );
+  }
+
+  factory Notification.createGroupInvitation({
+    required String fromUserId,
+    required String toUserId,
+    required String groupId,
+    String? fromUserDisplayName,
+    String? toUserDisplayName,
+  }) {
+    final now = DateTime.now();
+    return Notification(
+      id: '', // Firestoreで自動生成
+      type: NotificationType.groupInvitation,
+      sendUserId: fromUserId,
+      receiveUserId: toUserId,
+      sendUserDisplayName: fromUserDisplayName,
+      receiveUserDisplayName: toUserDisplayName,
+      status: NotificationStatus.pending,
+      createdAt: now,
+      updatedAt: now,
+      rejectionCount: 0,
+      isRead: false,
+      groupId: groupId,
+    );
+  }
+
+  factory Notification.createFriendRequest({
+    required String fromUserId,
+    required String toUserId,
+    String? fromUserDisplayName,
+    String? toUserDisplayName,
+  }) {
+    final now = DateTime.now();
+    return Notification(
+      id: '', // Firestoreで自動生成
+      type: NotificationType.friend,
+      sendUserId: fromUserId,
+      receiveUserId: toUserId,
+      sendUserDisplayName: fromUserDisplayName,
+      receiveUserDisplayName: toUserDisplayName,
+      status: NotificationStatus.pending,
+      createdAt: now,
+      updatedAt: now,
+      rejectionCount: 0,
+      isRead: false,
+    );
+  }
+  final String id;
+  final NotificationType type;
+  final String sendUserId;
+  final String receiveUserId;
+  final String? sendUserDisplayName;
+  final String? receiveUserDisplayName;
+  final NotificationStatus status;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+  final int rejectionCount;
+  final bool isRead;
+  final String? groupId; // グループ招待の場合に使用
+  final String? relatedItemId; // 投稿ID等の関連アイテムID
+  final String? interactionId;
 
   Map<String, dynamic> toJson() => {
         'id': id,

--- a/lib/domain/entity/user.dart
+++ b/lib/domain/entity/user.dart
@@ -148,12 +148,6 @@ class UserModel with _$UserModel {
 
 /// ユーザー検索結果を表現するモデルクラス
 class SearchUserModel {
-  final String id;
-  final String displayName;
-  final String searchId;
-  final String? iconUrl;
-  final String? shortBio;
-
   const SearchUserModel({
     required this.id,
     required this.displayName,
@@ -161,6 +155,15 @@ class SearchUserModel {
     this.iconUrl,
     this.shortBio,
   });
+  factory SearchUserModel.fromUserModel(UserModel user) {
+    return SearchUserModel(
+      id: user.id,
+      displayName: user.displayName,
+      searchId: user.searchId.toString(),
+      iconUrl: user.iconUrl,
+      shortBio: user.publicProfile.shortBio,
+    );
+  }
 
   factory SearchUserModel.fromFirestore(String id, Map<String, dynamic> data) {
     return SearchUserModel(
@@ -171,25 +174,14 @@ class SearchUserModel {
       shortBio: data['shortBio'] as String?,
     );
   }
-
-  factory SearchUserModel.fromUserModel(UserModel user) {
-    return SearchUserModel(
-      id: user.id,
-      displayName: user.displayName,
-      searchId: user.searchId.toString(),
-      iconUrl: user.iconUrl,
-      shortBio: user.publicProfile.shortBio,
-    );
-  }
-}
-
-class User {
   final String id;
   final String displayName;
   final String searchId;
   final String? iconUrl;
-  final String? bio;
+  final String? shortBio;
+}
 
+class User {
   const User({
     required this.id,
     required this.displayName,
@@ -207,6 +199,11 @@ class User {
       bio: json['bio'] as String?,
     );
   }
+  final String id;
+  final String displayName;
+  final String searchId;
+  final String? iconUrl;
+  final String? bio;
 
   Map<String, dynamic> toJson() {
     return {

--- a/lib/domain/entity/user_profile.dart
+++ b/lib/domain/entity/user_profile.dart
@@ -1,11 +1,6 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 
 class PublicProfile {
-  final String displayName;
-  final String searchId;
-  final String? iconUrl;
-  final String? shortBio;
-
   const PublicProfile({
     required this.displayName,
     required this.searchId,
@@ -21,6 +16,10 @@ class PublicProfile {
       shortBio: data['shortBio'] as String?,
     );
   }
+  final String displayName;
+  final String searchId;
+  final String? iconUrl;
+  final String? shortBio;
 
   Map<String, dynamic> toFirestore() {
     return {
@@ -33,11 +32,6 @@ class PublicProfile {
 }
 
 class PrivateProfile {
-  final String name;
-  final List<String> lists;
-  final DateTime createdAt;
-  final String? fcmToken;
-
   const PrivateProfile({
     required this.name,
     required this.lists,
@@ -55,6 +49,10 @@ class PrivateProfile {
       fcmToken: data['fcmToken'] as String?,
     );
   }
+  final String name;
+  final List<String> lists;
+  final DateTime createdAt;
+  final String? fcmToken;
 
   Map<String, dynamic> toFirestore() {
     return {
@@ -67,13 +65,6 @@ class PrivateProfile {
 }
 
 class UserProfile {
-  final String id;
-  final PublicProfile publicProfile;
-  final PrivateProfile privateProfile;
-  final List<String> friends;
-  final List<String> groups;
-  final String? fcmToken;
-
   const UserProfile({
     required this.id,
     required this.publicProfile,
@@ -93,6 +84,12 @@ class UserProfile {
       fcmToken: data['fcmToken'],
     );
   }
+  final String id;
+  final PublicProfile publicProfile;
+  final PrivateProfile privateProfile;
+  final List<String> friends;
+  final List<String> groups;
+  final String? fcmToken;
 
   Map<String, dynamic> toFirestore() {
     return {

--- a/lib/domain/service/group_manager.dart
+++ b/lib/domain/service/group_manager.dart
@@ -41,7 +41,6 @@ abstract class IGroupManager {
 }
 
 class GroupManager implements IGroupManager {
-
   GroupManager(
     this._groupRepository,
     this._notificationRepository,

--- a/lib/domain/service/group_manager.dart
+++ b/lib/domain/service/group_manager.dart
@@ -41,13 +41,13 @@ abstract class IGroupManager {
 }
 
 class GroupManager implements IGroupManager {
-  final IGroupRepository _groupRepository;
-  final INotificationRepository _notificationRepository;
 
   GroupManager(
     this._groupRepository,
     this._notificationRepository,
   );
+  final IGroupRepository _groupRepository;
+  final INotificationRepository _notificationRepository;
 
   @override
   Future<Group> createGroupWithNotifications({

--- a/lib/domain/service/list_manager.dart
+++ b/lib/domain/service/list_manager.dart
@@ -40,9 +40,8 @@ abstract class IListManager {
 }
 
 class ListManager implements IListManager {
-  final IListRepository _listRepository;
-
   ListManager(this._listRepository);
+  final IListRepository _listRepository;
 
   @override
   Future<List<UserList>> getAuthenticatedUserLists(String userId) async {

--- a/lib/domain/service/user_manager.dart
+++ b/lib/domain/service/user_manager.dart
@@ -22,9 +22,8 @@ abstract class IUserManager {
 }
 
 class UserManager implements IUserManager {
-  final IUserRepository _userRepository;
-
   UserManager(this._userRepository);
+  final IUserRepository _userRepository;
 
   @override
   Future<UserModel?> getIntegratedUser(String userId) async {

--- a/lib/domain/value/user_id.dart
+++ b/lib/domain/value/user_id.dart
@@ -1,14 +1,12 @@
 class UserId {
-  final String value;
-
-  UserId._(this.value);
-
   factory UserId(String value) {
     if (!isValidFormat(value)) {
       throw ArgumentError('Invalid user ID format');
     }
     return UserId._(value);
   }
+  UserId._(this.value);
+  final String value;
 
   static bool isValidFormat(String value) {
     // 8文字の英数字のみを許可

--- a/lib/infrastructure/auth_repository.dart
+++ b/lib/infrastructure/auth_repository.dart
@@ -2,24 +2,29 @@ import 'package:firebase_auth/firebase_auth.dart';
 import '../domain/interfaces/i_auth_repository.dart';
 import '../domain/interfaces/i_user_repository.dart';
 import '../domain/entity/user.dart';
+import '../utils/logger.dart';
 
 class AuthRepository implements IAuthRepository {
+  AuthRepository(this._auth, this._userRepository);
   final FirebaseAuth _auth;
   final IUserRepository _userRepository;
-
-  AuthRepository(this._auth, this._userRepository);
 
   @override
   Stream<UserModel?> authStateChanges() async* {
     await for (final user in _auth.authStateChanges()) {
+      AppLogger.debugOnly('authStateChanges受信: firebaseUser=${user?.uid}');
       if (user == null) {
         yield null;
       } else {
         // ユーザーデータの取得を最大5回試行
         UserModel? userModel;
         for (var i = 0; i < 5; i++) {
+          AppLogger.debugOnly(
+              'authStateChanges.getUser試行: userId=${user.uid}, attempt=${i + 1}');
           userModel = await _userRepository.getUser(user.uid);
           if (userModel != null) {
+            AppLogger.debugOnly(
+                'authStateChanges.getUser成功: userId=${user.uid}');
             yield userModel;
             break;
           }
@@ -30,6 +35,8 @@ class AuthRepository implements IAuthRepository {
         }
         // ユーザーデータが取得できなかった場合
         if (userModel == null) {
+          AppLogger.warningOnly(
+              'authStateChanges.getUser失敗: userId=${user.uid}');
           yield null;
         }
       }
@@ -39,6 +46,7 @@ class AuthRepository implements IAuthRepository {
   @override
   Future<UserModel?> signIn(String email, String password) async {
     try {
+      AppLogger.debugOnly('AuthRepository.signIn開始: email=$email');
       // 1. Firebase認証でサインイン
       final userCredential = await _auth.signInWithEmailAndPassword(
         email: email,
@@ -46,12 +54,19 @@ class AuthRepository implements IAuthRepository {
       );
 
       if (userCredential.user == null) {
+        AppLogger.warningOnly(
+            'AuthRepository.signIn: userCredential.userがnull');
         return null;
       }
+
+      AppLogger.debugOnly(
+          'AuthRepository.signIn認証成功: firebaseUid=${userCredential.user!.uid}');
 
       // 2. ユーザーデータを取得(最大5回試行)
       UserModel? userModel;
       for (var i = 0; i < 5; i++) {
+        AppLogger.debugOnly(
+            'AuthRepository.signIn.getUser試行: userId=${userCredential.user!.uid}, attempt=${i + 1}');
         userModel = await _userRepository.getUser(userCredential.user!.uid);
         if (userModel != null) break;
         // 最後の試行以外は待機
@@ -62,13 +77,17 @@ class AuthRepository implements IAuthRepository {
 
       if (userModel == null) {
         // ユーザーデータが見つからない場合は認証をクリア
+        AppLogger.warningOnly(
+            'AuthRepository.signIn失敗: Firestoreにユーザーデータなし userId=${userCredential.user!.uid}');
         await _auth.signOut();
         throw Exception('ユーザーデータが見つかりません');
       }
 
+      AppLogger.debugOnly('AuthRepository.signIn完了: userId=${userModel.id}');
       return userModel;
     } catch (e) {
       // エラーが発生した場合は認証をクリア
+      AppLogger.errorOnly('AuthRepository.signIn例外', e);
       await _auth.signOut();
       rethrow;
     }
@@ -78,6 +97,7 @@ class AuthRepository implements IAuthRepository {
   Future<UserModel?> signUp(String email, String password, String name) async {
     UserCredential? userCredential;
     try {
+      AppLogger.debugOnly('AuthRepository.signUp開始: email=$email, name=$name');
       // 1. Firebaseで認証アカウントを作成
       userCredential = await _auth.createUserWithEmailAndPassword(
         email: email,
@@ -85,8 +105,13 @@ class AuthRepository implements IAuthRepository {
       );
 
       if (userCredential.user == null) {
+        AppLogger.warningOnly(
+            'AuthRepository.signUp: userCredential.userがnull');
         throw Exception('認証アカウントの作成に失敗しました');
       }
+
+      AppLogger.debugOnly(
+          'AuthRepository.signUp認証作成成功: firebaseUid=${userCredential.user!.uid}');
 
       // 2. ユーザーモデルを作成
       final userModel = UserModel.create(
@@ -96,9 +121,14 @@ class AuthRepository implements IAuthRepository {
 
       try {
         // 3. Firestoreにユーザーデータを保存
+        AppLogger.debugOnly(
+            'AuthRepository.signUp.createUser開始: userId=${userModel.id}');
         await _userRepository.createUser(userModel);
+        AppLogger.debugOnly(
+            'AuthRepository.signUp.createUser完了: userId=${userModel.id}');
       } catch (e) {
         // Firestoreへの保存に失敗した場合、認証アカウントを削除
+        AppLogger.errorOnly('AuthRepository.signUp.createUser失敗', e);
         await userCredential.user!.delete();
         throw Exception('ユーザーデータの作成に失敗しました: ${e.toString()}');
       }
@@ -106,6 +136,8 @@ class AuthRepository implements IAuthRepository {
       // 4. ユーザーデータが確実に保存されたことを確認(最大5回試行)
       UserModel? savedUser;
       for (var i = 0; i < 5; i++) {
+        AppLogger.debugOnly(
+            'AuthRepository.signUp.getUser試行: userId=${userModel.id}, attempt=${i + 1}');
         savedUser = await _userRepository.getUser(userModel.id);
         if (savedUser != null) break;
         // 最後の試行以外は待機
@@ -115,12 +147,16 @@ class AuthRepository implements IAuthRepository {
       }
 
       if (savedUser == null) {
+        AppLogger.warningOnly(
+            'AuthRepository.signUp失敗: 作成確認できず userId=${userModel.id}');
         throw Exception('ユーザーデータの作成を確認できませんでした');
       }
 
+      AppLogger.debugOnly('AuthRepository.signUp完了: userId=${savedUser.id}');
       return savedUser;
     } catch (e) {
       // エラーが発生した場合、作成した認証アカウントを削除
+      AppLogger.errorOnly('AuthRepository.signUp例外', e);
       if (userCredential?.user != null) {
         await userCredential!.user!.delete();
       }

--- a/lib/infrastructure/firebase/firebase_storage_service.dart
+++ b/lib/infrastructure/firebase/firebase_storage_service.dart
@@ -5,14 +5,13 @@ import '../../domain/interfaces/i_storage_service.dart';
 import '../../utils/logger.dart';
 
 class FirebaseStorageService implements IStorageService {
-  final FirebaseStorage _storage;
-  final FirebaseAuth _auth;
-
   FirebaseStorageService({
     FirebaseStorage? storage,
     FirebaseAuth? auth,
   })  : _storage = storage ?? FirebaseStorage.instance,
         _auth = auth ?? FirebaseAuth.instance;
+  final FirebaseStorage _storage;
+  final FirebaseAuth _auth;
 
   @override
   Future<String> uploadFile({

--- a/lib/infrastructure/firebase/push_notification_sender.dart
+++ b/lib/infrastructure/firebase/push_notification_sender.dart
@@ -10,16 +10,15 @@ import '../../config/app_config.dart';
 /// Cloud FunctionsにPOSTリクエストを送信して通知を配信します
 /// 実際の実装ではCloud Functions側で認証とセキュリティチェックを行う必要があります
 class PushNotificationSender {
-  final String _cloudFunctionUrl;
-  final UserFcmTokenService _fcmTokenService;
-  static const int _tokenPreviewLength = 20;
-
   PushNotificationSender({
     String? cloudFunctionUrl,
     UserFcmTokenService? fcmTokenService,
   })  : _cloudFunctionUrl =
             cloudFunctionUrl ?? AppConfig.instance.pushNotificationUrl,
         _fcmTokenService = fcmTokenService ?? UserFcmTokenService();
+  final String _cloudFunctionUrl;
+  final UserFcmTokenService _fcmTokenService;
+  static const int _tokenPreviewLength = 20;
 
   Future<bool> sendFriendRequestNotification({
     required String toUserId,

--- a/lib/infrastructure/friend_list_repository.dart
+++ b/lib/infrastructure/friend_list_repository.dart
@@ -3,9 +3,8 @@ import '../domain/interfaces/i_friend_list_repository.dart';
 import '../utils/logger.dart';
 
 class FriendListRepository implements IFriendListRepository {
-  final FirebaseFirestore _firestore;
-
   FriendListRepository() : _firestore = FirebaseFirestore.instance;
+  final FirebaseFirestore _firestore;
 
   @override
   Future<List<String>?> getListMemberIds(String listId) async {

--- a/lib/infrastructure/group_repository.dart
+++ b/lib/infrastructure/group_repository.dart
@@ -3,9 +3,8 @@ import '../domain/entity/group.dart';
 import '../domain/interfaces/i_group_repository.dart';
 
 class GroupRepository implements IGroupRepository {
-  final FirebaseFirestore _firestore;
-
   GroupRepository() : _firestore = FirebaseFirestore.instance;
+  final FirebaseFirestore _firestore;
 
   Map<String, dynamic> _toFirestore(Group group) {
     final data = group.toJson();

--- a/lib/infrastructure/list_repository.dart
+++ b/lib/infrastructure/list_repository.dart
@@ -3,9 +3,8 @@ import '../domain/entity/list.dart';
 import '../domain/interfaces/i_list_repository.dart';
 
 class ListRepository implements IListRepository {
-  final FirebaseFirestore _firestore;
-
   ListRepository() : _firestore = FirebaseFirestore.instance;
+  final FirebaseFirestore _firestore;
 
   Map<String, dynamic> _toFirestore(UserList list) {
     final data = list.toJson();

--- a/lib/infrastructure/notification_repository.dart
+++ b/lib/infrastructure/notification_repository.dart
@@ -6,9 +6,8 @@ import '../utils/logger.dart';
 
 /// 通知関連のFirestoreとのデータアクセスを管理するリポジトリクラス
 class NotificationRepository implements INotificationRepository {
-  final FirebaseFirestore _firestore;
-
   NotificationRepository() : _firestore = FirebaseFirestore.instance;
+  final FirebaseFirestore _firestore;
 
   /// 新しい通知を作成する
   ///

--- a/lib/infrastructure/repository/reaction_repository_impl.dart
+++ b/lib/infrastructure/repository/reaction_repository_impl.dart
@@ -3,9 +3,8 @@ import 'package:lakiite/domain/entity/reaction.dart';
 import 'package:lakiite/domain/repository/reaction_repository.dart';
 
 class ReactionRepositoryImpl implements ReactionRepository {
-  final FirebaseFirestore _firestore;
-
   ReactionRepositoryImpl(this._firestore);
+  final FirebaseFirestore _firestore;
 
   @override
   Future<List<Reaction>> getReactionsForSchedule(String scheduleId) async {

--- a/lib/infrastructure/user_repository.dart
+++ b/lib/infrastructure/user_repository.dart
@@ -7,6 +7,9 @@ import '../domain/value/user_id.dart';
 import '../utils/logger.dart';
 
 class UserRepository implements IUserRepository {
+  UserRepository()
+      : _firestore = FirebaseFirestore.instance,
+        _storage = FirebaseStorage.instance;
   final FirebaseFirestore _firestore;
   final FirebaseStorage _storage;
 
@@ -14,10 +17,6 @@ class UserRepository implements IUserRepository {
   final Map<String, UserModel> _userCache = {};
   final Map<String, PublicUserModel> _publicProfileCache = {};
   final Map<String, PrivateUserModel> _privateProfileCache = {};
-
-  UserRepository()
-      : _firestore = FirebaseFirestore.instance,
-        _storage = FirebaseStorage.instance;
 
   // キャッシュをクリアするメソッド
   void clearCache() {
@@ -42,27 +41,43 @@ class UserRepository implements IUserRepository {
 
   @override
   Future<UserModel?> getUser(String id) async {
-    final userDoc = await _firestore.collection('users').doc(id).get();
-    if (!userDoc.exists) return null;
+    try {
+      AppLogger.debugOnly('UserRepository.getUser開始: userId=$id');
+      final userDoc = await _firestore.collection('users').doc(id).get();
+      if (!userDoc.exists) {
+        AppLogger.warningOnly(
+            'UserRepository.getUser: public docなし userId=$id');
+        return null;
+      }
 
-    final privateDoc = await _firestore
-        .collection('users')
-        .doc(id)
-        .collection('private')
-        .doc('profile')
-        .get();
-    if (!privateDoc.exists) return null;
+      final privateDoc = await _firestore
+          .collection('users')
+          .doc(id)
+          .collection('private')
+          .doc('profile')
+          .get();
+      if (!privateDoc.exists) {
+        AppLogger.warningOnly(
+            'UserRepository.getUser: private docなし userId=$id');
+        return null;
+      }
 
-    final publicData = userDoc.data()!;
-    publicData['id'] = userDoc.id;
+      final publicData = userDoc.data()!;
+      publicData['id'] = userDoc.id;
 
-    final privateData = privateDoc.data()!;
-    privateData['lists'] = privateData['lists'] ?? [];
+      final privateData = privateDoc.data()!;
+      privateData['lists'] = privateData['lists'] ?? [];
 
-    return UserModel(
-      publicProfile: PublicUserModel.fromJson(publicData),
-      privateProfile: PrivateUserModel.fromJson(privateData),
-    );
+      AppLogger.debugOnly('UserRepository.getUser成功: userId=$id');
+      return UserModel(
+        publicProfile: PublicUserModel.fromJson(publicData),
+        privateProfile: PrivateUserModel.fromJson(privateData),
+      );
+    } catch (e, stackTrace) {
+      AppLogger.errorOnly(
+          'UserRepository.getUser失敗: userId=$id', e, stackTrace);
+      rethrow;
+    }
   }
 
   // 友達の公開情報のみを取得するメソッド
@@ -78,9 +93,12 @@ class UserRepository implements IUserRepository {
   @override
   Future<void> createUser(UserModel user) async {
     try {
+      AppLogger.debugOnly('UserRepository.createUser開始: userId=${user.id}');
       // searchIdの一意性をチェック
       final isUnique = await isUserIdUnique(user.searchId);
       if (!isUnique) {
+        AppLogger.warningOnly(
+            'UserRepository.createUser失敗: searchId重複 searchId=${user.searchId}');
         throw Exception('このsearchIdは既に使用されています');
       }
 
@@ -102,24 +120,35 @@ class UserRepository implements IUserRepository {
         // 非公開情報をprivateサブコレクションに保存
         transaction.set(privateRef, _toFirestorePrivate(user.privateProfile));
       });
-    } catch (e) {
-      AppLogger.error('Error creating user: $e');
+      AppLogger.debugOnly('UserRepository.createUser完了: userId=${user.id}');
+    } catch (e, stackTrace) {
+      AppLogger.errorOnly(
+          'UserRepository.createUser失敗: userId=${user.id}', e, stackTrace);
       rethrow;
     }
   }
 
   @override
   Future<void> updateUser(UserModel user) async {
-    final userRef = _firestore.collection('users').doc(user.id);
-    final privateRef = userRef.collection('private').doc('profile');
+    try {
+      AppLogger.debugOnly('UserRepository.updateUser開始: userId=${user.id}');
+      final userRef = _firestore.collection('users').doc(user.id);
+      final privateRef = userRef.collection('private').doc('profile');
 
-    await _firestore.runTransaction((transaction) async {
-      // 公開情報を更新
-      transaction.update(userRef, _toFirestorePublic(user.publicProfile));
+      await _firestore.runTransaction((transaction) async {
+        // 公開情報を更新
+        transaction.update(userRef, _toFirestorePublic(user.publicProfile));
 
-      // 非公開情報を更新
-      transaction.update(privateRef, _toFirestorePrivate(user.privateProfile));
-    });
+        // 非公開情報を更新
+        transaction.update(
+            privateRef, _toFirestorePrivate(user.privateProfile));
+      });
+      AppLogger.debugOnly('UserRepository.updateUser完了: userId=${user.id}');
+    } catch (e, stackTrace) {
+      AppLogger.errorOnly(
+          'UserRepository.updateUser失敗: userId=${user.id}', e, stackTrace);
+      rethrow;
+    }
   }
 
   @override

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -46,7 +46,7 @@ Future<void> startApp([
   AppConfig.initialize(environment);
 
   // AdMob設定の初期化（Firebase初期化の前に行う）
-  AdMobConfig.initialize();
+  AdMobConfig.initialize(forceTestMode: skipFirebaseInit);
 
   // 日本語ロケールの初期化
   await initializeDateFormatting('ja_JP', null);
@@ -54,8 +54,21 @@ Future<void> startApp([
   // Firebase関連の初期化（テスト時はスキップ）
   if (!skipFirebaseInit) {
     try {
-      // Firebaseの初期化
-      await Firebase.initializeApp(options: AppConfig.instance.firebaseOptions);
+      AppLogger.info(
+          'Firebase初期化を開始: env=${AppConfig.instance.environmentName}, projectId=${AppConfig.instance.firebaseOptions.projectId}, iosBundleId=${AppConfig.instance.firebaseOptions.iosBundleId}');
+
+      if (Firebase.apps.isEmpty) {
+        await Firebase.initializeApp(
+            options: AppConfig.instance.firebaseOptions);
+        AppLogger.info('Firebase初期化完了: [DEFAULT] を作成しました');
+      } else {
+        AppLogger.warning(
+            'Firebaseは既に初期化済みのため再初期化をスキップします: apps=${Firebase.apps.map((app) => app.name).join(', ')}');
+      }
+
+      final defaultApp = Firebase.app();
+      AppLogger.info(
+          'Firebase使用中アプリ: name=${defaultApp.name}, projectId=${defaultApp.options.projectId}, appId=${defaultApp.options.appId}, senderId=${defaultApp.options.messagingSenderId}, iosBundleId=${defaultApp.options.iosBundleId}');
 
       // プッシュ通知サービスの初期化
       AppLogger.info('🚀 プッシュ通知サービスの初期化を開始...');

--- a/lib/presentation/bottom_navigation/bottom_navigation.dart
+++ b/lib/presentation/bottom_navigation/bottom_navigation.dart
@@ -3,11 +3,11 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../home/home_page.dart';
 import '../friend/friend_list_page.dart';
 import '../my_page/my_page.dart';
+import '../widgets/auth_dependent_builder.dart';
 
 class BottomNavigationPage extends ConsumerStatefulWidget {
-  static const String path = '/';
-
   const BottomNavigationPage({super.key});
+  static const String path = '/';
 
   @override
   ConsumerState<BottomNavigationPage> createState() =>
@@ -15,6 +15,30 @@ class BottomNavigationPage extends ConsumerStatefulWidget {
 }
 
 class _BottomNavigationPageState extends ConsumerState<BottomNavigationPage> {
+  @override
+  Widget build(BuildContext context) {
+    return AuthDependentBuilder(
+      onAuthenticated: (_) => const _AuthenticatedBottomNavigationShell(),
+      onLoading: (_) => const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      ),
+      onUnauthenticated: (_) => const Scaffold(
+        body: SizedBox.shrink(),
+      ),
+    );
+  }
+}
+
+class _AuthenticatedBottomNavigationShell extends StatefulWidget {
+  const _AuthenticatedBottomNavigationShell();
+
+  @override
+  State<_AuthenticatedBottomNavigationShell> createState() =>
+      _AuthenticatedBottomNavigationShellState();
+}
+
+class _AuthenticatedBottomNavigationShellState
+    extends State<_AuthenticatedBottomNavigationShell> {
   int _selectedIndex = 0;
 
   final List<Widget> _pages = [

--- a/lib/presentation/calendar/create_schedule_page.dart
+++ b/lib/presentation/calendar/create_schedule_page.dart
@@ -2,12 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:lakiite/presentation/calendar/schedule_form_page.dart';
 
 class CreateSchedulePage extends StatelessWidget {
-  final DateTime? initialDate;
-
   const CreateSchedulePage({
     super.key,
     this.initialDate,
   });
+  final DateTime? initialDate;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/presentation/calendar/edit_schedule_page.dart
+++ b/lib/presentation/calendar/edit_schedule_page.dart
@@ -3,8 +3,8 @@ import 'package:lakiite/domain/entity/schedule.dart';
 import 'package:lakiite/presentation/calendar/schedule_form_page.dart';
 
 class EditSchedulePage extends StatelessWidget {
-  final Schedule schedule;
   const EditSchedulePage({super.key, required this.schedule});
+  final Schedule schedule;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/presentation/calendar/schedule_detail_page.dart
+++ b/lib/presentation/calendar/schedule_detail_page.dart
@@ -503,7 +503,7 @@ class ScheduleDetailPage extends HookConsumerWidget {
 
     // リポジトリから取得したリアクションデータをログ出力
     developer.log('リポジトリから取得したリアクション: ${reactions.length}件');
-    for (var reaction in reactions) {
+    for (final reaction in reactions) {
       developer
           .log('取得したリアクション: userId=${reaction.userId}, type=${reaction.type}');
     }

--- a/lib/presentation/calendar/schedule_form_page.dart
+++ b/lib/presentation/calendar/schedule_form_page.dart
@@ -9,12 +9,11 @@ import 'package:lakiite/presentation/list/list_detail_page.dart';
 
 /// 15分単位の時間選択ダイアログ
 class CustomTimePickerDialog extends StatefulWidget {
-  final TimeOfDay initialTime;
-
   const CustomTimePickerDialog({
     super.key,
     required this.initialTime,
   });
+  final TimeOfDay initialTime;
 
   @override
   State<CustomTimePickerDialog> createState() => _CustomTimePickerDialogState();
@@ -126,14 +125,13 @@ class _CustomTimePickerDialogState extends State<CustomTimePickerDialog> {
 }
 
 class ScheduleFormPage extends HookConsumerWidget {
-  final Schedule? schedule;
-  final DateTime? initialDate;
-
   const ScheduleFormPage({
     super.key,
     this.schedule,
     this.initialDate,
   });
+  final Schedule? schedule;
+  final DateTime? initialDate;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/presentation/calendar/widgets/calendar_page_view.dart
+++ b/lib/presentation/calendar/widgets/calendar_page_view.dart
@@ -11,6 +11,7 @@ import 'dart:async'; // Timerのインポートを追加
 import 'package:flutter/gestures.dart' show DragStartBehavior;
 import 'package:flutter/services.dart' show rootBundle;
 import 'package:lakiite/utils/logger.dart'; // AppLoggerのインポートを追加
+import 'package:lakiite/application/auth/auth_state.dart';
 
 // 現在表示中のカレンダーページインデックスを保持するプロバイダー
 final calendarCurrentIndexProvider =
@@ -249,6 +250,18 @@ class CalendarPageView extends HookConsumerWidget {
             // 少し遅延させてからデータ表示を確実にする
             Future.delayed(const Duration(milliseconds: 500), () {
               try {
+                final latestAuthState = ref.read(authNotifierProvider);
+                final stillAuthenticated = latestAuthState.maybeWhen(
+                  data: (state) =>
+                      state.status == AuthStatus.authenticated &&
+                      state.user?.id == currentUserId,
+                  orElse: () => false,
+                );
+                if (!stillAuthenticated) {
+                  AppLogger.debug('カレンダー初期表示: 認証状態が変化したため強制再取得を中止');
+                  return;
+                }
+
                 // 最適化モードを無効化（スライド完了時と同じ処理）
                 if (ref.exists(calendarOptimizationProvider)) {
                   ref.read(calendarOptimizationProvider.notifier).state = false;
@@ -286,7 +299,7 @@ class CalendarPageView extends HookConsumerWidget {
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
                 Text(
-                  "$visibleYear年$visibleMonth",
+                  '$visibleYear年$visibleMonth',
                   style: const TextStyle(
                       fontSize: 18, fontWeight: FontWeight.bold),
                 ),
@@ -625,6 +638,16 @@ class CalendarPageView extends HookConsumerWidget {
       [bool force = false]) {
     try {
       final monthKey = getMonthKey(date);
+      final authState = ref.read(authNotifierProvider);
+      final stillAuthenticated = authState.maybeWhen(
+        data: (state) =>
+            state.status == AuthStatus.authenticated &&
+            state.user?.id == userId,
+        orElse: () => false,
+      );
+      if (!stillAuthenticated) {
+        return;
+      }
 
       // Providerの存在確認
       if (!ref.exists(lastDataFetchTimeProvider) ||
@@ -703,18 +726,18 @@ class CalendarPageView extends HookConsumerWidget {
 
   String _getMonthName(int month) {
     final monthNames = [
-      "1月",
-      "2月",
-      "3月",
-      "4月",
-      "5月",
-      "6月",
-      "7月",
-      "8月",
-      "9月",
-      "10月",
-      "11月",
-      "12月"
+      '1月',
+      '2月',
+      '3月',
+      '4月',
+      '5月',
+      '6月',
+      '7月',
+      '8月',
+      '9月',
+      '10月',
+      '11月',
+      '12月'
     ];
     return monthNames[month - 1];
   }

--- a/lib/presentation/calendar/widgets/daily_schedule_content.dart
+++ b/lib/presentation/calendar/widgets/daily_schedule_content.dart
@@ -30,7 +30,7 @@ class DailyScheduleContent extends HookConsumerWidget {
   List<List<Schedule>> _groupOverlappingSchedules(List<Schedule> schedules) {
     if (schedules.isEmpty) return [];
 
-    List<List<Schedule>> groups = [];
+    final List<List<Schedule>> groups = [];
     List<Schedule> currentGroup = [schedules[0]];
 
     for (int i = 1; i < schedules.length; i++) {

--- a/lib/presentation/calendar/widgets/daily_schedule_view.dart
+++ b/lib/presentation/calendar/widgets/daily_schedule_view.dart
@@ -7,6 +7,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:lakiite/presentation/presentation_provider.dart'
     hide scheduleNotifierProvider;
 import 'package:lakiite/application/schedule/schedule_notifier.dart';
+import 'package:lakiite/application/auth/auth_state.dart';
 import 'package:lakiite/utils/logger.dart';
 import 'package:lakiite/presentation/calendar/create_schedule_page.dart';
 
@@ -79,6 +80,19 @@ class DailyScheduleView extends HookConsumerWidget {
         // 少し遅延させてからスケジュールの取得を開始することで
         // Firebase認証が確実に完了した状態でデータ取得を行う
         Future.delayed(const Duration(milliseconds: 300), () {
+          final latestAuthState = ref.read(authNotifierProvider);
+          final stillAuthenticated = latestAuthState.maybeWhen(
+            data: (state) =>
+                state.status == AuthStatus.authenticated &&
+                state.user?.id == currentUserId,
+            orElse: () => false,
+          );
+          if (!stillAuthenticated) {
+            AppLogger.debug(
+                'DailyScheduleView - 認証状態が変化したためスケジュール監視開始を中止: userId=$currentUserId');
+            return;
+          }
+
           AppLogger.debug(
               'DailyScheduleView - スケジュール監視開始: userId=$currentUserId');
           ref

--- a/lib/presentation/debug/debug_notification_page.dart
+++ b/lib/presentation/debug/debug_notification_page.dart
@@ -5,7 +5,6 @@ import 'dart:io';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
-import '../../infrastructure/firebase/push_notification_service.dart';
 import '../../utils/logger.dart';
 
 /// デバッグ用：プッシュ通知トークン表示ページ
@@ -79,7 +78,7 @@ class _DebugNotificationPageState extends State<DebugNotificationPage> {
       // Android 13+の場合、詳細な権限デバッグログ
       if (Platform.isAndroid) {
         AppLogger.info('🐯 ANDROID FCM TOKEN取得開始');
-        AppLogger.info('🔔 通知権限ステータス: ${_notificationPermissionStatus}');
+        AppLogger.info('🔔 通知権限ステータス: $_notificationPermissionStatus');
         AppLogger.info('🔔 Alert権限: ${notificationSettings.alert}');
         AppLogger.info('🔔 Badge権限: ${notificationSettings.badge}');
         AppLogger.info('🔔 Sound権限: ${notificationSettings.sound}');

--- a/lib/presentation/friend/friend_profile_page.dart
+++ b/lib/presentation/friend/friend_profile_page.dart
@@ -7,12 +7,11 @@ import '../widgets/schedule_tile.dart';
 import '../../utils/logger.dart';
 
 class FriendProfilePage extends ConsumerWidget {
-  final String userId;
-
   const FriendProfilePage({
     super.key,
     required this.userId,
   });
+  final String userId;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -191,6 +190,7 @@ class FriendProfilePage extends ConsumerWidget {
                               // この友人が作成した予定
                               s.ownerId == userId &&
                               // 現在日以降の予定
+                              // ignore: avoid_dynamic_calls
                               s.endDateTime.isAfter(todayStart))
                           .toList();
 
@@ -231,6 +231,7 @@ class FriendProfilePage extends ConsumerWidget {
 
                       // 日付でソート
                       userSchedules.sort(
+                          // ignore: avoid_dynamic_calls
                           (a, b) => a.startDateTime.compareTo(b.startDateTime));
 
                       return ListView.builder(
@@ -270,13 +271,12 @@ class FriendProfilePage extends ConsumerWidget {
 
 /// セクションヘッダーウィジェット
 class _SectionHeader extends StatelessWidget {
-  final IconData icon;
-  final String title;
-
   const _SectionHeader({
     required this.icon,
     required this.title,
   });
+  final IconData icon;
+  final String title;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/presentation/friend/friend_request_list_page.dart
+++ b/lib/presentation/friend/friend_request_list_page.dart
@@ -120,16 +120,15 @@ class FriendRequestListPage extends ConsumerWidget {
 }
 
 class FriendRequestCard extends StatelessWidget {
-  final domain.Notification request;
-  final Future<void> Function() onAccept;
-  final VoidCallback onReject;
-
   const FriendRequestCard({
     super.key,
     required this.request,
     required this.onAccept,
     required this.onReject,
   });
+  final domain.Notification request;
+  final Future<void> Function() onAccept;
+  final VoidCallback onReject;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/presentation/friend/friend_search_view_model.dart
+++ b/lib/presentation/friend/friend_search_view_model.dart
@@ -7,13 +7,6 @@ import '../../presentation/presentation_provider.dart';
 import '../../utils/logger.dart';
 
 class SearchUserModel {
-  final String id;
-  final String displayName;
-  final String searchId;
-  final String iconUrl;
-  final String? shortBio;
-  final bool hasPendingRequest;
-
   const SearchUserModel({
     required this.id,
     required this.displayName,
@@ -22,6 +15,12 @@ class SearchUserModel {
     this.shortBio,
     this.hasPendingRequest = false,
   });
+  final String id;
+  final String displayName;
+  final String searchId;
+  final String iconUrl;
+  final String? shortBio;
+  final bool hasPendingRequest;
 }
 
 final friendSearchViewModelProvider =
@@ -40,19 +39,18 @@ final friendSearchViewModelProvider =
 
 class FriendSearchViewModel
     extends StateNotifier<AsyncValue<SearchUserModel?>> {
-  String? _message;
-  String? get message => _message;
-  final IUserRepository _userRepository;
-  final NotificationRepository _notificationRepository;
-  final String _currentUserId;
-  final String _currentUserDisplayName;
-
   FriendSearchViewModel(
     this._userRepository,
     this._notificationRepository,
     this._currentUserId,
     this._currentUserDisplayName,
   ) : super(const AsyncValue.data(null));
+  String? _message;
+  String? get message => _message;
+  final IUserRepository _userRepository;
+  final NotificationRepository _notificationRepository;
+  final String _currentUserId;
+  final String _currentUserDisplayName;
 
   Future<void> searchUser(String searchId) async {
     try {

--- a/lib/presentation/group/group_detail_page.dart
+++ b/lib/presentation/group/group_detail_page.dart
@@ -9,12 +9,11 @@ import 'group_member_invite_page.dart';
 /// グループのメンバー一覧や予定を表示し、メンバーの招待や
 /// グループ情報の編集機能を提供する
 class GroupDetailPage extends ConsumerStatefulWidget {
-  final Group group;
-
   const GroupDetailPage({
     super.key,
     required this.group,
   });
+  final Group group;
 
   @override
   ConsumerState<GroupDetailPage> createState() => _GroupDetailPageState();

--- a/lib/presentation/group/group_member_invite_page.dart
+++ b/lib/presentation/group/group_member_invite_page.dart
@@ -7,12 +7,11 @@ import 'widgets/friend_list_tile.dart';
 
 /// グループメンバー招待ページ
 class GroupMemberInvitePage extends ConsumerStatefulWidget {
-  final Group group;
-
   const GroupMemberInvitePage({
     super.key,
     required this.group,
   });
+  final Group group;
 
   @override
   ConsumerState<GroupMemberInvitePage> createState() =>

--- a/lib/presentation/group/models/group_member_invite_state.dart
+++ b/lib/presentation/group/models/group_member_invite_state.dart
@@ -4,13 +4,6 @@ import 'search_user_model.dart' as search;
 
 /// グループメンバー招待画面の状態を管理するクラス
 class GroupMemberInviteState {
-  final AsyncValue<search.SearchUserModel?> searchResult;
-  final List<UserModel> friends;
-  final Set<String> selectedFriends;
-  final Set<String> groupMembers;
-  final Set<String> pendingInvitations;
-  final String? message;
-
   const GroupMemberInviteState({
     this.searchResult = const AsyncValue.data(null),
     this.friends = const [],
@@ -19,6 +12,12 @@ class GroupMemberInviteState {
     this.pendingInvitations = const {},
     this.message,
   });
+  final AsyncValue<search.SearchUserModel?> searchResult;
+  final List<UserModel> friends;
+  final Set<String> selectedFriends;
+  final Set<String> groupMembers;
+  final Set<String> pendingInvitations;
+  final String? message;
 
   /// 状態を更新するためのコピーメソッド
   GroupMemberInviteState copyWith({

--- a/lib/presentation/group/models/search_user_model.dart
+++ b/lib/presentation/group/models/search_user_model.dart
@@ -1,11 +1,5 @@
 /// グループメンバー招待時の検索結果ユーザーモデル
 class SearchUserModel {
-  final String id;
-  final String displayName;
-  final String searchId;
-  final String iconUrl;
-  final bool hasPendingRequest;
-
   const SearchUserModel({
     required this.id,
     required this.displayName,
@@ -13,4 +7,9 @@ class SearchUserModel {
     required this.iconUrl,
     this.hasPendingRequest = false,
   });
+  final String id;
+  final String displayName;
+  final String searchId;
+  final String iconUrl;
+  final bool hasPendingRequest;
 }

--- a/lib/presentation/group/widgets/friend_list_tile.dart
+++ b/lib/presentation/group/widgets/friend_list_tile.dart
@@ -3,13 +3,6 @@ import '../../../domain/entity/user.dart';
 
 /// フレンドリストの各アイテムを表示するウィジェット
 class FriendListTile extends StatelessWidget {
-  final UserModel friend;
-  final bool isSelected;
-  final bool isInvitable;
-  final bool isGroupMember;
-  final bool hasPendingInvitation;
-  final Function(bool?)? onChanged;
-
   const FriendListTile({
     super.key,
     required this.friend,
@@ -19,6 +12,12 @@ class FriendListTile extends StatelessWidget {
     required this.hasPendingInvitation,
     this.onChanged,
   });
+  final UserModel friend;
+  final bool isSelected;
+  final bool isInvitable;
+  final bool isGroupMember;
+  final bool hasPendingInvitation;
+  final Function(bool?)? onChanged;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/presentation/group/widgets/user_search_dialog.dart
+++ b/lib/presentation/group/widgets/user_search_dialog.dart
@@ -3,16 +3,15 @@ import '../models/search_user_model.dart';
 
 /// ユーザー検索結果を表示するダイアログ
 class UserSearchDialog extends StatelessWidget {
-  final SearchUserModel user;
-  final VoidCallback onCancel;
-  final Function(String) onSelect;
-
   const UserSearchDialog({
     super.key,
     required this.user,
     required this.onCancel,
     required this.onSelect,
   });
+  final SearchUserModel user;
+  final VoidCallback onCancel;
+  final Function(String) onSelect;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/presentation/home/home_page.dart
+++ b/lib/presentation/home/home_page.dart
@@ -139,6 +139,19 @@ class HomePage extends HookConsumerWidget {
             // 認証完了後、少し遅延させてからスケジュールの取得を開始することで
             // Firebase認証が確実に完了した状態でデータ取得を行う
             Future.delayed(const Duration(milliseconds: 500), () {
+              final latestAuthState = ref.read(authNotifierProvider);
+              final stillAuthenticated = latestAuthState.maybeWhen(
+                data: (latestState) =>
+                    latestState.status == AuthStatus.authenticated &&
+                    latestState.user?.id == currentUserId,
+                orElse: () => false,
+              );
+              if (!stillAuthenticated) {
+                AppLogger.debug(
+                    'ホーム画面: 認証状態が変化したため遅延後データ取得を中止しました - userId: $currentUserId');
+                return;
+              }
+
               // 常に全ての予定を取得する
               ref
                   .read(scheduleNotifierProvider.notifier)

--- a/lib/presentation/home/widgets/error_widget.dart
+++ b/lib/presentation/home/widgets/error_widget.dart
@@ -4,16 +4,15 @@ import 'package:lakiite/application/auth/auth_state.dart';
 import 'package:lakiite/presentation/presentation_provider.dart';
 
 class HomeErrorWidget extends StatelessWidget {
-  final Object error;
-  final AuthState authState;
-  final WidgetRef ref;
-
   const HomeErrorWidget({
     super.key,
     required this.error,
     required this.authState,
     required this.ref,
   });
+  final Object error;
+  final AuthState authState;
+  final WidgetRef ref;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/presentation/home/widgets/schedule_item.dart
+++ b/lib/presentation/home/widgets/schedule_item.dart
@@ -13,12 +13,6 @@ import 'package:lakiite/presentation/widgets/reaction_icon_widget.dart';
 /// ホームタブのタイムラインに表示される予定の内容を表示します。
 /// 予定の基本情報とリアクション・コメントの状態を表示します。
 class ScheduleItem extends ConsumerWidget {
-  /// 表示する予定データ
-  final Schedule schedule;
-
-  /// 現在のユーザー情報
-  final UserModel currentUser;
-
   /// コンストラクタ
   ///
   /// [schedule] 表示する予定データ
@@ -28,6 +22,12 @@ class ScheduleItem extends ConsumerWidget {
     required this.schedule,
     required this.currentUser,
   });
+
+  /// 表示する予定データ
+  final Schedule schedule;
+
+  /// 現在のユーザー情報
+  final UserModel currentUser;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/presentation/list/list_detail_page.dart
+++ b/lib/presentation/list/list_detail_page.dart
@@ -13,9 +13,8 @@ import 'list_edit_page.dart';
 /// - リストメンバーの表示
 /// - リストの編集・削除
 class ListDetailPage extends ConsumerStatefulWidget {
-  final UserList list;
-
   const ListDetailPage({super.key, required this.list});
+  final UserList list;
 
   @override
   ConsumerState<ListDetailPage> createState() => _ListDetailPageState();

--- a/lib/presentation/list/list_edit_page.dart
+++ b/lib/presentation/list/list_edit_page.dart
@@ -7,9 +7,8 @@ import '../../domain/entity/user.dart';
 import '../presentation_provider.dart';
 
 class ListEditPage extends ConsumerStatefulWidget {
-  final UserList list;
-
   const ListEditPage({super.key, required this.list});
+  final UserList list;
 
   @override
   ConsumerState<ListEditPage> createState() => _ListEditPageState();
@@ -55,7 +54,7 @@ class _ListEditPageState extends ConsumerState<ListEditPage> {
     setState(() => _isLoading = true);
 
     try {
-      String? newIconUrl = widget.list.iconUrl;
+      final String? newIconUrl = widget.list.iconUrl;
       if (_selectedImage != null) {
         // 画像のアップロード処理を実装
         // newIconUrl = await uploadImage(_selectedImage!);

--- a/lib/presentation/list/list_member_invite_page.dart
+++ b/lib/presentation/list/list_member_invite_page.dart
@@ -6,12 +6,11 @@ import '../presentation_provider.dart';
 
 /// リストメンバー追加ページ
 class ListMemberInvitePage extends ConsumerStatefulWidget {
-  final UserList list;
-
   const ListMemberInvitePage({
     super.key,
     required this.list,
   });
+  final UserList list;
 
   @override
   ConsumerState<ListMemberInvitePage> createState() =>

--- a/lib/presentation/login/login_page.dart
+++ b/lib/presentation/login/login_page.dart
@@ -3,12 +3,11 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../presentation_provider.dart';
 import '../signup/signup.dart';
-import '../../presentation/bottom_navigation/bottom_navigation.dart';
+import '../../utils/logger.dart';
 
 class LoginPage extends ConsumerStatefulWidget {
-  static const String path = '/login';
-
   const LoginPage({super.key});
+  static const String path = '/login';
 
   @override
   ConsumerState<LoginPage> createState() => _LoginPageState();
@@ -29,6 +28,7 @@ class _LoginPageState extends ConsumerState<LoginPage> {
   Future<void> _handleLogin() async {
     if (_isLoading) return;
 
+    AppLogger.debugOnly('LoginPage._handleLogin開始');
     setState(() {
       _isLoading = true;
     });
@@ -38,10 +38,16 @@ class _LoginPageState extends ConsumerState<LoginPage> {
             _emailController.text,
             _passwordController.text,
           );
-      if (mounted) {
-        context.go(BottomNavigationPage.path);
+      final authState = ref.read(authNotifierProvider);
+      AppLogger.debugOnly('LoginPage._handleLogin後 state=$authState');
+      if (mounted && authState.hasError) {
+        final error = authState.error;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('ログインに失敗しました: ${error.toString()}')),
+        );
       }
     } catch (e) {
+      AppLogger.errorOnly('LoginPage._handleLogin例外', e);
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text('ログインに失敗しました: ${e.toString()}')),

--- a/lib/presentation/my_page/my_page.dart
+++ b/lib/presentation/my_page/my_page.dart
@@ -348,9 +348,8 @@ class _InvalidUserDataState extends StatelessWidget {
 
 /// エラー発生時の表示ウィジェット
 class _ErrorState extends StatelessWidget {
-  final Object error;
-
   const _ErrorState({required this.error});
+  final Object error;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/presentation/my_page/my_page_view_model.dart
+++ b/lib/presentation/my_page/my_page_view_model.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter/services.dart';
 import 'package:firebase_storage/firebase_storage.dart';
+import 'package:lakiite/application/auth/auth_state.dart';
 import '../../infrastructure/image_picker_service.dart' as picker;
 import '../../domain/entity/user.dart';
 import '../../domain/entity/schedule.dart';
@@ -19,17 +20,38 @@ final selectedImageProvider = StateProvider<File?>((ref) => null);
 final myPageEditingProvider = StateProvider<bool>((ref) => false);
 
 final timelineSchedulesProvider = StreamProvider<List<Schedule>>((ref) {
-  final scheduleRepository = ref.watch(scheduleRepositoryProvider);
-  final currentUserId = ref.watch(currentUserIdProvider);
-  if (currentUserId == null) return Stream.value([]);
+  final authState = ref.watch(authNotifierProvider);
 
-  return scheduleRepository.watchUserSchedules(currentUserId);
+  return authState.when(
+    data: (state) {
+      if (state.status != AuthStatus.authenticated || state.user == null) {
+        return Stream.value([]);
+      }
+
+      return ref
+          .watch(scheduleRepositoryProvider)
+          .watchUserSchedules(state.user!.id);
+    },
+    loading: () => Stream.value([]),
+    error: (_, __) => Stream.value([]),
+  );
 });
 
 final userSchedulesStreamProvider =
     StreamProvider.family<List<Schedule>, String>((ref, userId) {
-  final scheduleRepository = ref.watch(scheduleRepositoryProvider);
-  return scheduleRepository.watchUserSchedules(userId);
+  final authState = ref.watch(authNotifierProvider);
+
+  return authState.when(
+    data: (state) {
+      if (state.status != AuthStatus.authenticated || state.user == null) {
+        return Stream.value([]);
+      }
+
+      return ref.watch(scheduleRepositoryProvider).watchUserSchedules(userId);
+    },
+    loading: () => Stream.value([]),
+    error: (_, __) => Stream.value([]),
+  );
 });
 
 final cachedUserProvider =
@@ -51,12 +73,6 @@ final myPageViewModelProvider =
 });
 
 class MyPageViewModel extends StateNotifier<AsyncValue<UserModel?>> {
-  final IUserRepository _userRepository;
-  final IScheduleRepository _scheduleRepository;
-  final IStorageService _storageService;
-  final IImageProcessorService _imageProcessorService;
-  final Ref _ref;
-
   MyPageViewModel(
     this._userRepository,
     this._scheduleRepository,
@@ -64,6 +80,11 @@ class MyPageViewModel extends StateNotifier<AsyncValue<UserModel?>> {
     this._imageProcessorService,
     this._ref,
   ) : super(const AsyncValue.loading());
+  final IUserRepository _userRepository;
+  final IScheduleRepository _scheduleRepository;
+  final IStorageService _storageService;
+  final IImageProcessorService _imageProcessorService;
+  final Ref _ref;
 
   Future<void> pickImage() async {
     try {

--- a/lib/presentation/my_page/widgets/profile_card.dart
+++ b/lib/presentation/my_page/widgets/profile_card.dart
@@ -8,14 +8,13 @@ import 'search_id_display.dart';
 /// [user] 表示するユーザー情報
 /// [onEditPressed] プロフィール編集ボタンが押された時のコールバック
 class ProfileCard extends StatelessWidget {
-  final UserModel user;
-  final VoidCallback onEditPressed;
-
   const ProfileCard({
     super.key,
     required this.user,
     required this.onEditPressed,
   });
+  final UserModel user;
+  final VoidCallback onEditPressed;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/presentation/my_page/widgets/profile_edit_dialog.dart
+++ b/lib/presentation/my_page/widgets/profile_edit_dialog.dart
@@ -8,14 +8,13 @@ import '../my_page_view_model.dart';
 /// [user] 編集対象のユーザーモデル
 /// [onImageEdit] プロフィール画像編集時のコールバック
 class ProfileEditDialog extends ConsumerStatefulWidget {
-  final UserModel user;
-  final VoidCallback onImageEdit;
-
   const ProfileEditDialog({
     super.key,
     required this.user,
     required this.onImageEdit,
   });
+  final UserModel user;
+  final VoidCallback onImageEdit;
 
   @override
   ConsumerState<ProfileEditDialog> createState() => _ProfileEditDialogState();

--- a/lib/presentation/my_page/widgets/schedule_list.dart
+++ b/lib/presentation/my_page/widgets/schedule_list.dart
@@ -11,12 +11,11 @@ import '../../presentation_provider.dart';
 /// 予定がない場合は「予定がありません」というメッセージを表示します。
 /// 予定がある場合は、本日以降の日付でソートされたリストを表示します。
 class ScheduleList extends ConsumerWidget {
-  final String userId;
-
   const ScheduleList({
     super.key,
     required this.userId,
   });
+  final String userId;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/presentation/my_page/widgets/search_id_display.dart
+++ b/lib/presentation/my_page/widgets/search_id_display.dart
@@ -7,12 +7,11 @@ import '../../theme/app_theme.dart';
 ///
 /// [searchId] 表示する検索ID
 class SearchIdDisplay extends StatelessWidget {
-  final UserId searchId;
-
   const SearchIdDisplay({
     super.key,
     required this.searchId,
   });
+  final UserId searchId;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/presentation/my_page/widgets/section_header.dart
+++ b/lib/presentation/my_page/widgets/section_header.dart
@@ -5,14 +5,13 @@ import 'package:flutter/material.dart';
 /// [icon] 表示するアイコン
 /// [title] 表示するタイトル
 class SectionHeader extends StatelessWidget {
-  final IconData icon;
-  final String title;
-
   const SectionHeader({
     super.key,
     required this.icon,
     required this.title,
   });
+  final IconData icon;
+  final String title;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/presentation/my_page/widgets/short_bio_card.dart
+++ b/lib/presentation/my_page/widgets/short_bio_card.dart
@@ -4,12 +4,11 @@ import 'package:flutter/material.dart';
 ///
 /// [shortBio] 表示する一言コメント
 class ShortBioCard extends StatelessWidget {
-  final String? shortBio;
-
   const ShortBioCard({
     super.key,
     this.shortBio,
   });
+  final String? shortBio;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/presentation/notification/notification_list_page.dart
+++ b/lib/presentation/notification/notification_list_page.dart
@@ -101,13 +101,12 @@ class NotificationListPage extends ConsumerWidget {
 }
 
 class _NotificationList extends ConsumerWidget {
-  final AsyncValue<List<domain.Notification>> asyncValue;
-  final NotificationFilter filter;
-
   const _NotificationList({
     required this.asyncValue,
     required this.filter,
   });
+  final AsyncValue<List<domain.Notification>> asyncValue;
+  final NotificationFilter filter;
 
   List<domain.Notification> _filterNotifications(
       List<domain.Notification> notifications) {
@@ -193,11 +192,10 @@ class _NotificationList extends ConsumerWidget {
 }
 
 class _NotificationItem extends ConsumerWidget {
-  final domain.Notification notification;
-
   const _NotificationItem({
     required this.notification,
   });
+  final domain.Notification notification;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/presentation/presentation_provider.dart
+++ b/lib/presentation/presentation_provider.dart
@@ -35,18 +35,39 @@ import 'package:lakiite/infrastructure/repository/reaction_repository_impl.dart'
 export 'package:lakiite/application/notification/notification_notifier.dart'
     show currentUserIdProvider;
 export 'package:lakiite/application/auth/auth_notifier.dart'
-    show authRepositoryProvider;
+    show authNotifierProvider, authRepositoryProvider;
+
+typedef UserRepositoryFactory = IUserRepository Function();
+typedef ScheduleRepositoryFactory = IScheduleRepository Function();
 
 /// Firebase認証インスタンスを提供するプロバイダー
 final firebaseAuthProvider = Provider((ref) => FirebaseAuth.instance);
 
+/// Firebase 認証状態の変化を監視し、repository のセッション境界を提供する。
+final repositorySessionKeyProvider = StreamProvider.autoDispose<String?>((ref) {
+  final firebaseAuth = ref.watch(firebaseAuthProvider);
+  return firebaseAuth.authStateChanges().map((user) => user?.uid);
+});
+
 /// リポジトリプロバイダー群
+final userRepositoryFactoryProvider = Provider<UserRepositoryFactory>((ref) {
+  return () => UserRepository();
+});
+
+final scheduleRepositoryFactoryProvider =
+    Provider<ScheduleRepositoryFactory>((ref) {
+  return () => ScheduleRepository();
+});
+
 // ユーザーリポジトリプロバイダー
 final userRepositoryProvider = Provider<IUserRepository>((ref) {
-  final repository = UserRepository();
+  ref.watch(repositorySessionKeyProvider);
+
+  final repository = ref.watch(userRepositoryFactoryProvider).call();
   ref.onDispose(() {
-    // キャッシュをクリア
-    (repository).clearCache();
+    if (repository is UserRepository) {
+      repository.clearCache();
+    }
   });
   return repository;
 });
@@ -63,7 +84,8 @@ final listRepositoryProvider = Provider<IListRepository>((ref) {
 
 /// スケジュールリポジトリプロバイダー
 final scheduleRepositoryProvider = Provider<IScheduleRepository>((ref) {
-  return ScheduleRepository();
+  ref.watch(repositorySessionKeyProvider);
+  return ref.watch(scheduleRepositoryFactoryProvider).call();
 });
 
 /// 通知リポジトリプロバイダー
@@ -88,12 +110,6 @@ final authStateProvider = StreamProvider.autoDispose((ref) {
   final authRepository = ref.watch(authRepositoryProvider);
   return authRepository.authStateChanges();
 });
-
-/// 認証状態を管理するNotifierプロバイダー
-final authNotifierProvider =
-    AutoDisposeAsyncNotifierProvider<AuthNotifier, AuthState>(
-  AuthNotifier.new,
-);
 
 /// グループ状態プロバイダー群
 // グループ状態を管理するNotifierプロバイダー
@@ -121,37 +137,42 @@ final listNotifierProvider =
 /// 認証状態に基づいて適切にリストを提供します。
 /// Application層のビジネスロジックに依存しません。
 final userListsStreamProvider =
-    StreamProvider.autoDispose<List<UserList>>((ref) async* {
-  final authState = await ref.watch(authNotifierProvider.future);
+    StreamProvider.autoDispose<List<UserList>>((ref) {
+  final authState = ref.watch(authNotifierProvider);
 
-  if (authState.status == AuthStatus.authenticated && authState.user != null) {
-    await for (final lists in ref
-        .watch(listManagerProvider)
-        .watchAuthenticatedUserLists(authState.user!.id)) {
-      yield lists;
-    }
-  } else {
-    yield [];
-  }
+  return authState.when(
+    data: (state) {
+      if (state.status != AuthStatus.authenticated || state.user == null) {
+        return Stream.value([]);
+      }
+
+      return ref
+          .watch(listManagerProvider)
+          .watchAuthenticatedUserLists(state.user!.id);
+    },
+    loading: () => Stream.value([]),
+    error: (_, __) => Stream.value([]),
+  );
 });
 
 /// 認証済みユーザーのグループを監視するStreamプロバイダー
 ///
 /// 認証状態に基づいて適切にグループを提供します。
 /// Application層のビジネスロジックに依存しません。
-final userGroupsStreamProvider =
-    StreamProvider.autoDispose<List<Group>>((ref) async* {
-  final authState = await ref.watch(authNotifierProvider.future);
+final userGroupsStreamProvider = StreamProvider.autoDispose<List<Group>>((ref) {
+  final authState = ref.watch(authNotifierProvider);
 
-  if (authState.status == AuthStatus.authenticated && authState.user != null) {
-    await for (final groups in ref
-        .watch(groupManagerProvider)
-        .watchUserGroups(authState.user!.id)) {
-      yield groups;
-    }
-  } else {
-    yield [];
-  }
+  return authState.when(
+    data: (state) {
+      if (state.status != AuthStatus.authenticated || state.user == null) {
+        return Stream.value([]);
+      }
+
+      return ref.watch(groupManagerProvider).watchUserGroups(state.user!.id);
+    },
+    loading: () => Stream.value([]),
+    error: (_, __) => Stream.value([]),
+  );
 });
 
 /// 統合されたユーザー情報をリアルタイムで監視するStreamプロバイダー
@@ -161,7 +182,19 @@ final userGroupsStreamProvider =
 /// UserManagerを使用して統合されたユーザー情報を提供します。
 final userStreamProvider =
     StreamProvider.family<UserModel?, String>((ref, userId) {
-  return ref.watch(userManagerProvider).watchIntegratedUser(userId);
+  final authState = ref.watch(authNotifierProvider);
+
+  return authState.when(
+    data: (state) {
+      if (state.status != AuthStatus.authenticated || state.user == null) {
+        return Stream.value(null);
+      }
+
+      return ref.watch(userManagerProvider).watchIntegratedUser(userId);
+    },
+    loading: () => Stream.value(null),
+    error: (_, __) => Stream.value(null),
+  );
 });
 
 /// 特定のリストをリアルタイムで監視するStreamプロバイダー
@@ -169,25 +202,41 @@ final userStreamProvider =
 /// [listId] 監視対象のリストID
 final listStreamProvider =
     StreamProvider.family<UserList?, String>((ref, listId) {
-  return ref.watch(listManagerProvider).watchList(listId);
+  final authState = ref.watch(authNotifierProvider);
+
+  return authState.when(
+    data: (state) {
+      if (state.status != AuthStatus.authenticated || state.user == null) {
+        return Stream.value(null);
+      }
+
+      return ref.watch(listManagerProvider).watchList(listId);
+    },
+    loading: () => Stream.value(null),
+    error: (_, __) => Stream.value(null),
+  );
 });
 
 /// 認証済みユーザーのフレンド一覧を監視するStreamプロバイダー
 ///
 /// UserManagerを使用してフレンド情報を提供します。
 final userFriendsStreamProvider =
-    StreamProvider.autoDispose<List<PublicUserModel>>((ref) async* {
-  final authState = await ref.watch(authNotifierProvider.future);
+    StreamProvider.autoDispose<List<PublicUserModel>>((ref) {
+  final authState = ref.watch(authNotifierProvider);
 
-  if (authState.status == AuthStatus.authenticated && authState.user != null) {
-    await for (final friends in ref
-        .watch(userManagerProvider)
-        .watchAuthenticatedUserFriends(authState.user!.id)) {
-      yield friends;
-    }
-  } else {
-    yield [];
-  }
+  return authState.when(
+    data: (state) {
+      if (state.status != AuthStatus.authenticated || state.user == null) {
+        return Stream.value([]);
+      }
+
+      return ref
+          .watch(userManagerProvider)
+          .watchAuthenticatedUserFriends(state.user!.id);
+    },
+    loading: () => Stream.value([]),
+    error: (_, __) => Stream.value([]),
+  );
 });
 
 /// 認証済みユーザーのフレンド一覧を取得するFutureプロバイダー
@@ -209,10 +258,21 @@ final userFriendsProvider =
 ///
 /// [userId] 監視対象のユーザーID
 final userSchedulesStreamProvider =
-    StreamProvider.family<List<Schedule>, String>(
-  (ref, userId) =>
-      ref.watch(scheduleRepositoryProvider).watchUserSchedules(userId),
-);
+    StreamProvider.family<List<Schedule>, String>((ref, userId) {
+  final authState = ref.watch(authNotifierProvider);
+
+  return authState.when(
+    data: (state) {
+      if (state.status != AuthStatus.authenticated || state.user == null) {
+        return Stream.value([]);
+      }
+
+      return ref.watch(scheduleRepositoryProvider).watchUserSchedules(userId);
+    },
+    loading: () => Stream.value([]),
+    error: (_, __) => Stream.value([]),
+  );
+});
 
 final reactionRepositoryProvider = Provider<ReactionRepository>((ref) {
   final firestore = FirebaseFirestore.instance;

--- a/lib/presentation/settings/edit_email_page.dart
+++ b/lib/presentation/settings/edit_email_page.dart
@@ -3,9 +3,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 
 class EditEmailPage extends ConsumerStatefulWidget {
-  static const String path = 'email';
-
   const EditEmailPage({super.key});
+  static const String path = 'email';
 
   @override
   ConsumerState<EditEmailPage> createState() => _EditEmailPageState();

--- a/lib/presentation/settings/edit_name_page.dart
+++ b/lib/presentation/settings/edit_name_page.dart
@@ -3,9 +3,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../my_page/my_page_view_model.dart';
 
 class EditNamePage extends ConsumerStatefulWidget {
-  static const String path = 'name';
-
   const EditNamePage({super.key});
+  static const String path = 'name';
 
   @override
   ConsumerState<EditNamePage> createState() => _EditNamePageState();

--- a/lib/presentation/settings/edit_search_id_page.dart
+++ b/lib/presentation/settings/edit_search_id_page.dart
@@ -5,9 +5,8 @@ import '../../domain/value/user_id.dart';
 import '../my_page/my_page_view_model.dart';
 
 class EditSearchIdPage extends ConsumerStatefulWidget {
-  static const String path = 'search-id';
-
   const EditSearchIdPage({super.key});
+  static const String path = 'search-id';
 
   @override
   ConsumerState<EditSearchIdPage> createState() => _EditSearchIdPageState();

--- a/lib/presentation/settings/legal_info_page.dart
+++ b/lib/presentation/settings/legal_info_page.dart
@@ -5,17 +5,17 @@ import '../../utils/logger.dart';
 
 /// 法的情報（プライバシーポリシーや利用規約）を表示するページ
 class LegalInfoPage extends StatefulWidget {
-  /// 表示するページのタイトル
-  final String title;
-
-  /// 表示するURLパス
-  final String urlPath;
-
   const LegalInfoPage({
     super.key,
     required this.title,
     required this.urlPath,
   });
+
+  /// 表示するページのタイトル
+  final String title;
+
+  /// 表示するURLパス
+  final String urlPath;
 
   @override
   State<LegalInfoPage> createState() => _LegalInfoPageState();

--- a/lib/presentation/settings/legal_info_page_alternative.dart
+++ b/lib/presentation/settings/legal_info_page_alternative.dart
@@ -6,6 +6,12 @@ import '../../utils/logger.dart';
 /// 法的情報（プライバシーポリシーや利用規約）を表示するための代替ページ
 /// WebViewの代わりにURLランチャーを使用して外部ブラウザで表示します
 class LegalInfoPageAlternative extends StatelessWidget {
+  const LegalInfoPageAlternative({
+    super.key,
+    required this.title,
+    required this.urlPath,
+  });
+
   /// プライバシーポリシーのパス
   static const String privacyPolicyPath = 'privacy-policy';
 
@@ -17,12 +23,6 @@ class LegalInfoPageAlternative extends StatelessWidget {
 
   /// 表示するURLパス
   final String urlPath;
-
-  const LegalInfoPageAlternative({
-    super.key,
-    required this.title,
-    required this.urlPath,
-  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/presentation/settings/settings_page.dart
+++ b/lib/presentation/settings/settings_page.dart
@@ -7,7 +7,6 @@ import '../../utils/logger.dart';
 import 'edit_name_page.dart';
 import 'edit_email_page.dart';
 import 'edit_search_id_page.dart';
-import '../login/login_page.dart';
 import 'account_deletion_webview_page.dart';
 
 class SettingsPage extends ConsumerWidget {
@@ -143,6 +142,8 @@ class SettingsPage extends ConsumerWidget {
               );
 
               if (confirmed == true && context.mounted) {
+                final navigator = Navigator.of(context, rootNavigator: true);
+
                 // ローディングインジケータを表示
                 showDialog(
                   context: context,
@@ -161,22 +162,7 @@ class SettingsPage extends ConsumerWidget {
 
                 try {
                   await ref.read(authNotifierProvider.notifier).signOut();
-
-                  // ローディングインジケータを閉じる
-                  if (context.mounted) {
-                    Navigator.of(context).pop();
-                  }
-
-                  // ログイン画面へ遷移
-                  if (context.mounted) {
-                    context.go(LoginPage.path);
-                  }
                 } catch (e) {
-                  // ローディングインジケータを閉じる
-                  if (context.mounted) {
-                    Navigator.of(context).pop();
-                  }
-
                   if (context.mounted) {
                     // エラーの種類に応じて適切なメッセージを表示
                     String errorMessage = 'ログアウトに失敗しました';
@@ -190,6 +176,12 @@ class SettingsPage extends ConsumerWidget {
                       SnackBar(content: Text(errorMessage)),
                     );
                   }
+                } finally {
+                  WidgetsBinding.instance.addPostFrameCallback((_) {
+                    if (navigator.mounted && navigator.canPop()) {
+                      navigator.pop();
+                    }
+                  });
                 }
               }
             },
@@ -318,7 +310,7 @@ class SettingsPage extends ConsumerWidget {
 
                     // ログイン画面に遷移
                     if (context.mounted) {
-                      context.go(LoginPage.path);
+                      context.go('/login');
                     }
                   } catch (e) {
                     // 進捗ダイアログを閉じる

--- a/lib/presentation/signup/signup.dart
+++ b/lib/presentation/signup/signup.dart
@@ -2,11 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../presentation_provider.dart';
+import '../../utils/logger.dart';
 
 class SignupPage extends ConsumerStatefulWidget {
-  static const String path = '/signup';
-
   const SignupPage({super.key});
+  static const String path = '/signup';
 
   @override
   ConsumerState<SignupPage> createState() => _SignupPageState();
@@ -30,6 +30,7 @@ class _SignupPageState extends ConsumerState<SignupPage> {
   Future<void> _handleSignup() async {
     if (_isLoading) return;
 
+    AppLogger.debugOnly('SignupPage._handleSignup開始');
     setState(() {
       _isLoading = true;
     });
@@ -43,9 +44,16 @@ class _SignupPageState extends ConsumerState<SignupPage> {
                 ? _displayNameController.text
                 : null,
           );
-      // AuthNotifier経由で認証状態が更新されるため、
-      // GoRouterのリダイレクト処理により自動的にホーム画面に遷移する
+      final authState = ref.read(authNotifierProvider);
+      AppLogger.debugOnly('SignupPage._handleSignup後 state=$authState');
+      if (mounted && authState.hasError) {
+        final error = authState.error;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('サインアップに失敗しました: ${error.toString()}')),
+        );
+      }
     } catch (e) {
+      AppLogger.errorOnly('SignupPage._handleSignup例外', e);
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text('サインアップに失敗しました: ${e.toString()}')),

--- a/lib/presentation/splash/splash_screen.dart
+++ b/lib/presentation/splash/splash_screen.dart
@@ -7,9 +7,8 @@ import '../bottom_navigation/bottom_navigation.dart';
 import '../login/login_page.dart';
 
 class SplashScreen extends ConsumerStatefulWidget {
-  static const String path = '/splash';
-
   const SplashScreen({super.key});
+  static const String path = '/splash';
 
   @override
   ConsumerState<SplashScreen> createState() => _SplashScreenState();

--- a/lib/presentation/widgets/auth_dependent_builder.dart
+++ b/lib/presentation/widgets/auth_dependent_builder.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../application/auth/auth_state.dart';
+import '../presentation_provider.dart';
+
+/// 認証済みの場合のみ [onAuthenticated] を表示する。
+/// 認証済み subtree は userId をキーに再生成されるため、
+/// ユーザー切り替え時に前ユーザーの widget state を残しにくい。
+class AuthDependentBuilder extends ConsumerWidget {
+  const AuthDependentBuilder({
+    super.key,
+    required this.onAuthenticated,
+    this.onUnauthenticated,
+    this.onLoading,
+  });
+
+  final Widget Function(String userId) onAuthenticated;
+  final WidgetBuilder? onUnauthenticated;
+  final WidgetBuilder? onLoading;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final authState = ref.watch(authNotifierProvider);
+
+    return authState.when(
+      data: (state) {
+        if (state.status == AuthStatus.authenticated && state.user != null) {
+          return ProviderScope(
+            key: ValueKey(state.user!.id),
+            child: KeyedSubtree(
+              key: ValueKey('auth-subtree-${state.user!.id}'),
+              child: onAuthenticated(state.user!.id),
+            ),
+          );
+        }
+
+        if (onUnauthenticated != null) {
+          return onUnauthenticated!(context);
+        }
+
+        return const SizedBox.shrink();
+      },
+      loading: () {
+        if (onLoading != null) {
+          return onLoading!(context);
+        }
+
+        return const Center(child: CircularProgressIndicator());
+      },
+      error: (_, __) {
+        if (onUnauthenticated != null) {
+          return onUnauthenticated!(context);
+        }
+
+        return const SizedBox.shrink();
+      },
+    );
+  }
+}

--- a/lib/presentation/widgets/banner_ad_widget.dart
+++ b/lib/presentation/widgets/banner_ad_widget.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
@@ -15,16 +17,19 @@ final bannerAdProvider =
 });
 
 class BannerAdWidget extends ConsumerWidget {
-  // 一意のIDを追加
-  final String uniqueId;
-
   const BannerAdWidget({
     super.key,
     required this.uniqueId,
   });
+  // 一意のIDを追加
+  final String uniqueId;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    if (!Platform.isAndroid && !Platform.isIOS) {
+      return const SizedBox.shrink();
+    }
+
     // 一意のIDを使用して独自のBannerAdを取得
     final bannerAd = ref.watch(bannerAdProvider(uniqueId));
 

--- a/lib/presentation/widgets/error_widget.dart
+++ b/lib/presentation/widgets/error_widget.dart
@@ -4,16 +4,15 @@ import 'package:lakiite/application/auth/auth_state.dart';
 import 'package:lakiite/presentation/presentation_provider.dart';
 
 class ScheduleErrorWidget extends StatelessWidget {
-  final Object error;
-  final AuthState state;
-  final WidgetRef ref;
-
   const ScheduleErrorWidget({
     super.key,
     required this.error,
     required this.state,
     required this.ref,
   });
+  final Object error;
+  final AuthState state;
+  final WidgetRef ref;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/presentation/widgets/notification_badge.dart
+++ b/lib/presentation/widgets/notification_badge.dart
@@ -16,14 +16,6 @@ typedef NotificationType = domain.NotificationType;
 /// [fontSize] バッジ内のテキストサイズ
 /// [padding] バッジ内のパディング
 class NotificationBadge extends ConsumerWidget {
-  final Widget child;
-  final NotificationType? type;
-  final Color badgeColor;
-  final Color textColor;
-  final double badgeSize;
-  final double fontSize;
-  final EdgeInsets padding;
-
   const NotificationBadge({
     super.key,
     required this.child,
@@ -34,6 +26,13 @@ class NotificationBadge extends ConsumerWidget {
     this.fontSize = 10,
     this.padding = const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
   });
+  final Widget child;
+  final NotificationType? type;
+  final Color badgeColor;
+  final Color textColor;
+  final double badgeSize;
+  final double fontSize;
+  final EdgeInsets padding;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -109,12 +108,11 @@ class NotificationBadge extends ConsumerWidget {
 ///
 /// [child] バッジを表示する対象のウィジェット
 class FriendRequestBadge extends ConsumerWidget {
-  final Widget child;
-
   const FriendRequestBadge({
     super.key,
     required this.child,
   });
+  final Widget child;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -129,12 +127,11 @@ class FriendRequestBadge extends ConsumerWidget {
 ///
 /// [child] バッジを表示する対象のウィジェット
 class GroupInvitationBadge extends ConsumerWidget {
-  final Widget child;
-
   const GroupInvitationBadge({
     super.key,
     required this.child,
   });
+  final Widget child;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/presentation/widgets/notification_button.dart
+++ b/lib/presentation/widgets/notification_button.dart
@@ -7,6 +7,13 @@ import './notification_badge.dart';
 /// 未読通知がある場合は赤いバッジを表示します。
 /// タップすると通知一覧画面に遷移します。
 class NotificationButton extends StatelessWidget {
+  const NotificationButton({
+    super.key,
+    this.rightPadding = 24.0,
+    this.iconColor,
+    this.iconSize = 24.0,
+  });
+
   /// 右側のパディング
   final double rightPadding;
 
@@ -15,13 +22,6 @@ class NotificationButton extends StatelessWidget {
 
   /// アイコンのサイズ
   final double iconSize;
-
-  const NotificationButton({
-    super.key,
-    this.rightPadding = 24.0,
-    this.iconColor,
-    this.iconSize = 24.0,
-  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/presentation/widgets/reaction_icon_widget.dart
+++ b/lib/presentation/widgets/reaction_icon_widget.dart
@@ -15,18 +15,6 @@ import 'package:lakiite/domain/entity/schedule_reaction.dart';
 ///
 /// また、`isLoading`パラメータがtrueの場合はローディングインジケータを表示します。
 class ReactionIconWidget extends StatelessWidget {
-  /// 「行きます！」リアクションの有無
-  final bool hasGoing;
-
-  /// 「考え中！」リアクションの有無
-  final bool hasThinking;
-
-  /// アイコンの表示サイズ
-  final double iconSize;
-
-  /// ローディング中かどうかのフラグ
-  final bool isLoading;
-
   /// コンストラクタ
   ///
   /// [hasGoing] 「行きます！」リアクションの有無
@@ -65,6 +53,18 @@ class ReactionIconWidget extends StatelessWidget {
       isLoading: isLoading,
     );
   }
+
+  /// 「行きます！」リアクションの有無
+  final bool hasGoing;
+
+  /// 「考え中！」リアクションの有無
+  final bool hasThinking;
+
+  /// アイコンの表示サイズ
+  final double iconSize;
+
+  /// ローディング中かどうかのフラグ
+  final bool isLoading;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/presentation/widgets/schedule_card.dart
+++ b/lib/presentation/widgets/schedule_card.dart
@@ -4,14 +4,13 @@ import '../../domain/entity/schedule.dart';
 import '../calendar/schedule_detail_page.dart';
 
 class ScheduleCard extends StatelessWidget {
-  final Schedule schedule;
-  final bool isOwner;
-
   const ScheduleCard({
     super.key,
     required this.schedule,
     required this.isOwner,
   });
+  final Schedule schedule;
+  final bool isOwner;
 
   String _formatDateTime(DateTime dateTime) {
     final formatter = DateFormat('HH:mm');

--- a/lib/presentation/widgets/schedule_tile.dart
+++ b/lib/presentation/widgets/schedule_tile.dart
@@ -17,6 +17,34 @@ import 'package:lakiite/presentation/widgets/reaction_icon_widget.dart';
 /// 予定の詳細情報（タイトル、説明、日時、場所、作成者）とリアクション・コメント情報を表示します。
 /// また、オプションで編集ボタンを表示したり、タイムラインビューでの特別なスタイルを適用できます。
 class ScheduleTile extends ConsumerWidget {
+  /// コンストラクタ
+  ///
+  /// [schedule] 表示する予定データ
+  /// [currentUserId] 現在のユーザーID
+  /// [showOwner] 作成者情報を表示するかどうか（デフォルト: true）
+  /// [showEditButton] 編集ボタンを表示するかどうか（デフォルト: false）
+  /// [showDeleteButton] 削除ボタンを表示するかどうか（デフォルト: false）
+  /// [isTimelineView] タイムラインビューとして表示するかどうか（デフォルト: false）
+  /// [showDivider] 区切り線を表示するかどうか（デフォルト: false）
+  /// [onEditPressed] 編集ボタンがタップされた時のコールバック
+  /// [onDeletePressed] 削除ボタンがタップされた時のコールバック
+  /// [onReactionTap] リアクション部分がタップされた時のコールバック
+  /// [margin] カードのマージン
+  const ScheduleTile({
+    super.key,
+    required this.schedule,
+    required this.currentUserId,
+    this.showOwner = true,
+    this.showEditButton = false,
+    this.showDeleteButton = false,
+    this.isTimelineView = false,
+    this.showDivider = false,
+    this.onEditPressed,
+    this.onDeletePressed,
+    this.onReactionTap,
+    this.margin,
+  });
+
   /// 表示する予定のデータ
   final Schedule schedule;
 
@@ -49,34 +77,6 @@ class ScheduleTile extends ConsumerWidget {
 
   /// カードのマージン
   final EdgeInsetsGeometry? margin;
-
-  /// コンストラクタ
-  ///
-  /// [schedule] 表示する予定データ
-  /// [currentUserId] 現在のユーザーID
-  /// [showOwner] 作成者情報を表示するかどうか（デフォルト: true）
-  /// [showEditButton] 編集ボタンを表示するかどうか（デフォルト: false）
-  /// [showDeleteButton] 削除ボタンを表示するかどうか（デフォルト: false）
-  /// [isTimelineView] タイムラインビューとして表示するかどうか（デフォルト: false）
-  /// [showDivider] 区切り線を表示するかどうか（デフォルト: false）
-  /// [onEditPressed] 編集ボタンがタップされた時のコールバック
-  /// [onDeletePressed] 削除ボタンがタップされた時のコールバック
-  /// [onReactionTap] リアクション部分がタップされた時のコールバック
-  /// [margin] カードのマージン
-  const ScheduleTile({
-    super.key,
-    required this.schedule,
-    required this.currentUserId,
-    this.showOwner = true,
-    this.showEditButton = false,
-    this.showDeleteButton = false,
-    this.isTimelineView = false,
-    this.showDivider = false,
-    this.onEditPressed,
-    this.onDeletePressed,
-    this.onReactionTap,
-    this.margin,
-  });
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/utils/logger.dart
+++ b/lib/utils/logger.dart
@@ -69,6 +69,35 @@ class AppLogger {
     }
   }
 
+  static void debugOnly(dynamic message) {
+    assert(() {
+      debug(message);
+      return true;
+    }());
+  }
+
+  static void infoOnly(dynamic message) {
+    assert(() {
+      info(message);
+      return true;
+    }());
+  }
+
+  static void warningOnly(dynamic message) {
+    assert(() {
+      warning(message);
+      return true;
+    }());
+  }
+
+  static void errorOnly(dynamic message,
+      [dynamic errorObject, StackTrace? stackTrace]) {
+    assert(() {
+      error(message, errorObject, stackTrace);
+      return true;
+    }());
+  }
+
   static void info(dynamic message) {
     // テスト環境ではinfoログを出力しない
     if (_isTestEnvironment) return;

--- a/mock/providers/test_providers.dart
+++ b/mock/providers/test_providers.dart
@@ -1,15 +1,26 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lakiite/application/notification/notification_notifier.dart'
+    as notification;
 import 'package:lakiite/domain/entity/user.dart';
+import 'package:lakiite/infrastructure/providers.dart';
 import 'package:lakiite/presentation/presentation_provider.dart';
 import '../repositories/mock_auth_repository.dart';
+import '../repositories/mock_list_repository.dart';
+import '../repositories/mock_notification_repository.dart';
 import '../repositories/mock_schedule_repository.dart';
 import '../repositories/mock_user_repository.dart';
+import '../services/mock_image_processor_service.dart';
+import '../services/mock_storage_service.dart';
 
 /// 統合テスト用のプロバイダー設定クラス
 class TestProviders {
   static MockAuthRepository? _mockAuthRepository;
+  static MockListRepository? _mockListRepository;
+  static MockNotificationRepository? _mockNotificationRepository;
   static MockScheduleRepository? _mockScheduleRepository;
   static MockUserRepository? _mockUserRepository;
+  static MockStorageService? _mockStorageService;
+  static MockImageProcessorService? _mockImageProcessorService;
 
   /// モックリポジトリーの取得
   static MockAuthRepository get mockAuthRepository {
@@ -22,36 +33,70 @@ class TestProviders {
     return _mockScheduleRepository!;
   }
 
+  static MockListRepository get mockListRepository {
+    _mockListRepository ??= MockListRepository();
+    return _mockListRepository!;
+  }
+
+  static MockNotificationRepository get mockNotificationRepository {
+    _mockNotificationRepository ??= MockNotificationRepository();
+    return _mockNotificationRepository!;
+  }
+
   static MockUserRepository get mockUserRepository {
     _mockUserRepository ??= MockUserRepository();
     return _mockUserRepository!;
   }
 
+  static MockStorageService get mockStorageService {
+    _mockStorageService ??= MockStorageService();
+    return _mockStorageService!;
+  }
+
+  static MockImageProcessorService get mockImageProcessorService {
+    _mockImageProcessorService ??= MockImageProcessorService();
+    return _mockImageProcessorService!;
+  }
+
+  static List<Override> _baseOverrides({String? currentUserId}) {
+    return [
+      authRepositoryProvider.overrideWithValue(mockAuthRepository),
+      userRepositoryProvider.overrideWithValue(mockUserRepository),
+      scheduleRepositoryProvider.overrideWithValue(mockScheduleRepository),
+      listRepositoryProvider.overrideWithValue(mockListRepository),
+      notification.notificationRepositoryProvider
+          .overrideWithValue(mockNotificationRepository),
+      storageServiceProvider.overrideWithValue(mockStorageService),
+      imageProcessorServiceProvider
+          .overrideWithValue(mockImageProcessorService),
+      if (currentUserId != null)
+        notification.currentUserIdProvider.overrideWithValue(currentUserId),
+    ];
+  }
+
   /// プロバイダーをリセット
   static void reset() {
     _mockAuthRepository = null;
+    _mockListRepository = null;
+    _mockNotificationRepository = null;
     _mockScheduleRepository = null;
     _mockUserRepository = null;
+    _mockStorageService = null;
+    _mockImageProcessorService = null;
   }
 
   /// 新規登録フォーム用のプロバイダーオーバーライド
   static List<Override> get forSignupForm {
     // 未認証状態でスタート
     mockAuthRepository.setUser(null);
-    return [
-      authRepositoryProvider.overrideWithValue(mockAuthRepository),
-      userRepositoryProvider.overrideWithValue(mockUserRepository),
-    ];
+    return _baseOverrides();
   }
 
   /// ログインフォーム用のプロバイダーオーバーライド
   static List<Override> get forLoginForm {
     // 未認証状態でスタート
     mockAuthRepository.setUser(null);
-    return [
-      authRepositoryProvider.overrideWithValue(mockAuthRepository),
-      userRepositoryProvider.overrideWithValue(mockUserRepository),
-    ];
+    return _baseOverrides();
   }
 
   /// 認証済み状態用のプロバイダーオーバーライド
@@ -67,10 +112,7 @@ class TestProviders {
     mockAuthRepository.setUser(testUser);
     mockUserRepository.addTestUser(testUser);
 
-    return [
-      authRepositoryProvider.overrideWithValue(mockAuthRepository),
-      userRepositoryProvider.overrideWithValue(mockUserRepository),
-    ];
+    return _baseOverrides(currentUserId: testUser.id);
   }
 
   /// スケジュール作成用のプロバイダーオーバーライド
@@ -86,10 +128,6 @@ class TestProviders {
     mockUserRepository.addTestUser(testUser);
     mockScheduleRepository.setupSampleSchedules();
 
-    return [
-      authRepositoryProvider.overrideWithValue(mockAuthRepository),
-      userRepositoryProvider.overrideWithValue(mockUserRepository),
-      scheduleRepositoryProvider.overrideWithValue(mockScheduleRepository),
-    ];
+    return _baseOverrides(currentUserId: testUser.id);
   }
 }

--- a/mock/repositories/mock_auth_repository.dart
+++ b/mock/repositories/mock_auth_repository.dart
@@ -97,25 +97,21 @@ class MockAuthRepository implements IAuthRepository {
     return true;
   }
 
-  @override
   Future<void> updateEmail(String newEmail) async {
     await Future.delayed(const Duration(milliseconds: 200));
     // テスト用の実装
   }
 
-  @override
   Future<void> updatePassword(String newPassword) async {
     await Future.delayed(const Duration(milliseconds: 200));
     // テスト用の実装
   }
 
-  @override
   Future<void> sendPasswordResetEmail(String email) async {
     await Future.delayed(const Duration(milliseconds: 200));
     // テスト用の実装
   }
 
-  @override
   Future<void> resetPassword(String newPassword, String actionCode) async {
     await Future.delayed(const Duration(milliseconds: 200));
     // テスト用の実装

--- a/mock/repositories/mock_list_repository.dart
+++ b/mock/repositories/mock_list_repository.dart
@@ -1,0 +1,79 @@
+import 'package:lakiite/domain/entity/list.dart';
+import 'package:lakiite/domain/interfaces/i_list_repository.dart';
+
+class MockListRepository implements IListRepository {
+  final List<UserList> _lists = [];
+
+  void addTestList(UserList list) {
+    _lists.add(list);
+  }
+
+  void reset() {
+    _lists.clear();
+  }
+
+  @override
+  Future<void> addMember(String listId, String userId) async {}
+
+  @override
+  Future<UserList> createList({
+    required String listName,
+    required List<String> memberIds,
+    required String ownerId,
+    String? iconUrl,
+    String? description,
+  }) async {
+    final list = UserList(
+      id: 'list-${_lists.length + 1}',
+      listName: listName,
+      memberIds: memberIds,
+      ownerId: ownerId,
+      iconUrl: iconUrl,
+      description: description,
+      createdAt: DateTime.now(),
+    );
+    _lists.add(list);
+    return list;
+  }
+
+  @override
+  Future<void> deleteList(String listId) async {
+    _lists.removeWhere((list) => list.id == listId);
+  }
+
+  @override
+  Future<UserList?> getList(String listId) async {
+    for (final list in _lists) {
+      if (list.id == listId) {
+        return list;
+      }
+    }
+    return null;
+  }
+
+  @override
+  Future<List<UserList>> getLists(String ownerId) async {
+    return _lists.where((list) => list.ownerId == ownerId).toList();
+  }
+
+  @override
+  Future<void> removeMember(String listId, String userId) async {}
+
+  @override
+  Future<void> updateList(UserList list) async {
+    final index = _lists.indexWhere((item) => item.id == list.id);
+    if (index >= 0) {
+      _lists[index] = list;
+    }
+  }
+
+  @override
+  Stream<UserList?> watchList(String listId) async* {
+    yield await getList(listId);
+  }
+
+  @override
+  Stream<List<UserList>> watchUserLists(String ownerId) async* {
+    yield await getLists(ownerId);
+  }
+}

--- a/mock/repositories/mock_notification_repository.dart
+++ b/mock/repositories/mock_notification_repository.dart
@@ -1,0 +1,101 @@
+import 'package:lakiite/domain/entity/notification.dart';
+import 'package:lakiite/domain/interfaces/i_notification_repository.dart';
+
+class MockNotificationRepository implements INotificationRepository {
+  final List<Notification> _notifications = [];
+
+  void addTestNotification(Notification notification) {
+    _notifications.add(notification);
+  }
+
+  void reset() {
+    _notifications.clear();
+  }
+
+  @override
+  Future<void> acceptNotification(String notificationId) async {}
+
+  @override
+  Future<void> createNotification(Notification notification) async {
+    _notifications.add(notification);
+  }
+
+  @override
+  Future<Notification?> getNotification(String notificationId) async {
+    for (final notification in _notifications) {
+      if (notification.id == notificationId) {
+        return notification;
+      }
+    }
+    return null;
+  }
+
+  @override
+  Future<bool> hasPendingFriendRequest(String fromUserId, String toUserId) async {
+    return false;
+  }
+
+  @override
+  Future<bool> hasPendingGroupInvitation(
+    String fromUserId,
+    String toUserId,
+    String groupId,
+  ) async {
+    return false;
+  }
+
+  @override
+  Future<void> markAsRead(String notificationId) async {}
+
+  @override
+  Future<void> rejectNotification(String notificationId) async {}
+
+  @override
+  Future<void> updateNotification(Notification notification) async {}
+
+  @override
+  Stream<List<Notification>> watchReceivedNotifications(String userId) async* {
+    yield _notifications.where((n) => n.receiveUserId == userId).toList();
+  }
+
+  @override
+  Stream<List<Notification>> watchReceivedNotificationsByType(
+    String userId,
+    NotificationType type,
+  ) async* {
+    yield _notifications
+        .where((n) => n.receiveUserId == userId && n.type == type)
+        .toList();
+  }
+
+  @override
+  Stream<List<Notification>> watchSentNotifications(String userId) async* {
+    yield _notifications.where((n) => n.sendUserId == userId).toList();
+  }
+
+  @override
+  Stream<List<Notification>> watchSentNotificationsByType(
+    String userId,
+    NotificationType type,
+  ) async* {
+    yield _notifications
+        .where((n) => n.sendUserId == userId && n.type == type)
+        .toList();
+  }
+
+  @override
+  Stream<int> watchUnreadCount(String userId) async* {
+    yield _notifications
+        .where((n) => n.receiveUserId == userId && !n.isRead)
+        .length;
+  }
+
+  @override
+  Stream<int> watchUnreadCountByType(String userId, NotificationType type) async* {
+    yield _notifications
+        .where(
+          (n) => n.receiveUserId == userId && n.type == type && !n.isRead,
+        )
+        .length;
+  }
+}

--- a/mock/repositories/mock_notification_repository.dart
+++ b/mock/repositories/mock_notification_repository.dart
@@ -31,7 +31,8 @@ class MockNotificationRepository implements INotificationRepository {
   }
 
   @override
-  Future<bool> hasPendingFriendRequest(String fromUserId, String toUserId) async {
+  Future<bool> hasPendingFriendRequest(
+      String fromUserId, String toUserId) async {
     return false;
   }
 
@@ -91,7 +92,8 @@ class MockNotificationRepository implements INotificationRepository {
   }
 
   @override
-  Stream<int> watchUnreadCountByType(String userId, NotificationType type) async* {
+  Stream<int> watchUnreadCountByType(
+      String userId, NotificationType type) async* {
     yield _notifications
         .where(
           (n) => n.receiveUserId == userId && n.type == type && !n.isRead,

--- a/mock/repositories/mock_schedule_repository.dart
+++ b/mock/repositories/mock_schedule_repository.dart
@@ -146,6 +146,7 @@ class MockScheduleRepository implements IScheduleRepository {
     yield _schedules.where((schedule) => schedule.ownerId == userId).toList();
   }
 
+  @override
   Stream<Schedule?> watchSchedule(String scheduleId) async* {
     final schedule = _schedules.firstWhere(
       (s) => s.id == scheduleId,
@@ -154,7 +155,6 @@ class MockScheduleRepository implements IScheduleRepository {
     yield schedule;
   }
 
-  @override
   Future<List<Schedule>> getSchedulesByDateRange(
     String userId,
     DateTime startDate,
@@ -169,7 +169,6 @@ class MockScheduleRepository implements IScheduleRepository {
         .toList();
   }
 
-  @override
   Future<List<Schedule>> getSchedulesByDate(
       String userId, DateTime date) async {
     await Future.delayed(const Duration(milliseconds: 200));

--- a/mock/services/mock_image_processor_service.dart
+++ b/mock/services/mock_image_processor_service.dart
@@ -1,0 +1,29 @@
+import 'dart:io';
+
+import 'package:lakiite/domain/interfaces/i_image_processor_service.dart';
+
+class MockImageProcessorService implements IImageProcessorService {
+  @override
+  Future<File> compressImage(
+    File imageFile, {
+    int minWidth = 1920,
+    int minHeight = 1080,
+    int quality = 95,
+  }) async {
+    return imageFile;
+  }
+
+  @override
+  Future<Directory> createTempDirectory() async {
+    return Directory.systemTemp.createTemp('mock-image-processor');
+  }
+
+  @override
+  Future<File> createTempFile(List<int> data, String extension) async {
+    final file = File(
+      '${Directory.systemTemp.path}/mock_image_processor.$extension',
+    );
+    await file.writeAsBytes(data);
+    return file;
+  }
+}

--- a/mock/services/mock_storage_service.dart
+++ b/mock/services/mock_storage_service.dart
@@ -1,0 +1,15 @@
+import 'dart:io';
+
+import 'package:lakiite/domain/interfaces/i_storage_service.dart';
+
+class MockStorageService implements IStorageService {
+  @override
+  Future<String> uploadFile({
+    required String path,
+    required File file,
+    required Map<String, String> metadata,
+    String contentType = 'image/jpeg',
+  }) async {
+    return 'https://example.com/$path';
+  }
+}

--- a/test/application/auth/auth_notifier_test.dart
+++ b/test/application/auth/auth_notifier_test.dart
@@ -2,8 +2,23 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:lakiite/application/auth/auth_notifier.dart' as notifier;
 import 'package:lakiite/application/auth/auth_state.dart';
-import 'package:riverpod/riverpod.dart';
+import 'package:lakiite/domain/interfaces/i_schedule_repository.dart';
+import 'package:lakiite/domain/interfaces/i_user_repository.dart';
+import 'package:lakiite/presentation/presentation_provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../mock/repository/mock_auth_repository.dart';
+
+class _ThrowingUserRepository implements IUserRepository {
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw StateError('userRepositoryProvider should not be read');
+}
+
+class _ThrowingScheduleRepository implements IScheduleRepository {
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw StateError('scheduleRepositoryProvider should not be read');
+}
 
 /// テスト用のプロバイダーコンテナーを作成する関数
 ProviderContainer createTestProviderContainer({
@@ -236,6 +251,72 @@ void main() {
         // 認証状態の確認でエラーが発生しても、主要な機能（削除）は成功している
         print('認証状態確認でエラー（無視）: $e');
       }
+    });
+
+    test('アカウント削除は repository 参照なしでも成功する', () async {
+      final isolatedContainer = createTestProviderContainer(
+        overrides: [
+          notifier.authRepositoryProvider.overrideWithValue(mockAuthRepository),
+          notifier.authStateStreamProvider.overrideWith((ref) {
+            return mockAuthRepository.authStateChanges().map((user) {
+              if (user != null) {
+                return AuthState.authenticated(user);
+              }
+              return AuthState.unauthenticated();
+            });
+          }),
+          userRepositoryProvider.overrideWithValue(_ThrowingUserRepository()),
+          scheduleRepositoryProvider
+              .overrideWithValue(_ThrowingScheduleRepository()),
+        ],
+      );
+
+      final testUser = MockAuthRepository.createTestUser(
+        name: 'テストユーザー',
+        displayName: 'テスト表示名',
+      );
+      mockAuthRepository.setCurrentUser(testUser);
+
+      final authNotifier =
+          isolatedContainer.read(notifier.authNotifierProvider.notifier);
+
+      final result = await authNotifier.deleteAccount();
+      expect(result, isTrue);
+
+      isolatedContainer.dispose();
+    });
+
+    test('再認証付きアカウント削除は repository 参照なしでも成功する', () async {
+      final isolatedContainer = createTestProviderContainer(
+        overrides: [
+          notifier.authRepositoryProvider.overrideWithValue(mockAuthRepository),
+          notifier.authStateStreamProvider.overrideWith((ref) {
+            return mockAuthRepository.authStateChanges().map((user) {
+              if (user != null) {
+                return AuthState.authenticated(user);
+              }
+              return AuthState.unauthenticated();
+            });
+          }),
+          userRepositoryProvider.overrideWithValue(_ThrowingUserRepository()),
+          scheduleRepositoryProvider
+              .overrideWithValue(_ThrowingScheduleRepository()),
+        ],
+      );
+
+      final testUser = MockAuthRepository.createTestUser(
+        name: 'テストユーザー',
+        displayName: 'テスト表示名',
+      );
+      mockAuthRepository.setCurrentUser(testUser);
+
+      final authNotifier =
+          isolatedContainer.read(notifier.authNotifierProvider.notifier);
+
+      final result = await authNotifier.deleteAccountWithReauth('password123');
+      expect(result, isTrue);
+
+      isolatedContainer.dispose();
     });
   });
 }

--- a/test/application/list/list_notifier_test.dart
+++ b/test/application/list/list_notifier_test.dart
@@ -1,0 +1,115 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:lakiite/application/list/list_state.dart';
+import 'package:lakiite/domain/entity/list.dart';
+import 'package:lakiite/domain/entity/user.dart';
+import 'package:lakiite/domain/interfaces/i_list_repository.dart';
+import 'package:lakiite/presentation/presentation_provider.dart';
+
+import '../../../mock/repositories/mock_auth_repository.dart';
+import '../../../mock/repositories/mock_user_repository.dart';
+
+class _TrackingListRepository implements IListRepository {
+  _TrackingListRepository() {
+    _listsController.onCancel = () {
+      cancelCount++;
+    };
+  }
+
+  final _listsController = StreamController<List<UserList>>.broadcast();
+  int cancelCount = 0;
+
+  @override
+  Stream<List<UserList>> watchUserLists(String ownerId) => _listsController.stream;
+
+  @override
+  Stream<UserList?> watchList(String listId) => const Stream<UserList?>.empty();
+
+  @override
+  Future<void> addMember(String listId, String userId) =>
+      Future.error(UnimplementedError());
+
+  @override
+  Future<UserList> createList({
+    required String listName,
+    required List<String> memberIds,
+    required String ownerId,
+    String? iconUrl,
+    String? description,
+  }) =>
+      Future.error(UnimplementedError());
+
+  @override
+  Future<void> deleteList(String listId) => Future.error(UnimplementedError());
+
+  @override
+  Future<UserList?> getList(String listId) => Future.error(UnimplementedError());
+
+  @override
+  Future<List<UserList>> getLists(String ownerId) =>
+      Future.error(UnimplementedError());
+
+  @override
+  Future<void> removeMember(String listId, String userId) =>
+      Future.error(UnimplementedError());
+
+  @override
+  Future<void> updateList(UserList list) => Future.error(UnimplementedError());
+
+  void dispose() {
+    _listsController.close();
+  }
+}
+
+void main() {
+  group('ListNotifier', () {
+    late ProviderContainer container;
+    late MockAuthRepository mockAuthRepository;
+    late _TrackingListRepository listRepository;
+    late MockUserRepository mockUserRepository;
+
+    setUp(() {
+      mockAuthRepository = MockAuthRepository();
+      listRepository = _TrackingListRepository();
+      mockUserRepository = MockUserRepository();
+
+      final testUser = UserModel.create(
+        id: 'test-user-id',
+        name: 'テストユーザー',
+        displayName: 'テストユーザー',
+      );
+      mockUserRepository.addTestUser(testUser);
+      mockAuthRepository.setUser(testUser);
+
+      container = ProviderContainer(
+        overrides: [
+          authRepositoryProvider.overrideWithValue(mockAuthRepository),
+          listRepositoryProvider.overrideWithValue(listRepository),
+          userRepositoryProvider.overrideWithValue(mockUserRepository),
+        ],
+      );
+    });
+
+    tearDown(() {
+      listRepository.dispose();
+      mockAuthRepository.dispose();
+      container.dispose();
+    });
+
+    test('ログアウト時にリスト購読を解除して初期状態へ戻す', () async {
+      await container.read(authNotifierProvider.future);
+      await container
+          .read(listNotifierProvider.notifier)
+          .watchUserLists('test-user-id');
+
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      await mockAuthRepository.signOut();
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(listRepository.cancelCount, 1);
+      expect(container.read(listNotifierProvider).hasError, isFalse);
+    });
+  });
+}

--- a/test/application/list/list_notifier_test.dart
+++ b/test/application/list/list_notifier_test.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:lakiite/application/list/list_state.dart';
 import 'package:lakiite/domain/entity/list.dart';
 import 'package:lakiite/domain/entity/user.dart';
 import 'package:lakiite/domain/interfaces/i_list_repository.dart';
@@ -22,7 +21,8 @@ class _TrackingListRepository implements IListRepository {
   int cancelCount = 0;
 
   @override
-  Stream<List<UserList>> watchUserLists(String ownerId) => _listsController.stream;
+  Stream<List<UserList>> watchUserLists(String ownerId) =>
+      _listsController.stream;
 
   @override
   Stream<UserList?> watchList(String listId) => const Stream<UserList?>.empty();
@@ -45,7 +45,8 @@ class _TrackingListRepository implements IListRepository {
   Future<void> deleteList(String listId) => Future.error(UnimplementedError());
 
   @override
-  Future<UserList?> getList(String listId) => Future.error(UnimplementedError());
+  Future<UserList?> getList(String listId) =>
+      Future.error(UnimplementedError());
 
   @override
   Future<List<UserList>> getLists(String ownerId) =>

--- a/test/application/schedule/schedule_notifier_test.dart
+++ b/test/application/schedule/schedule_notifier_test.dart
@@ -1,0 +1,159 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:lakiite/application/schedule/schedule_state.dart';
+import 'package:lakiite/domain/entity/schedule.dart';
+import 'package:lakiite/domain/entity/user.dart';
+import 'package:lakiite/domain/interfaces/i_schedule_repository.dart';
+import 'package:lakiite/presentation/presentation_provider.dart';
+
+import '../../../mock/repositories/mock_auth_repository.dart';
+import '../../../mock/repositories/mock_user_repository.dart';
+
+class _TrackingScheduleRepository implements IScheduleRepository {
+  _TrackingScheduleRepository() {
+    _controller.onCancel = () {
+      cancelCount++;
+    };
+  }
+  final _controller = StreamController<List<Schedule>>.broadcast();
+  int cancelCount = 0;
+  int watchUserSchedulesCallCount = 0;
+  int watchUserSchedulesForMonthCallCount = 0;
+  Object? monthError;
+
+  @override
+  Stream<List<Schedule>> watchUserSchedules(String userId) {
+    watchUserSchedulesCallCount++;
+    return _controller.stream;
+  }
+
+  @override
+  Stream<List<Schedule>> watchUserSchedulesForMonth(
+      String userId, DateTime displayMonth) {
+    watchUserSchedulesForMonthCallCount++;
+    if (monthError != null) {
+      return Stream<List<Schedule>>.error(monthError!);
+    }
+    return _controller.stream;
+  }
+
+  @override
+  Stream<List<Schedule>> watchListSchedules(String listId) =>
+      _controller.stream;
+
+  @override
+  Stream<Schedule?> watchSchedule(String scheduleId) =>
+      const Stream<Schedule?>.empty();
+
+  @override
+  Future<Schedule> createSchedule(Schedule schedule) =>
+      Future.error(UnimplementedError());
+
+  @override
+  Future<void> deleteSchedule(String scheduleId) =>
+      Future.error(UnimplementedError());
+
+  @override
+  Future<List<Schedule>> getListSchedules(String listId) =>
+      Future.error(UnimplementedError());
+
+  @override
+  Future<List<Schedule>> getUserSchedules(String userId) =>
+      Future.error(UnimplementedError());
+
+  @override
+  Future<void> updateSchedule(Schedule schedule) =>
+      Future.error(UnimplementedError());
+
+  void dispose() {
+    _controller.close();
+  }
+}
+
+void main() {
+  group('ScheduleNotifier', () {
+    late ProviderContainer container;
+    late MockAuthRepository mockAuthRepository;
+    late MockUserRepository mockUserRepository;
+    late _TrackingScheduleRepository scheduleRepository;
+    ProviderSubscription<AsyncValue<ScheduleState>>? scheduleSubscription;
+
+    setUp(() {
+      mockAuthRepository = MockAuthRepository();
+      mockUserRepository = MockUserRepository();
+      scheduleRepository = _TrackingScheduleRepository();
+
+      final testUser = UserModel.create(
+        id: 'test-user-id',
+        name: 'テストユーザー',
+        displayName: 'テストユーザー',
+      );
+      mockUserRepository.addTestUser(testUser);
+      mockAuthRepository.setUser(testUser);
+
+      container = ProviderContainer(
+        overrides: [
+          authRepositoryProvider.overrideWithValue(mockAuthRepository),
+          userRepositoryProvider.overrideWithValue(mockUserRepository),
+          scheduleRepositoryProvider.overrideWithValue(scheduleRepository),
+        ],
+      );
+
+      scheduleSubscription = container.listen(
+        scheduleNotifierProvider,
+        (_, __) {},
+        fireImmediately: true,
+      );
+    });
+
+    tearDown(() {
+      scheduleSubscription?.close();
+      scheduleRepository.dispose();
+      mockAuthRepository.dispose();
+      container.dispose();
+    });
+
+    test('ログアウト時にスケジュール購読を解除して初期状態へ戻す', () async {
+      await Future<void>.delayed(const Duration(milliseconds: 450));
+      expect(scheduleRepository.cancelCount, 0);
+
+      await mockAuthRepository.signOut();
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      final scheduleState = container.read(scheduleNotifierProvider);
+      expect(scheduleRepository.cancelCount, 1);
+      expect(
+        scheduleState.value,
+        const ScheduleState.initial(),
+      );
+    });
+
+    test('認証直後にログアウトした場合は遅延後の購読開始を行わない', () async {
+      await mockAuthRepository.signOut();
+      await Future<void>.delayed(const Duration(milliseconds: 450));
+
+      expect(scheduleRepository.watchUserSchedulesCallCount, 0);
+      expect(container.read(scheduleNotifierProvider).value,
+          const ScheduleState.initial());
+    });
+
+    test('月別購読の permission-denied は初期状態へ戻して終了する', () async {
+      await Future<void>.delayed(const Duration(milliseconds: 450));
+      scheduleRepository.monthError = Exception(
+        '[cloud_firestore/permission-denied] The caller does not have permission to execute the specified operation.',
+      );
+
+      container
+          .read(scheduleNotifierProvider.notifier)
+          .watchUserSchedulesForMonth('test-user-id', DateTime(2026, 3, 1));
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(scheduleRepository.watchUserSchedulesForMonthCallCount,
+          greaterThanOrEqualTo(1));
+      expect(container.read(scheduleNotifierProvider).value,
+          const ScheduleState.initial());
+    });
+  });
+}

--- a/test/domain/service/schedule_manager_test.dart
+++ b/test/domain/service/schedule_manager_test.dart
@@ -117,22 +117,18 @@ class MockUserRepository implements IUserRepository {
     throw UnimplementedError();
   }
 
-  @override
   Future<List<UserModel>> getUsers(List<String> userIds) async {
     throw UnimplementedError();
   }
 
-  @override
   Future<List<UserModel>> searchUsersByName(String query) async {
     throw UnimplementedError();
   }
 
-  @override
   Future<UserModel?> getUserBySearchId(String searchId) async {
     throw UnimplementedError();
   }
 
-  @override
   Future<List<UserModel>> getFriends(String userId) async {
     throw UnimplementedError();
   }

--- a/test/infrastructure/auth_repository_test.dart
+++ b/test/infrastructure/auth_repository_test.dart
@@ -77,22 +77,18 @@ class MockUserRepository implements IUserRepository {
     throw UnimplementedError('テストでは使用しません');
   }
 
-  @override
   Future<List<domain.UserModel>> getUsers(List<String> userIds) async {
     throw UnimplementedError('テストでは使用しません');
   }
 
-  @override
   Future<List<domain.UserModel>> searchUsersByName(String query) async {
     throw UnimplementedError('テストでは使用しません');
   }
 
-  @override
   Future<domain.UserModel?> getUserBySearchId(String searchId) async {
     throw UnimplementedError('テストでは使用しません');
   }
 
-  @override
   Future<List<domain.UserModel>> getFriends(String userId) async {
     throw UnimplementedError('テストでは使用しません');
   }

--- a/test/mock/providers/test_providers.dart
+++ b/test/mock/providers/test_providers.dart
@@ -1,19 +1,13 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:lakiite/presentation/presentation_provider.dart';
 import 'package:lakiite/domain/entity/list.dart';
 import 'package:lakiite/domain/entity/notification.dart';
-import 'package:lakiite/domain/interfaces/i_auth_repository.dart';
+import 'package:lakiite/presentation/presentation_provider.dart';
 import '../repository/mock_auth_repository.dart';
 import '../repository/mock_schedule_repository.dart';
 import '../repository/mock_list_repository.dart';
 import '../repository/mock_notification_repository.dart';
 import '../repository/mock_user_repository.dart';
 import '../base_mock.dart';
-
-// 認証リポジトリプロバイダー（presentation_providerに存在しない場合のため）
-final authRepositoryProvider = Provider<IAuthRepository>((ref) {
-  throw UnimplementedError('テスト環境では直接使用せず、オーバーライドしてください');
-});
 
 class TestProviders {
   static MockAuthRepository? _mockAuthRepository;

--- a/test/presentation/auth/auth_home_navigation_test.dart
+++ b/test/presentation/auth/auth_home_navigation_test.dart
@@ -1,0 +1,165 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/date_symbol_data_local.dart';
+import 'package:lakiite/config/admob_config.dart';
+import 'package:lakiite/config/app_config.dart';
+import 'package:lakiite/main.dart';
+
+import '../../../mock/providers/test_providers.dart';
+import '../../utils/test_utils.dart';
+
+void main() {
+  setUpAll(() async {
+    AppConfig.initialize(Environment.development);
+    AdMobConfig.initialize(forceTestMode: true);
+    await initializeDateFormatting('ja_JP', null);
+  });
+
+  setUp(() {
+    TestProviders.reset();
+  });
+
+  tearDown(() {
+    TestProviders.reset();
+  });
+
+  testWidgets('ログイン成功後にカレンダー初期画面へ遷移する', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: TestProviders.forLoginForm,
+        child: const MyApp(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.pump(const Duration(seconds: 2));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.descendant(
+        of: find.byType(AppBar),
+        matching: find.text('ログイン'),
+      ),
+      findsOneWidget,
+    );
+
+    await TestUtils.performLogin(tester: tester);
+    await tester.pump(const Duration(seconds: 3));
+    await tester.pump(const Duration(milliseconds: 300));
+
+    _expectCalendarInitialScreen();
+    await _drainAsyncWork(tester);
+  });
+
+  testWidgets('新規登録成功後にカレンダー初期画面へ遷移する', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: TestProviders.forSignupForm,
+        child: const MyApp(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.pump(const Duration(seconds: 2));
+    await tester.pumpAndSettle();
+
+    final signupLink = find.text('アカウントをお持ちでない方は新規登録');
+    expect(signupLink, findsOneWidget);
+
+    await tester.tap(signupLink);
+    await tester.pumpAndSettle();
+
+    expect(
+      find.descendant(
+        of: find.byType(AppBar),
+        matching: find.text('新規登録'),
+      ),
+      findsOneWidget,
+    );
+
+    await TestUtils.performSignUp(
+      tester: tester,
+      name: '統合テストユーザー',
+      displayName: '統合テスト表示名',
+      email: 'widget-signup@example.com',
+      password: 'password123',
+    );
+    await tester.pump(const Duration(seconds: 3));
+    await tester.pump(const Duration(milliseconds: 300));
+
+    _expectCalendarInitialScreen();
+    await _drainAsyncWork(tester);
+  });
+
+  testWidgets('ログアウト後にログイン画面へ戻る', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: TestProviders.authenticated,
+        child: const MyApp(),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 2));
+    await tester.pump(const Duration(milliseconds: 300));
+
+    _expectCalendarInitialScreen();
+
+    await tester.tap(find.text('マイページ'));
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(
+      find.descendant(
+        of: find.byType(AppBar),
+        matching: find.text('マイページ'),
+      ),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.byIcon(Icons.settings_outlined));
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(
+      find.descendant(
+        of: find.byType(AppBar),
+        matching: find.text('設定'),
+      ),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.widgetWithText(ListTile, 'ログアウト'));
+    await tester.pump(const Duration(milliseconds: 300));
+
+    await tester.tap(find.widgetWithText(TextButton, 'ログアウト'));
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.descendant(
+        of: find.byType(AppBar),
+        matching: find.text('ログイン'),
+      ),
+      findsOneWidget,
+    );
+  });
+}
+
+void _expectCalendarInitialScreen() {
+  expect(find.text('カレンダー'), findsOneWidget);
+  expect(find.text('タイムライン'), findsOneWidget);
+  expect(
+    find.descendant(
+      of: find.byType(AppBar),
+      matching: find.text('ホーム'),
+    ),
+    findsOneWidget,
+  );
+}
+
+Future<void> _drainAsyncWork(WidgetTester tester) async {
+  await tester.pump(const Duration(seconds: 4));
+  await tester.pumpWidget(const SizedBox.shrink());
+  await tester.pump();
+}

--- a/test/presentation/auth/session_scoped_subtree_test.dart
+++ b/test/presentation/auth/session_scoped_subtree_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final _sessionCounterProvider = StateProvider<int>((ref) => 0);
+
+class _SessionCounterView extends ConsumerWidget {
+  const _SessionCounterView();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final count = ref.watch(_sessionCounterProvider);
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text('count:$count'),
+        ElevatedButton(
+          onPressed: () {
+            ref.read(_sessionCounterProvider.notifier).state++;
+          },
+          child: const Text('increment'),
+        ),
+      ],
+    );
+  }
+}
+
+class _SessionScopedSubtree extends StatelessWidget {
+  const _SessionScopedSubtree({required this.userId});
+
+  final String userId;
+
+  @override
+  Widget build(BuildContext context) {
+    return ProviderScope(
+      key: ValueKey(userId),
+      child: const _SessionCounterView(),
+    );
+  }
+}
+
+void main() {
+  testWidgets('userId を切り替えると subtree 配下の provider state がリセットされる',
+      (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: _SessionScopedSubtree(userId: 'user-a'),
+        ),
+      ),
+    );
+
+    expect(find.text('count:0'), findsOneWidget);
+
+    await tester.tap(find.text('increment'));
+    await tester.pumpAndSettle();
+    expect(find.text('count:1'), findsOneWidget);
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: _SessionScopedSubtree(userId: 'user-b'),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('count:0'), findsOneWidget);
+  });
+}

--- a/test/presentation/auth/signup_widget_test.dart
+++ b/test/presentation/auth/signup_widget_test.dart
@@ -154,6 +154,8 @@ void main() {
 
       // ローディング状態の確認（CircularProgressIndicatorまたはボタンが無効化）
       // 実際の実装に合わせて調整
+      await tester.pump(const Duration(milliseconds: 500));
+      await tester.pumpAndSettle();
     });
 
     testWidgets('ログインボタンが機能する', (tester) async {

--- a/test/presentation/presentation_provider_test.dart
+++ b/test/presentation/presentation_provider_test.dart
@@ -15,7 +15,6 @@ import '../../mock/repositories/mock_auth_repository.dart';
 import '../../mock/repositories/mock_user_repository.dart';
 
 class _TrackingScheduleRepository implements IScheduleRepository {
-
   _TrackingScheduleRepository() {
     _controller
       ..onListen = () {
@@ -30,7 +29,8 @@ class _TrackingScheduleRepository implements IScheduleRepository {
   int listenCount = 0;
 
   @override
-  Stream<List<Schedule>> watchUserSchedules(String userId) => _controller.stream;
+  Stream<List<Schedule>> watchUserSchedules(String userId) =>
+      _controller.stream;
 
   @override
   Stream<List<Schedule>> watchUserSchedulesForMonth(
@@ -38,7 +38,8 @@ class _TrackingScheduleRepository implements IScheduleRepository {
       _controller.stream;
 
   @override
-  Stream<List<Schedule>> watchListSchedules(String listId) => _controller.stream;
+  Stream<List<Schedule>> watchListSchedules(String listId) =>
+      _controller.stream;
 
   @override
   Stream<Schedule?> watchSchedule(String scheduleId) =>
@@ -95,7 +96,8 @@ class _TrackingListRepository implements IListRepository {
   int listsListenCount = 0;
 
   @override
-  Stream<List<UserList>> watchUserLists(String ownerId) => _listsController.stream;
+  Stream<List<UserList>> watchUserLists(String ownerId) =>
+      _listsController.stream;
 
   @override
   Stream<UserList?> watchList(String listId) => _listController.stream;
@@ -118,7 +120,8 @@ class _TrackingListRepository implements IListRepository {
   Future<void> deleteList(String listId) => Future.error(UnimplementedError());
 
   @override
-  Future<UserList?> getList(String listId) => Future.error(UnimplementedError());
+  Future<UserList?> getList(String listId) =>
+      Future.error(UnimplementedError());
 
   @override
   Future<List<UserList>> getLists(String ownerId) =>

--- a/test/presentation/presentation_provider_test.dart
+++ b/test/presentation/presentation_provider_test.dart
@@ -1,0 +1,264 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:lakiite/domain/entity/list.dart';
+import 'package:lakiite/domain/entity/schedule.dart';
+import 'package:lakiite/domain/entity/user.dart';
+import 'package:lakiite/domain/interfaces/i_list_repository.dart';
+import 'package:lakiite/domain/interfaces/i_schedule_repository.dart';
+import 'package:lakiite/presentation/my_page/my_page_view_model.dart'
+    show timelineSchedulesProvider;
+import 'package:lakiite/presentation/presentation_provider.dart';
+
+import '../../mock/repositories/mock_auth_repository.dart';
+import '../../mock/repositories/mock_user_repository.dart';
+
+class _TrackingScheduleRepository implements IScheduleRepository {
+
+  _TrackingScheduleRepository() {
+    _controller
+      ..onListen = () {
+        listenCount++;
+      }
+      ..onCancel = () {
+        cancelCount++;
+      };
+  }
+  final _controller = StreamController<List<Schedule>>.broadcast();
+  int cancelCount = 0;
+  int listenCount = 0;
+
+  @override
+  Stream<List<Schedule>> watchUserSchedules(String userId) => _controller.stream;
+
+  @override
+  Stream<List<Schedule>> watchUserSchedulesForMonth(
+          String userId, DateTime displayMonth) =>
+      _controller.stream;
+
+  @override
+  Stream<List<Schedule>> watchListSchedules(String listId) => _controller.stream;
+
+  @override
+  Stream<Schedule?> watchSchedule(String scheduleId) =>
+      const Stream<Schedule?>.empty();
+
+  @override
+  Future<Schedule> createSchedule(Schedule schedule) =>
+      Future.error(UnimplementedError());
+
+  @override
+  Future<void> deleteSchedule(String scheduleId) =>
+      Future.error(UnimplementedError());
+
+  @override
+  Future<List<Schedule>> getListSchedules(String listId) =>
+      Future.error(UnimplementedError());
+
+  @override
+  Future<List<Schedule>> getUserSchedules(String userId) =>
+      Future.error(UnimplementedError());
+
+  @override
+  Future<void> updateSchedule(Schedule schedule) =>
+      Future.error(UnimplementedError());
+
+  void dispose() {
+    _controller.close();
+  }
+}
+
+class _TrackingListRepository implements IListRepository {
+  _TrackingListRepository() {
+    _listsController
+      ..onListen = () {
+        listsListenCount++;
+      }
+      ..onCancel = () {
+        listsCancelCount++;
+      };
+    _listController
+      ..onListen = () {
+        listListenCount++;
+      }
+      ..onCancel = () {
+        listCancelCount++;
+      };
+  }
+
+  final _listsController = StreamController<List<UserList>>.broadcast();
+  final _listController = StreamController<UserList?>.broadcast();
+  int listCancelCount = 0;
+  int listListenCount = 0;
+  int listsCancelCount = 0;
+  int listsListenCount = 0;
+
+  @override
+  Stream<List<UserList>> watchUserLists(String ownerId) => _listsController.stream;
+
+  @override
+  Stream<UserList?> watchList(String listId) => _listController.stream;
+
+  @override
+  Future<void> addMember(String listId, String userId) =>
+      Future.error(UnimplementedError());
+
+  @override
+  Future<UserList> createList({
+    required String listName,
+    required List<String> memberIds,
+    required String ownerId,
+    String? iconUrl,
+    String? description,
+  }) =>
+      Future.error(UnimplementedError());
+
+  @override
+  Future<void> deleteList(String listId) => Future.error(UnimplementedError());
+
+  @override
+  Future<UserList?> getList(String listId) => Future.error(UnimplementedError());
+
+  @override
+  Future<List<UserList>> getLists(String ownerId) =>
+      Future.error(UnimplementedError());
+
+  @override
+  Future<void> removeMember(String listId, String userId) =>
+      Future.error(UnimplementedError());
+
+  @override
+  Future<void> updateList(UserList list) => Future.error(UnimplementedError());
+
+  void dispose() {
+    _listsController.close();
+    _listController.close();
+  }
+}
+
+void main() {
+  group('presentation providers', () {
+    late ProviderContainer container;
+    late MockAuthRepository mockAuthRepository;
+    late _TrackingListRepository listRepository;
+    late MockUserRepository mockUserRepository;
+    late _TrackingScheduleRepository scheduleRepository;
+    late UserModel testUser;
+
+    setUp(() {
+      mockAuthRepository = MockAuthRepository();
+      listRepository = _TrackingListRepository();
+      mockUserRepository = MockUserRepository();
+      scheduleRepository = _TrackingScheduleRepository();
+      testUser = UserModel.create(
+        id: 'test-user-id',
+        name: 'テストユーザー',
+        displayName: 'テストユーザー',
+      );
+
+      mockAuthRepository.setUser(testUser);
+      mockUserRepository.addTestUser(testUser);
+
+      container = ProviderContainer(
+        overrides: [
+          authRepositoryProvider.overrideWithValue(mockAuthRepository),
+          listRepositoryProvider.overrideWithValue(listRepository),
+          userRepositoryProvider.overrideWithValue(mockUserRepository),
+          scheduleRepositoryProvider.overrideWithValue(scheduleRepository),
+        ],
+      );
+    });
+
+    tearDown(() {
+      listRepository.dispose();
+      scheduleRepository.dispose();
+      mockAuthRepository.dispose();
+      container.dispose();
+    });
+
+    test('userSchedulesStreamProvider はログアウト時に空配列へ切り替わる', () async {
+      await container.read(authNotifierProvider.future);
+
+      final subscription = container.listen(
+        userSchedulesStreamProvider(testUser.id),
+        (_, __) {},
+        fireImmediately: true,
+      );
+
+      await mockAuthRepository.signOut();
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      final state = container.read(userSchedulesStreamProvider(testUser.id));
+      expect(state.hasValue, isTrue);
+      expect(state.value, isEmpty);
+
+      subscription.close();
+    });
+
+    test('timelineSchedulesProvider はログアウト時に空配列へ切り替わる', () async {
+      await container.read(authNotifierProvider.future);
+
+      final subscription = container.listen(
+        timelineSchedulesProvider,
+        (_, __) {},
+        fireImmediately: true,
+      );
+
+      await mockAuthRepository.signOut();
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      final state = container.read(timelineSchedulesProvider);
+      expect(state.hasValue, isTrue);
+      expect(state.value, isEmpty);
+
+      subscription.close();
+    });
+
+    test('userListsStreamProvider はログアウト時に空配列へ切り替わる', () async {
+      await container.read(authNotifierProvider.future);
+
+      final subscription = container.listen(
+        userListsStreamProvider,
+        (_, __) {},
+        fireImmediately: true,
+      );
+
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(listRepository.listsListenCount, 1);
+
+      await mockAuthRepository.signOut();
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      final state = container.read(userListsStreamProvider);
+      expect(state.hasValue, isTrue);
+      expect(state.value, isEmpty);
+      expect(listRepository.listsCancelCount, 1);
+
+      subscription.close();
+    });
+
+    test('listStreamProvider はログアウト時に null へ切り替わる', () async {
+      await container.read(authNotifierProvider.future);
+
+      final subscription = container.listen(
+        listStreamProvider('test-list-id'),
+        (_, __) {},
+        fireImmediately: true,
+      );
+
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(listRepository.listListenCount, 1);
+
+      await mockAuthRepository.signOut();
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      final state = container.read(listStreamProvider('test-list-id'));
+      expect(state.hasValue, isTrue);
+      expect(state.value, isNull);
+      expect(listRepository.listCancelCount, 1);
+
+      subscription.close();
+    });
+  });
+}

--- a/test/presentation/repository_session_scope_test.dart
+++ b/test/presentation/repository_session_scope_test.dart
@@ -1,0 +1,198 @@
+import 'dart:async';
+
+import 'package:firebase_auth/firebase_auth.dart' as firebase_auth;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:lakiite/domain/entity/schedule.dart';
+import 'package:lakiite/domain/interfaces/i_schedule_repository.dart';
+import 'package:lakiite/domain/interfaces/i_user_repository.dart';
+import 'package:lakiite/presentation/presentation_provider.dart';
+
+class _FakeFirebaseUser implements firebase_auth.User {
+  _FakeFirebaseUser(this._uid);
+
+  final String _uid;
+
+  @override
+  String get uid => _uid;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeFirebaseAuth implements firebase_auth.FirebaseAuth {
+  final _controller = StreamController<firebase_auth.User?>.broadcast();
+  firebase_auth.User? _currentUser;
+
+  @override
+  firebase_auth.User? get currentUser => _currentUser;
+
+  void setCurrentUser(firebase_auth.User? user) {
+    _currentUser = user;
+    _controller.add(user);
+  }
+
+  @override
+  Stream<firebase_auth.User?> authStateChanges() async* {
+    yield _currentUser;
+    yield* _controller.stream;
+  }
+
+  void dispose() {
+    _controller.close();
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _TrackingUserRepository implements IUserRepository {
+  _TrackingUserRepository(this.instanceId);
+
+  final int instanceId;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _TrackingScheduleRepository implements IScheduleRepository {
+  _TrackingScheduleRepository(this.instanceId);
+
+  final int instanceId;
+
+  @override
+  Stream<List<Schedule>> watchUserSchedules(String userId) =>
+      const Stream.empty();
+
+  @override
+  Stream<List<Schedule>> watchUserSchedulesForMonth(
+          String userId, DateTime displayMonth) =>
+      const Stream.empty();
+
+  @override
+  Stream<List<Schedule>> watchListSchedules(String listId) =>
+      const Stream.empty();
+
+  @override
+  Stream<Schedule?> watchSchedule(String scheduleId) => const Stream.empty();
+
+  @override
+  Future<Schedule> createSchedule(Schedule schedule) =>
+      Future.error(UnimplementedError());
+
+  @override
+  Future<void> deleteSchedule(String scheduleId) =>
+      Future.error(UnimplementedError());
+
+  @override
+  Future<List<Schedule>> getListSchedules(String listId) =>
+      Future.error(UnimplementedError());
+
+  @override
+  Future<List<Schedule>> getUserSchedules(String userId) =>
+      Future.error(UnimplementedError());
+
+  @override
+  Future<void> updateSchedule(Schedule schedule) =>
+      Future.error(UnimplementedError());
+}
+
+void main() {
+  group('repository session scope', () {
+    late ProviderContainer container;
+    late _FakeFirebaseAuth firebaseAuth;
+    late ProviderSubscription<IUserRepository> userRepositorySubscription;
+    late ProviderSubscription<IScheduleRepository>
+        scheduleRepositorySubscription;
+    var userRepositoryInstanceCount = 0;
+    var scheduleRepositoryInstanceCount = 0;
+
+    setUp(() {
+      firebaseAuth = _FakeFirebaseAuth();
+
+      container = ProviderContainer(
+        overrides: [
+          firebaseAuthProvider.overrideWithValue(firebaseAuth),
+          userRepositoryFactoryProvider.overrideWithValue(
+            () => _TrackingUserRepository(++userRepositoryInstanceCount),
+          ),
+          scheduleRepositoryFactoryProvider.overrideWithValue(
+            () =>
+                _TrackingScheduleRepository(++scheduleRepositoryInstanceCount),
+          ),
+        ],
+      );
+
+      userRepositorySubscription = container.listen(
+        userRepositoryProvider,
+        (_, __) {},
+        fireImmediately: true,
+      );
+      scheduleRepositorySubscription = container.listen(
+        scheduleRepositoryProvider,
+        (_, __) {},
+        fireImmediately: true,
+      );
+    });
+
+    tearDown(() {
+      userRepositorySubscription.close();
+      scheduleRepositorySubscription.close();
+      firebaseAuth.dispose();
+      container.dispose();
+    });
+
+    test('ログアウト時に repository インスタンスを作り直す', () async {
+      firebaseAuth.setCurrentUser(_FakeFirebaseUser('user-a'));
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      final signedInUserRepository =
+          container.read(userRepositoryProvider) as _TrackingUserRepository;
+      final signedInScheduleRepository = container.read(
+        scheduleRepositoryProvider,
+      ) as _TrackingScheduleRepository;
+
+      firebaseAuth.setCurrentUser(null);
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      final signedOutUserRepository =
+          container.read(userRepositoryProvider) as _TrackingUserRepository;
+      final signedOutScheduleRepository = container.read(
+        scheduleRepositoryProvider,
+      ) as _TrackingScheduleRepository;
+
+      expect(signedOutUserRepository.instanceId,
+          isNot(signedInUserRepository.instanceId));
+      expect(
+        signedOutScheduleRepository.instanceId,
+        isNot(signedInScheduleRepository.instanceId),
+      );
+    });
+
+    test('ユーザー切替時に repository インスタンスを作り直す', () async {
+      firebaseAuth.setCurrentUser(_FakeFirebaseUser('user-a'));
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      final userARepository =
+          container.read(userRepositoryProvider) as _TrackingUserRepository;
+      final scheduleUserARepository = container.read(
+        scheduleRepositoryProvider,
+      ) as _TrackingScheduleRepository;
+
+      firebaseAuth.setCurrentUser(_FakeFirebaseUser('user-b'));
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      final userBRepository =
+          container.read(userRepositoryProvider) as _TrackingUserRepository;
+      final scheduleUserBRepository = container.read(
+        scheduleRepositoryProvider,
+      ) as _TrackingScheduleRepository;
+
+      expect(userBRepository.instanceId, isNot(userARepository.instanceId));
+      expect(
+        scheduleUserBRepository.instanceId,
+        isNot(scheduleUserARepository.instanceId),
+      );
+    });
+  });
+}

--- a/test/utils/test_utils.dart
+++ b/test/utils/test_utils.dart
@@ -6,6 +6,25 @@ import 'package:lakiite/main.dart';
 import 'package:lakiite/config/app_config.dart';
 
 class TestUtils {
+  static Finder _findTextFieldByLabel(String labelText) {
+    return find
+        .byWidgetPredicate(
+          (widget) =>
+              widget is TextField && widget.decoration?.labelText == labelText,
+          description: 'TextField(labelText: $labelText)',
+        )
+        .last;
+  }
+
+  static Finder _findElevatedButtonByText(String text) {
+    return find
+        .descendant(
+          of: find.byType(ElevatedButton),
+          matching: find.text(text),
+        )
+        .last;
+  }
+
   /// 標準的なテストウィジェットのセットアップ
   static Widget createTestApp({
     required Widget child,
@@ -51,11 +70,11 @@ class TestUtils {
     List<Override> overrides = const [],
   }) async {
     await startApp(Environment.development, overrides);
-    await tester.pumpAndSettle();
+    await tester.pump();
 
     // スプラッシュ画面の待機
     await Future.delayed(const Duration(seconds: 2));
-    await tester.pumpAndSettle();
+    await tester.pump(const Duration(milliseconds: 300));
   }
 
   /// ログイン操作のヘルパー
@@ -65,7 +84,7 @@ class TestUtils {
     String password = 'password123',
   }) async {
     // メールアドレス入力
-    final emailField = find.widgetWithText(TextField, 'メールアドレス');
+    final emailField = _findTextFieldByLabel('メールアドレス');
     if (emailField.evaluate().isNotEmpty) {
       await tester.enterText(emailField, email);
     } else {
@@ -77,7 +96,7 @@ class TestUtils {
     }
 
     // パスワード入力
-    final passwordField = find.widgetWithText(TextField, 'パスワード');
+    final passwordField = _findTextFieldByLabel('パスワード');
     if (passwordField.evaluate().isNotEmpty) {
       await tester.enterText(passwordField, password);
     } else {
@@ -87,10 +106,10 @@ class TestUtils {
       }
     }
 
-    await tester.pumpAndSettle();
+    await tester.pump();
 
     // ログインボタンをタップ
-    final loginButton = find.text('ログイン');
+    final loginButton = _findElevatedButtonByText('ログイン');
     if (loginButton.evaluate().isNotEmpty) {
       await tester.tap(loginButton);
     } else {
@@ -100,7 +119,7 @@ class TestUtils {
       }
     }
 
-    await tester.pumpAndSettle();
+    await tester.pump(const Duration(milliseconds: 300));
   }
 
   /// サインアップ操作のヘルパー
@@ -112,7 +131,7 @@ class TestUtils {
     String password = 'password123',
   }) async {
     // 名前入力（実際のラベルに合わせて修正）
-    final nameField = find.widgetWithText(TextField, '名前(フルネーム)');
+    final nameField = _findTextFieldByLabel('名前(フルネーム)');
     if (nameField.evaluate().isNotEmpty) {
       await tester.enterText(nameField, name);
     } else {
@@ -123,13 +142,13 @@ class TestUtils {
     }
 
     // 表示名入力（実際のラベルに合わせて修正）
-    final displayNameField = find.widgetWithText(TextField, '表示名(ニックネーム)');
+    final displayNameField = _findTextFieldByLabel('表示名(ニックネーム)');
     if (displayNameField.evaluate().isNotEmpty) {
       await tester.enterText(displayNameField, displayName);
     }
 
     // メールアドレス入力
-    final emailField = find.widgetWithText(TextField, 'メールアドレス');
+    final emailField = _findTextFieldByLabel('メールアドレス');
     if (emailField.evaluate().isNotEmpty) {
       await tester.enterText(emailField, email);
     } else {
@@ -140,7 +159,7 @@ class TestUtils {
     }
 
     // パスワード入力
-    final passwordField = find.widgetWithText(TextField, 'パスワード');
+    final passwordField = _findTextFieldByLabel('パスワード');
     if (passwordField.evaluate().isNotEmpty) {
       await tester.enterText(passwordField, password);
     } else {
@@ -150,13 +169,10 @@ class TestUtils {
       }
     }
 
-    await tester.pumpAndSettle();
+    await tester.pump();
 
     // サインアップボタンをタップ（ElevatedButtonの「新規登録」テキストを特定）
-    final signUpButton = find.descendant(
-      of: find.byType(ElevatedButton),
-      matching: find.text('新規登録'),
-    );
+    final signUpButton = _findElevatedButtonByText('新規登録');
     if (signUpButton.evaluate().isNotEmpty) {
       await tester.tap(signUpButton);
     } else {
@@ -166,7 +182,7 @@ class TestUtils {
       }
     }
 
-    await tester.pumpAndSettle();
+    await tester.pump(const Duration(milliseconds: 300));
   }
 
   /// スケジュール作成操作のヘルパー

--- a/utils/test_utils.dart
+++ b/utils/test_utils.dart
@@ -192,10 +192,9 @@ class TestUtils {
 }
 
 class TimeoutException implements Exception {
+  TimeoutException(this.message, this.timeout);
   final String message;
   final Duration timeout;
-
-  TimeoutException(this.message, this.timeout);
 
   @override
   String toString() => 'TimeoutException: $message (timeout: $timeout)';


### PR DESCRIPTION
## Summary
- auth/session 切替時に Router、provider state、repository instance がずれないように認証依存の境界を整理
- 未認証時の stream/provider を安全な空状態へ切り替え、logout/user switch 後の購読残留を抑止
- mock auth 前提の widget/integration test を追加し、Android `dev` flavor でログイン/新規登録からホーム遷移を検証
- 要件整理を [`.ai/plan/auth_session_stabilization_20260413.md`](/Users/keisukeshimizu/development/flutter-apps/LaKiite/lakiite-flutter-app/.ai/plan/auth_session_stabilization_20260413.md) に記録

## Test Plan
- `fvm flutter test test/presentation/repository_session_scope_test.dart test/presentation/presentation_provider_test.dart test/presentation/auth/session_scoped_subtree_test.dart test/presentation/auth/auth_home_navigation_test.dart test/application/list/list_notifier_test.dart test/application/schedule/schedule_notifier_test.dart test/application/auth/auth_notifier_test.dart`
- `fvm flutter test -d emulator-5554 --flavor dev integration_test/login_signup_home_navigation_integration_test.dart --dart-define=TEST_MODE=true`
