### PR TITLE
AdMob SKAdNetwork設定のCIガードを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@
 /build/
 build/ios/XCBuildData/
 ios/build/
+ios/.derived-data-log-*
 
 # Web related
 lib/generated_plugin_registrant.dart

--- a/docs/setup/ADMOB_CONFIG.md
+++ b/docs/setup/ADMOB_CONFIG.md
@@ -111,6 +111,18 @@ final bannerAd = AdMobService.createBannerAd();
 ✅ AdMob初期化完了
 ```
 
+### iOS SKAdNetwork設定
+
+iOSではGoogle Mobile Ads SDKが起動時に`SKAdNetworkItems`の不足を警告することがあります。`ios/Runner/Info.plist`にはGoogle公式ドキュメントのSKAdNetwork IDを設定済みです。
+
+設定漏れの再発防止として、以下のテストで必須IDの存在と重複なしを確認しています。
+
+```bash
+fvm flutter test test/utils/skadnetwork_info_plist_test.dart --dart-define=FLUTTER_TEST=true
+```
+
+SKAdNetwork IDはGoogle側で更新されることがあるため、AdMob SDK更新時やストア提出前に公式ドキュメントも確認してください。
+
 ## AdMob審査について
 
 ### 現在の状態

--- a/test/utils/skadnetwork_info_plist_test.dart
+++ b/test/utils/skadnetwork_info_plist_test.dart
@@ -1,0 +1,80 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('Info.plist contains Google Mobile Ads SKAdNetwork identifiers', () {
+    final infoPlist = File('ios/Runner/Info.plist').readAsStringSync();
+    final configuredIdentifiers = RegExp(
+      r'<string>([a-z0-9]+\.skadnetwork)</string>',
+    ).allMatches(infoPlist).map((match) => match.group(1)!).toSet();
+
+    const requiredIdentifiers = {
+      'cstr6suwn9.skadnetwork',
+      '4fzdc2evr5.skadnetwork',
+      '2fnua5tdw4.skadnetwork',
+      'ydx93a7ass.skadnetwork',
+      'p78axxw29g.skadnetwork',
+      'v72qych5uu.skadnetwork',
+      'ludvb6z3bs.skadnetwork',
+      'cp8zw746q7.skadnetwork',
+      '3sh42y64q3.skadnetwork',
+      'c6k4g5qg8m.skadnetwork',
+      's39g8k73mm.skadnetwork',
+      'wg4vff78zm.skadnetwork',
+      '3qy4746246.skadnetwork',
+      'f38h382jlk.skadnetwork',
+      'hs6bdukanm.skadnetwork',
+      'mlmmfzh3r3.skadnetwork',
+      'v4nxqhlyqp.skadnetwork',
+      'wzmmz9fp6w.skadnetwork',
+      'su67r6k2v3.skadnetwork',
+      'yclnxrl5pm.skadnetwork',
+      't38b2kh725.skadnetwork',
+      '7ug5zh24hu.skadnetwork',
+      'gta9lk7p23.skadnetwork',
+      'vutu7akeur.skadnetwork',
+      'y5ghdn5j9k.skadnetwork',
+      'v9wttpbfk9.skadnetwork',
+      'n38lu8286q.skadnetwork',
+      '47vhws6wlr.skadnetwork',
+      'kbd757ywx3.skadnetwork',
+      '9t245vhmpl.skadnetwork',
+      'a2p9lx4jpn.skadnetwork',
+      '22mmun2rn5.skadnetwork',
+      '44jx6755aq.skadnetwork',
+      'k674qkevps.skadnetwork',
+      '4468km3ulz.skadnetwork',
+      '2u9pt9hc89.skadnetwork',
+      '8s468mfl3y.skadnetwork',
+      'klf5c3l5u5.skadnetwork',
+      'ppxm28t8ap.skadnetwork',
+      'kbmxgpxpgc.skadnetwork',
+      'uw77j35x4d.skadnetwork',
+      '578prtvx9j.skadnetwork',
+      '4dzt52r2t5.skadnetwork',
+      'tl55sbb4fm.skadnetwork',
+      'c3frkrj4fj.skadnetwork',
+      'e5fvkxwrpn.skadnetwork',
+      '8c4e2ghe7u.skadnetwork',
+      '3rd42ekr43.skadnetwork',
+      '97r2b46745.skadnetwork',
+      '3qcr597p9d.skadnetwork',
+    };
+
+    expect(
+      configuredIdentifiers,
+      containsAll(requiredIdentifiers),
+      reason: 'Google Mobile Ads SDK logs missing SKAdNetwork IDs at startup.',
+    );
+  });
+
+  test('Info.plist does not contain duplicate SKAdNetwork identifiers', () {
+    final infoPlist = File('ios/Runner/Info.plist').readAsStringSync();
+    final identifiers = RegExp(
+      r'<string>([a-z0-9]+\.skadnetwork)</string>',
+    ).allMatches(infoPlist).map((match) => match.group(1)!).toList();
+
+    expect(identifiers.toSet(), hasLength(identifiers.length));
+  });
+}


### PR DESCRIPTION
## 概要
- iOSの`Info.plist`にGoogle Mobile Ads向けSKAdNetwork IDが揃っていることを検証するテストを追加
- SKAdNetwork IDの重複も検知するようにしました
- AdMob設定ドキュメントに確認方法を追記
- Xcode由来の一時ログ`ios/.derived-data-log-*`をGit管理対象外に追加

## 背景
起動ログで`required SKAdNetwork identifier(s) missing from Info.plist`警告が出ていたため、今後`Info.plist`更新時に必須IDの欠落をCIで検知できるようにします。現時点の`Info.plist`はGoogle公式のSKAdNetwork IDを満たしています。

参考: https://developers.google.com/admob/ios/privacy/strategies#enable-skadnetwork-to-track-conversions

## 確認
- `fvm flutter test test/utils/skadnetwork_info_plist_test.dart --dart-define=FLUTTER_TEST=true`
- `fvm flutter test --coverage --dart-define=FLUTTER_TEST=true --exclude-tags=integration test/domain/ test/utils/ test/application/`
- `fvm flutter analyze --no-fatal-infos`
- `fvm dart format --output=none --set-exit-if-changed .`