### PR TITLE
子どもの安全基準ページを追加

### DIFF
--- a/web/child-safety-standards.html
+++ b/web/child-safety-standards.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>LaKiite 子どもの安全基準</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+            max-width: 900px;
+            margin: 0 auto;
+            padding: 24px;
+            line-height: 1.6;
+            color: #333;
+            background-color: #fff;
+        }
+        .header {
+            text-align: center;
+            margin-bottom: 48px;
+            padding-bottom: 24px;
+            border-bottom: 1px solid #e1e5e9;
+        }
+        .header h1 {
+            color: #1a1a1a;
+            margin-bottom: 8px;
+            font-size: 2.25rem;
+            font-weight: 600;
+        }
+        .header p {
+            color: #6b7280;
+            font-size: 0.875rem;
+            margin: 0;
+        }
+        h2 {
+            color: #1a1a1a;
+            margin-top: 40px;
+            margin-bottom: 16px;
+            border-bottom: 1px solid #e1e5e9;
+            padding-bottom: 8px;
+            font-size: 1.5rem;
+            font-weight: 600;
+        }
+        ul {
+            padding-left: 24px;
+            margin: 16px 0;
+        }
+        li {
+            margin-bottom: 8px;
+        }
+        .contact {
+            background: #f9fafb;
+            padding: 24px;
+            border: 1px solid #e1e5e9;
+            border-radius: 8px;
+            margin-top: 40px;
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>LaKiite 子どもの安全基準</h1>
+        <p>最終更新日: 2026年5月17日</p>
+    </div>
+
+    <h2>1. 基本方針</h2>
+    <p>LaKiiteは、児童の性的虐待と搾取（CSAE）および児童性的虐待コンテンツ（CSAM）を一切容認しません。当サービスは、ユーザーが安全に予定を共有できる環境を維持するため、子どもの安全に関する懸念へ迅速に対応します。</p>
+
+    <h2>2. 禁止事項</h2>
+    <ul>
+        <li>児童の性的虐待、搾取、勧誘、グルーミングに該当する行為</li>
+        <li>CSAMまたはCSAMを想起させるコンテンツの投稿、共有、保存、要求</li>
+        <li>未成年者に対する性的な接触、会話、画像共有の要求</li>
+        <li>子どもの安全を脅かす外部サービス、コンテンツ、連絡先への誘導</li>
+    </ul>
+
+    <h2>3. 報告と対応</h2>
+    <p>ユーザーは、アプリ内の設定画面から確認できる利用規約・問い合わせ先、または下記連絡先を通じて、子どもの安全に関する懸念を報告できます。報告を受けた場合、当社は内容を確認し、必要に応じてコンテンツ削除、アカウント制限、関係当局への報告などの措置を行います。</p>
+
+    <h2>4. 法令遵守と当局への報告</h2>
+    <p>LaKiiteは、適用される子どもの安全関連法令およびGoogle Playのポリシーを遵守します。CSAMまたは児童の安全に関わる重大なリスクを確認した場合、必要に応じて国や地域の関係当局または適切な機関へ報告します。</p>
+
+    <h2>5. 継続的な改善</h2>
+    <p>当社は、子どもの安全に関する通報導線、運用手順、コンテンツ確認体制を継続的に見直し、必要な改善を行います。</p>
+
+    <div class="contact">
+        <h2>連絡先</h2>
+        <p>子どもの安全に関する懸念、CSAE/CSAMに関する報告、または本基準に関する問い合わせは、以下までご連絡ください。</p>
+        <ul>
+            <li><strong>運営者</strong>: Inoworl</li>
+            <li><strong>メールアドレス</strong>: business-contact@inoworl.com</li>
+        </ul>
+    </div>
+</body>
+</html>

--- a/web/index.html
+++ b/web/index.html
@@ -79,6 +79,11 @@
             <h3>📋 利用規約</h3>
             <p>サービス利用に関する規約</p>
         </a>
+
+        <a href="child-safety-standards.html" class="link-card">
+            <h3>子どもの安全基準</h3>
+            <p>CSAE/CSAM防止に関する基準</p>
+        </a>
     </div>
 </body>
 </html>


### PR DESCRIPTION
## 概要
- Google Play の子どもの安全基準申告に使用する公開ページを追加
- Web公開トップから子どもの安全基準へリンクを追加

## 確認
- HTMLParserで  と  の構文確認済み

## 備考
- Google Play Console の公開前チェックで必要になったCSAE/CSAM基準URL用の変更です。