### PR TITLE
iOS本番配信CIの署名設定を修正

### DIFF
--- a/.github/workflows/deploy_prod_ios.yml
+++ b/.github/workflows/deploy_prod_ios.yml
@@ -50,6 +50,7 @@ jobs:
         run: |
           echo "${{ secrets.IOS_CERTIFICATES_P12_BASE64 }}" | base64 -d > certificates.p12
           security import certificates.p12 -k build.keychain -P "${{ secrets.IOS_CERTIFICATES_P12_PASSWORD }}" -A
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "" build.keychain
 
       # 証明書の一覧を表示する。
       - name: List available certificates
@@ -61,7 +62,7 @@ jobs:
         run: |
           # ios/project.pbxproj を上書きする設定を Dart-Defines.xcconfig に書き込む。
           touch Dart-Defines.xcconfig
-          echo "PROVISIONING_PROFILE_SPECIFIER = LaKiite Prod Distribution" >> Dart-Defines.xcconfig
+          echo "PROVISIONING_PROFILE_SPECIFIER = LaKiite Prod App Store" >> Dart-Defines.xcconfig
           echo "CODE_SIGN_STYLE = Manual" >> Dart-Defines.xcconfig
           echo "DEVELOPMENT_TEAM = ${{ secrets.APPLE_TEAM_ID }}" >> Dart-Defines.xcconfig
           echo "CODE_SIGN_IDENTITY = Apple Distribution" >> Dart-Defines.xcconfig


### PR DESCRIPTION
## 概要

iOS本番配信workflowで証明書のimportに失敗していたため、署名設定を修正しました。

## 原因

- GitHub Actionsの `Import Code-Signing Certificates` で `security import certificates.p12` が失敗していました。
- ログ上は `MAC verification failed during PKCS12 import (wrong password?)` で、登録済みP12とパスワードの不一致が原因です。
- さらに、workflow側の `PROVISIONING_PROFILE_SPECIFIER` が `LaKiite Prod Distribution`、export plist側が `LaKiite Prod App Store` で不一致でした。

## 対応内容

- prod environment secret の `IOS_CERTIFICATES_P12_BASE64` / `IOS_CERTIFICATES_P12_PASSWORD` を、ローカルの有効な Apple Distribution identity から再生成したP12で更新しました。
- CIの一時キーチェーンに `security set-key-partition-list` を追加し、codesignが秘密鍵へアクセスできるようにしました。
- `PROVISIONING_PROFILE_SPECIFIER` を `LaKiite Prod App Store` に統一しました。

## 検証

- ローカルで生成したP12を一時キーチェーンへimportし、`Apple Distribution: Keisuke Shimizu (T6ZYALKC4V)` が含まれることを確認しました。
- `ruby` によるworkflow YAML読み込み確認済みです。
- `git diff --check` 済みです。

## 補足

このPRをmerge後、`[Release] Prod iOS` workflowを `main` から再実行し、TestFlightアップロードまで進むか確認します。