### PR TITLE
iOS本番CIで署名設定を消さないよう修正

### DIFF
--- a/.github/workflows/deploy_prod_ios.yml
+++ b/.github/workflows/deploy_prod_ios.yml
@@ -92,8 +92,12 @@ jobs:
         run: echo "LATEST_COMMIT_MESSAGES=$(git log -n 10 --pretty=format:'%s' | tr '\n' '; ')" >> $GITHUB_ENV
 
       - name: Setup App Store Connect API Key
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
         run: |
-          echo "${{ secrets.ASC_PRIVATE_KEY_P8_BASE64 }}" | base64 -d > AuthKey.p8
+          mkdir -p private_keys
+          echo "${{ secrets.ASC_PRIVATE_KEY_P8_BASE64 }}" | base64 -d > "private_keys/AuthKey_${ASC_KEY_ID}.p8"
+          chmod 600 "private_keys/AuthKey_${ASC_KEY_ID}.p8"
 
       - name: Upload to TestFlight
         run: |
@@ -102,5 +106,4 @@ jobs:
             -t ios \
             -f "$IPA_FILE" \
             --apiKey "${{ secrets.ASC_KEY_ID }}" \
-            --apiIssuer "${{ secrets.ASC_ISSUER_ID }}" \
-            --apiKeyFile AuthKey.p8
+            --apiIssuer "${{ secrets.ASC_ISSUER_ID }}"

--- a/.github/workflows/deploy_prod_ios.yml
+++ b/.github/workflows/deploy_prod_ios.yml
@@ -60,26 +60,14 @@ jobs:
 
       - name: Prepare Xcode build settings for Distribution
         run: |
-          # ios/project.pbxproj を上書きする設定を Dart-Defines.xcconfig に書き込む。
-          touch Dart-Defines.xcconfig
-          echo "PROVISIONING_PROFILE_SPECIFIER = LaKiite Prod App Store" >> Dart-Defines.xcconfig
-          echo "CODE_SIGN_STYLE = Manual" >> Dart-Defines.xcconfig
-          echo "DEVELOPMENT_TEAM = ${{ secrets.APPLE_TEAM_ID }}" >> Dart-Defines.xcconfig
-          echo "CODE_SIGN_IDENTITY = Apple Distribution" >> Dart-Defines.xcconfig
-          mv Dart-Defines.xcconfig ios/Flutter/
-
           # ios/ExportOptions.plist を ProdExportOptions.plist からコピーして作成する。
           cp ios/ProdExportOptions.plist ios/ExportOptions.plist
 
-          # ios/project.pbxproj から関連する設定を削除する。
-          sed -i '' '/PROVISIONING_PROFILE_SPECIFIER = /d' ios/Runner.xcodeproj/project.pbxproj
-          sed -i '' '/CODE_SIGN_STYLE = /d' ios/Runner.xcodeproj/project.pbxproj
-          sed -i '' '/DEVELOPMENT_TEAM = /d' ios/Runner.xcodeproj/project.pbxproj
-          sed -i '' '/CODE_SIGN_IDENTITY = /d' ios/Runner.xcodeproj/project.pbxproj
-          sed -i '' '/CODE_SIGN_IDENTITY\[sdk=iphoneos\*\] = /d' ios/Runner.xcodeproj/project.pbxproj
-
-          # 最終的な Dart-Defines.xcconfig の内容を表示
-          cat ios/Flutter/Dart-Defines.xcconfig
+          # Release-prod の署名設定が残っていることをCIログで確認する。
+          xcodebuild -project ios/Runner.xcodeproj \
+            -scheme prod \
+            -configuration Release-prod \
+            -showBuildSettings | grep -E "PRODUCT_BUNDLE_IDENTIFIER|DEVELOPMENT_TEAM|CODE_SIGN_STYLE|CODE_SIGN_IDENTITY|PROVISIONING_PROFILE_SPECIFIER"
 
       - name: Calculate Build Number
         id: calculate_build_number

--- a/.github/workflows/deploy_prod_ios.yml
+++ b/.github/workflows/deploy_prod_ios.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-26
     timeout-minutes: 45
     environment: prod
 
@@ -18,7 +18,7 @@ jobs:
         run: |
           xcode-select -p
           xcodebuild -version
-          echo "Using default Xcode for Xcode 16 compatibility"
+          echo "Using default Xcode for iOS 26 SDK upload compliance"
 
       - name: Setup CI
         uses: ./.github/actions/setup

--- a/.github/workflows/deploy_prod_ios.yml
+++ b/.github/workflows/deploy_prod_ios.yml
@@ -25,7 +25,9 @@ jobs:
 
       - name: Restore Firebase config files
         run: |
-          echo "${{ secrets.PROD_GOOGLESERVICE_INFO_PLIST_BASE64 }}" | base64 -d > ios/Runner/GoogleService-Info.plist
+          echo "${{ secrets.PROD_GOOGLESERVICE_INFO_PLIST_BASE64 }}" | base64 -d > ios/Runner/Firebase/Prod/GoogleService-Info.plist
+          cp ios/Runner/Firebase/Prod/GoogleService-Info.plist ios/Runner/GoogleService-Info.plist
+          echo "${{ secrets.PROD_FIREBASE_OPTIONS_DART_BASE64 }}" | base64 -d > lib/firebase_options.dart
 
       - name: Restore dart-define config
         run: |


### PR DESCRIPTION
## 概要

iOS本番配信workflowで `Release-prod` の署名設定を削除していた処理を取り除きました。

## 原因

PR #134 merge後の `[Release] Prod iOS` 実行では、`--flavor prod` が効いて `Archiving com.inoworl.lakiite...` まで進みました。

一方で `flutter build ipa` は `Signing for "Runner" requires a development team` で失敗しました。workflow内で `PROVISIONING_PROFILE_SPECIFIER` / `CODE_SIGN_STYLE` / `DEVELOPMENT_TEAM` / `CODE_SIGN_IDENTITY` を `Dart-Defines.xcconfig` に書いていましたが、`Release.xcconfig` はこのファイルを読み込んでいません。その後の `sed` により、`project.pbxproj` に存在していた `Release-prod` の署名設定まで削除され、Xcode archive時に Development Team が空扱いになっていました。

## 対応内容

- 未使用の `Dart-Defines.xcconfig` への署名設定書き込みを削除
- `project.pbxproj` から署名設定を削除する `sed` 処理を削除
- CIログで `Release-prod` の署名 build settings を確認できるよう、`xcodebuild -showBuildSettings` の確認出力を追加

## 検証

- workflow YAML構文確認済み
- `git diff --check` 済み
- ローカルで `xcodebuild -project ios/Runner.xcodeproj -scheme prod -configuration Release-prod -showBuildSettings` を実行し、以下が確認できました。
  - `PRODUCT_BUNDLE_IDENTIFIER = com.inoworl.lakiite`
  - `DEVELOPMENT_TEAM = T6ZYALKC4V`
  - `CODE_SIGN_STYLE = Manual`
  - `CODE_SIGN_IDENTITY = Apple Distribution`
  - `PROVISIONING_PROFILE_SPECIFIER = LaKiite Prod App Store`

## 次の確認

merge後に `[Release] Prod iOS` workflowを `main` から再実行し、IPAビルドとTestFlightアップロードまで確認します。