### PR TITLE
dev実機debug用のiOS署名設定を修正

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -652,9 +652,9 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "AppIcon-development";
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner-Dev.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = T6ZYALKC4V;
 				ENABLE_BITCODE = NO;
@@ -665,7 +665,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.inoworl.lakiite.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = "LaKiite Dev Development";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -811,9 +811,9 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "AppIcon-development";
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner-Dev.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = T6ZYALKC4V;
 				ENABLE_BITCODE = NO;
@@ -824,7 +824,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.inoworl.lakiite.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = "LaKiite Dev Development";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";


### PR DESCRIPTION
## 概要
- `dev` flavor の実機debugで Push Notifications entitlement を含む development profile を使うようにしました。
- `Debug-dev` / `Profile-dev` の entitlements を `Runner-Dev.entitlements` に切り替えました。
- `Debug-dev` / `Profile-dev` を Manual signing にし、`LaKiite Dev Development` profile を明示指定しました。

## Apple Developer 側で実施したこと
- `LaKiite Dev Development` を新規作成
  - Type: iOS App Development
  - App ID: `T6ZYALKC4V.com.inoworl.lakiite.dev`
  - Certificate: `Keisuke Shimizu (KeisukeのMacBook Pro (2)) (Development)`
  - Device: `KeisukeのiPhone`
  - Expires: `2027/05/17`
- ダウンロードした profile をローカルの Provisioning Profiles にインストール
- profile 内容確認
  - `application-identifier = T6ZYALKC4V.com.inoworl.lakiite.dev`
  - `aps-environment = development`

## 検証
- `xcodebuild -showBuildSettings -workspace ios/Runner.xcworkspace -scheme dev -configuration Debug-dev -destination generic/platform=iOS`
  - `CODE_SIGN_ENTITLEMENTS = Runner/Runner-Dev.entitlements`
  - `CODE_SIGN_STYLE = Manual`
  - `PROVISIONING_PROFILE_SPECIFIER = LaKiite Dev Development`
  - `PRODUCT_BUNDLE_IDENTIFIER = com.inoworl.lakiite.dev`
- `fvm flutter run -d 00008101-001A60992108001E --flavor dev --dart-define-from-file=dart_define/dev_dart_define.json`
  - KeisukeのiPhone / iOS 26.4.2 実機で install / launch 成功
  - APNs token 取得成功
  - FCM token 取得成功
  - VM Service 接続成功
- `fvm flutter analyze`
  - `No issues found!`

## 補足
- TestFlight / App Store 配信用の `Release-dev` は従来通り `LaKiite Dev App Store` のままです。
- TestFlightで動いている production APNs の設定は変更していません。