### PR TITLE
iOS TestFlightアップロードでフレーバー別アイコンを使う

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -19,8 +19,8 @@ platform :ios do
   lane :dev do
     # Set environment-specific configuration
     ENV["APP_IDENTIFIER"] = "com.inoworl.lakiite.dev"
-    ENV["SCHEME"] = "Runner"
-    ENV["CONFIGURATION"] = "Release"
+    ENV["SCHEME"] = "dev"
+    ENV["CONFIGURATION"] = "Release-dev"
 
     # Skip prepare_build due to Flutter SDK permission issues
     # prepare_build
@@ -37,8 +37,8 @@ platform :ios do
   lane :prod do
     # Set environment-specific configuration
     ENV["APP_IDENTIFIER"] = "com.inoworl.lakiite"
-    ENV["SCHEME"] = "Runner"
-    ENV["CONFIGURATION"] = "Release"
+    ENV["SCHEME"] = "prod"
+    ENV["CONFIGURATION"] = "Release-prod"
 
     prepare_build
     build_and_upload_prod
@@ -186,8 +186,8 @@ platform :ios do
     # Build and sign the app using fastlane
     build_app(
       workspace: "Runner.xcworkspace",
-      scheme: "Runner",
-      configuration: "Release-dev",
+      scheme: ENV["SCHEME"],
+      configuration: ENV["CONFIGURATION"],
       export_method: "app-store",
       output_directory: "./build",
       output_name: "#{ipa_output_name}.ipa",
@@ -271,7 +271,7 @@ platform :ios do
 
   private_lane :build_and_upload_prod do
     # Build Flutter iOS app for Production
-    sh "cd .. && fvm flutter build ios --release --dart-define-from-file=dart_define/prod_dart_define.json"
+    sh "cd .. && fvm flutter build ios --release --flavor prod --dart-define-from-file=dart_define/prod_dart_define.json"
 
     # Build and archive with locale fix
     ENV["LANG"] = "en_US.UTF-8"
@@ -279,8 +279,9 @@ platform :ios do
     ENV["LC_ALL"] = "en_US.UTF-8"
 
     build_app(
+      workspace: "Runner.xcworkspace",
       scheme: ENV["SCHEME"],
-      configuration: "Release",
+      configuration: ENV["CONFIGURATION"],
       export_method: "app-store",
       clean: true,
       output_directory: "./build",

--- a/test/utils/ios_app_icon_config_test.dart
+++ b/test/utils/ios_app_icon_config_test.dart
@@ -1,0 +1,112 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const xcodeProjectPath = 'ios/Runner.xcodeproj/project.pbxproj';
+  const fastfilePath = 'ios/fastlane/Fastfile';
+
+  test('iOS flavor build configurations use matching app icon sets', () {
+    final project = File(xcodeProjectPath).readAsStringSync();
+
+    _expectBuildConfigurationIcon(
+      project,
+      configurationName: 'Debug-dev',
+      expectedIconName: 'AppIcon-development',
+    );
+    _expectBuildConfigurationIcon(
+      project,
+      configurationName: 'Release-dev',
+      expectedIconName: 'AppIcon-development',
+    );
+    _expectBuildConfigurationIcon(
+      project,
+      configurationName: 'Profile-dev',
+      expectedIconName: 'AppIcon-development',
+    );
+    _expectBuildConfigurationIcon(
+      project,
+      configurationName: 'Debug-prod',
+      expectedIconName: 'AppIcon-production',
+    );
+    _expectBuildConfigurationIcon(
+      project,
+      configurationName: 'Release-prod',
+      expectedIconName: 'AppIcon-production',
+    );
+    _expectBuildConfigurationIcon(
+      project,
+      configurationName: 'Profile-prod',
+      expectedIconName: 'AppIcon-production',
+    );
+  });
+
+  test('fastlane uploads use flavor-specific iOS schemes', () {
+    final fastfile = File(fastfilePath).readAsStringSync();
+
+    expect(fastfile, contains('ENV["SCHEME"] = "dev"'));
+    expect(fastfile, contains('ENV["CONFIGURATION"] = "Release-dev"'));
+    expect(fastfile, contains('ENV["SCHEME"] = "prod"'));
+    expect(fastfile, contains('ENV["CONFIGURATION"] = "Release-prod"'));
+    expect(
+      fastfile,
+      contains(
+        'flutter build ios --release --flavor prod '
+        '--dart-define-from-file=dart_define/prod_dart_define.json',
+      ),
+    );
+  });
+}
+
+void _expectBuildConfigurationIcon(
+  String project, {
+  required String configurationName,
+  required String expectedIconName,
+}) {
+  final icons = _targetBuildConfigurations(project)
+      .where((settings) => settings['name'] == configurationName)
+      .map((settings) => settings['ASSETCATALOG_COMPILER_APPICON_NAME'])
+      .whereType<String>()
+      .toSet();
+
+  expect(
+    icons,
+    {expectedIconName},
+    reason:
+        '$configurationName must archive with $expectedIconName for App Store Connect.',
+  );
+}
+
+List<Map<String, String>> _targetBuildConfigurations(String project) {
+  final configurationBlocks = RegExp(
+    r'buildSettings = \{(?<settings>[\s\S]*?)\n\t+\};\n\t+\tname = (?<name>"?[^";]+"?);',
+  ).allMatches(project);
+
+  final result = <Map<String, String>>[];
+
+  for (final match in configurationBlocks) {
+    final settings = match.namedGroup('settings')!;
+    if (!settings.contains('PRODUCT_BUNDLE_IDENTIFIER')) {
+      continue;
+    }
+
+    result.add({
+      'name': match.namedGroup('name')!.replaceAll('"', ''),
+      'ASSETCATALOG_COMPILER_APPICON_NAME': _extractBuildSetting(
+        settings,
+        'ASSETCATALOG_COMPILER_APPICON_NAME',
+      ),
+    });
+  }
+
+  return result;
+}
+
+String _extractBuildSetting(String settings, String key) {
+  final match = RegExp('$key = "?([^";]+)"?;').firstMatch(settings);
+  if (match == null) {
+    return '';
+  }
+
+  return match.group(1)!;
+}


### PR DESCRIPTION
## 概要
- iOSのfastlane dev/prod laneを、それぞれdev/prod schemeとRelease-dev/Release-prod構成でビルドするよう修正
- 本番iOSビルドに --flavor prod を明示し、App Store Connectに反映されるApp Iconが本番用になるように修正
- Xcode build settingsとfastlane設定の組み合わせを検証するテストを追加

## 確認
- fvm flutter test test/utils/ios_app_icon_config_test.dart test/utils/ios_admob_app_id_config_test.dart
- xcodebuildでprod/Release-prodがAppIcon-productionとcom.inoworl.lakiiteを使うことを確認
- xcodebuildでdev/Release-devがAppIcon-developmentとcom.inoworl.lakiite.devを使うことを確認

## 補足
- App Store Connectのアプリ一覧・アプリメニューのアイコンは、次回この修正を含むビルドをアップロードしてApple側の処理が完了した後に反映されます。