### PR TITLE
fix: Android prodのPush通知を複数FCMトークン対応に修正

### DIFF
--- a/lib/infrastructure/firebase/push_notification_sender.dart
+++ b/lib/infrastructure/firebase/push_notification_sender.dart
@@ -10,14 +10,30 @@ import '../../config/app_config.dart';
 /// Cloud FunctionsにPOSTリクエストを送信して通知を配信します
 /// 実際の実装ではCloud Functions側で認証とセキュリティチェックを行う必要があります
 class PushNotificationSender {
-  PushNotificationSender({
+  factory PushNotificationSender({
     String? cloudFunctionUrl,
     UserFcmTokenService? fcmTokenService,
-  })  : _cloudFunctionUrl =
-            cloudFunctionUrl ?? AppConfig.instance.pushNotificationUrl,
-        _fcmTokenService = fcmTokenService ?? UserFcmTokenService();
+    Future<List<String>> Function(String userId)? tokenResolver,
+    http.Client? httpClient,
+  }) {
+    final resolvedTokenResolver = tokenResolver ??
+        (fcmTokenService ?? UserFcmTokenService()).getUserFcmTokens;
+    return PushNotificationSender._(
+      cloudFunctionUrl ?? AppConfig.instance.pushNotificationUrl,
+      resolvedTokenResolver,
+      httpClient ?? http.Client(),
+    );
+  }
+
+  PushNotificationSender._(
+    this._cloudFunctionUrl,
+    this._tokenResolver,
+    this._httpClient,
+  );
+
   final String _cloudFunctionUrl;
-  final UserFcmTokenService _fcmTokenService;
+  final Future<List<String>> Function(String userId) _tokenResolver;
+  final http.Client _httpClient;
   static const int _tokenPreviewLength = 20;
 
   Future<bool> sendFriendRequestNotification({
@@ -139,18 +155,38 @@ class PushNotificationSender {
     required Map<String, dynamic> data,
   }) async {
     try {
-      final token = await _fetchRecipientToken(toUserId, logContext);
-      if (token == null) {
+      final tokens = await _fetchRecipientTokens(toUserId, logContext);
+      if (tokens.isEmpty) {
         return false;
       }
 
-      final payload = {
-        'token': token,
-        'notification': notificationBody,
-        'data': data,
-      };
+      var successCount = 0;
+      for (final token in tokens) {
+        final payload = {
+          'token': token,
+          'notification': notificationBody,
+          'data': data,
+        };
 
-      return await _postNotification(payload, logContext);
+        final didSend = await _postNotification(payload, logContext, token);
+        if (didSend) {
+          successCount++;
+        }
+      }
+
+      if (successCount == 0) {
+        AppLogger.error('$logContext 送信失敗: 全${tokens.length}件のトークンで失敗');
+        return false;
+      }
+
+      if (successCount < tokens.length) {
+        AppLogger.warning(
+            '$logContext 一部送信成功: $successCount/${tokens.length}件');
+      } else {
+        AppLogger.debug('$logContext 全トークン送信成功: $successCount件');
+      }
+
+      return true;
     } catch (e, stack) {
       AppLogger.error('$logContext 送信例外: $e');
       AppLogger.error('スタックトレース: $stack');
@@ -158,20 +194,26 @@ class PushNotificationSender {
     }
   }
 
-  Future<String?> _fetchRecipientToken(String userId, String logContext) async {
-    AppLogger.info('🔍 $logContext: 宛先ユーザーのFCMトークンを取得中...');
-    final token = await _fcmTokenService.getUserFcmToken(userId);
-    if (token == null) {
+  Future<List<String>> _fetchRecipientTokens(
+      String userId, String logContext) async {
+    AppLogger.info('🔍 $logContext: 宛先ユーザーのFCMトークン一覧を取得中...');
+    final tokens = _deduplicateTokens(await _tokenResolver(userId));
+    if (tokens.isEmpty) {
       AppLogger.warning('❌ $logContext: 宛先ユーザーのFCMトークンがありません - $userId');
-      return null;
+      return const [];
     }
-    AppLogger.info('✅ $logContext: FCMトークン取得成功: ${_previewToken(token)}');
-    return token;
+
+    AppLogger.info(
+        '✅ $logContext: FCMトークン取得成功: ${tokens.length}件 (${tokens.map(_previewToken).join(', ')})');
+    return tokens;
   }
 
   Future<bool> _postNotification(
-      Map<String, dynamic> payload, String logContext) async {
-    final response = await http.post(
+    Map<String, dynamic> payload,
+    String logContext,
+    String token,
+  ) async {
+    final response = await _httpClient.post(
       Uri.parse(_cloudFunctionUrl),
       headers: {
         'Content-Type': 'application/json',
@@ -180,13 +222,18 @@ class PushNotificationSender {
     );
 
     if (response.statusCode == 200) {
-      AppLogger.debug('$logContext 送信成功: ${response.body}');
+      AppLogger.debug(
+          '$logContext 送信成功: ${_previewToken(token)} ${response.body}');
       return true;
     }
 
     AppLogger.error(
-        '$logContext 送信エラー: ${response.statusCode} - ${response.body}');
+        '$logContext 送信エラー: ${_previewToken(token)} ${response.statusCode} - ${response.body}');
     return false;
+  }
+
+  List<String> _deduplicateTokens(List<String> tokens) {
+    return tokens.where((token) => token.isNotEmpty).toSet().toList();
   }
 
   String _previewToken(String token) {

--- a/lib/infrastructure/user_fcm_token_service.dart
+++ b/lib/infrastructure/user_fcm_token_service.dart
@@ -1,5 +1,8 @@
+import 'dart:io';
+
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/foundation.dart';
 import '../infrastructure/firebase/push_notification_service.dart';
 import '../utils/logger.dart';
 import '../utils/notification_token_log_formatter.dart';
@@ -15,6 +18,14 @@ class UserFcmTokenService {
   final FirebaseFirestore _firestore;
   final FirebaseAuth _auth;
   final PushNotificationService _pushNotificationService;
+
+  static const String _legacyTokenField = 'fcmToken';
+  static const String _tokenPlatformField = 'fcmTokenPlatform';
+  static const String _tokenUpdatedAtField = 'fcmTokenUpdatedAt';
+  static const String _tokensField = 'fcmTokens';
+  static const String _tokenValueField = 'token';
+  static const String _platformField = 'platform';
+  static const String _updatedAtField = 'updatedAt';
 
   /// 現在のユーザーのFCMトークンを更新する
   Future<bool> updateCurrentUserFcmToken() async {
@@ -34,10 +45,21 @@ class UserFcmTokenService {
       AppLogger.debug(
           'FCMトークン更新: ユーザーID=${user.uid}, トークン=${maskNotificationToken(token)}');
 
-      // Firebase Functionsが参照する場所（users/{userId}直下）に保存
-      // updateではなくsetを使用してドキュメントが存在しない場合でも確実に保存
+      final platform = _currentPlatformKey();
+
+      // Firebase Functionsが参照する従来フィールドは後方互換のため維持しつつ、
+      // iOS/Androidのトークン上書きを避けるためplatform別にも保存する。
       await _firestore.collection('users').doc(user.uid).set({
-        'fcmToken': token,
+        _legacyTokenField: token,
+        _tokenPlatformField: platform,
+        _tokenUpdatedAtField: FieldValue.serverTimestamp(),
+        _tokensField: {
+          platform: {
+            _tokenValueField: token,
+            _platformField: platform,
+            _updatedAtField: FieldValue.serverTimestamp(),
+          },
+        },
       }, SetOptions(merge: true));
 
       AppLogger.debug('FCMトークン更新: 完了');
@@ -70,17 +92,23 @@ class UserFcmTokenService {
           return;
         }
 
-        // fcmTokenフィールドが存在するか確認
+        final platform = _currentPlatformKey();
+        final token = await _pushNotificationService.refreshToken();
+        final updates = <String, dynamic>{
+          '$_tokensField.$platform': FieldValue.delete(),
+        };
+
         final data = docSnapshot.data();
-        if (data == null || !data.containsKey('fcmToken')) {
-          AppLogger.warning('FCMトークン削除: fcmTokenフィールドが存在しません');
-          return; // 既に削除されているか存在しない場合は何もしない
+        if (data != null &&
+            token != null &&
+            data[_legacyTokenField] is String &&
+            data[_legacyTokenField] == token) {
+          updates[_legacyTokenField] = FieldValue.delete();
+          updates[_tokenPlatformField] = FieldValue.delete();
+          updates[_tokenUpdatedAtField] = FieldValue.delete();
         }
 
-        // トークンを削除（Firebase Functionsが参照する場所）
-        await docRef.update({
-          'fcmToken': FieldValue.delete(),
-        });
+        await docRef.update(updates);
 
         AppLogger.debug('FCMトークン削除: 完了');
       } catch (e) {
@@ -132,5 +160,81 @@ class UserFcmTokenService {
       AppLogger.error('スタックトレース: $stack');
       return null;
     }
+  }
+
+  /// 特定ユーザーに紐づくFCMトークンを全platform分取得する。
+  ///
+  /// 旧実装の `fcmToken` も読み込むため、既存データやFunctionsとの後方互換を保てる。
+  Future<List<String>> getUserFcmTokens(String userId) async {
+    try {
+      AppLogger.debug('FCMトークン一覧取得: ユーザーID=$userId');
+
+      final doc = await _firestore.collection('users').doc(userId).get();
+      if (!doc.exists) {
+        AppLogger.warning('FCMトークン一覧取得: ユーザーが存在しません - $userId');
+        return const [];
+      }
+
+      final tokens = extractFcmTokens(doc.data());
+      AppLogger.debug(
+          'FCMトークン一覧取得: ${tokens.length}件 (${tokens.map(maskNotificationToken).join(', ')})');
+      return tokens;
+    } catch (e, stack) {
+      AppLogger.error('FCMトークン一覧取得エラー: $e');
+      AppLogger.error('スタックトレース: $stack');
+      return const [];
+    }
+  }
+
+  @visibleForTesting
+  static List<String> extractFcmTokens(Map<String, dynamic>? data) {
+    if (data == null) {
+      return const [];
+    }
+
+    final tokens = <String>{};
+
+    final platformTokens = data[_tokensField];
+    if (platformTokens is Map) {
+      for (final entry in platformTokens.values) {
+        if (entry is String && entry.isNotEmpty) {
+          tokens.add(entry);
+        } else if (entry is Map) {
+          final token = entry[_tokenValueField];
+          if (token is String && token.isNotEmpty) {
+            tokens.add(token);
+          }
+        }
+      }
+    }
+
+    final legacyToken = data[_legacyTokenField];
+    if (legacyToken is String && legacyToken.isNotEmpty) {
+      tokens.add(legacyToken);
+    }
+
+    return tokens.toList(growable: false);
+  }
+
+  static String _currentPlatformKey() {
+    if (kIsWeb) {
+      return 'web';
+    }
+    if (Platform.isAndroid) {
+      return 'android';
+    }
+    if (Platform.isIOS) {
+      return 'ios';
+    }
+    if (Platform.isMacOS) {
+      return 'macos';
+    }
+    if (Platform.isWindows) {
+      return 'windows';
+    }
+    if (Platform.isLinux) {
+      return 'linux';
+    }
+    return 'unknown';
   }
 }

--- a/lib/infrastructure/user_fcm_token_service.dart
+++ b/lib/infrastructure/user_fcm_token_service.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/foundation.dart';
@@ -19,13 +17,7 @@ class UserFcmTokenService {
   final FirebaseAuth _auth;
   final PushNotificationService _pushNotificationService;
 
-  static const String _legacyTokenField = 'fcmToken';
-  static const String _tokenPlatformField = 'fcmTokenPlatform';
-  static const String _tokenUpdatedAtField = 'fcmTokenUpdatedAt';
   static const String _tokensField = 'fcmTokens';
-  static const String _tokenValueField = 'token';
-  static const String _platformField = 'platform';
-  static const String _updatedAtField = 'updatedAt';
 
   /// 現在のユーザーのFCMトークンを更新する
   Future<bool> updateCurrentUserFcmToken() async {
@@ -45,21 +37,10 @@ class UserFcmTokenService {
       AppLogger.debug(
           'FCMトークン更新: ユーザーID=${user.uid}, トークン=${maskNotificationToken(token)}');
 
-      final platform = _currentPlatformKey();
-
-      // Firebase Functionsが参照する従来フィールドは後方互換のため維持しつつ、
-      // iOS/Androidのトークン上書きを避けるためplatform別にも保存する。
+      // ZENと同じく、複数端末のトークンを配列で保持する。
+      // 単一fcmTokenフィールドは使わず、iOS/Androidや複数端末の上書きを避ける。
       await _firestore.collection('users').doc(user.uid).set({
-        _legacyTokenField: token,
-        _tokenPlatformField: platform,
-        _tokenUpdatedAtField: FieldValue.serverTimestamp(),
-        _tokensField: {
-          platform: {
-            _tokenValueField: token,
-            _platformField: platform,
-            _updatedAtField: FieldValue.serverTimestamp(),
-          },
-        },
+        _tokensField: FieldValue.arrayUnion([token]),
       }, SetOptions(merge: true));
 
       AppLogger.debug('FCMトークン更新: 完了');
@@ -92,23 +73,15 @@ class UserFcmTokenService {
           return;
         }
 
-        final platform = _currentPlatformKey();
         final token = await _pushNotificationService.refreshToken();
-        final updates = <String, dynamic>{
-          '$_tokensField.$platform': FieldValue.delete(),
-        };
-
-        final data = docSnapshot.data();
-        if (data != null &&
-            token != null &&
-            data[_legacyTokenField] is String &&
-            data[_legacyTokenField] == token) {
-          updates[_legacyTokenField] = FieldValue.delete();
-          updates[_tokenPlatformField] = FieldValue.delete();
-          updates[_tokenUpdatedAtField] = FieldValue.delete();
+        if (token == null) {
+          AppLogger.warning('FCMトークン削除: 現在端末のトークンが取得できませんでした');
+          return;
         }
 
-        await docRef.update(updates);
+        await docRef.update({
+          _tokensField: FieldValue.arrayRemove([token]),
+        });
 
         AppLogger.debug('FCMトークン削除: 完了');
       } catch (e) {
@@ -145,13 +118,8 @@ class UserFcmTokenService {
         return null;
       }
 
-      final data = doc.data();
-      if (data == null) {
-        AppLogger.warning('FCMトークン取得: ユーザーデータがありません - $userId');
-        return null;
-      }
-
-      final token = data['fcmToken'] as String?;
+      final tokens = extractFcmTokens(doc.data());
+      final token = tokens.isEmpty ? null : tokens.first;
       AppLogger.debug('FCMトークン取得: トークン=${maskNotificationToken(token)}');
 
       return token;
@@ -162,9 +130,7 @@ class UserFcmTokenService {
     }
   }
 
-  /// 特定ユーザーに紐づくFCMトークンを全platform分取得する。
-  ///
-  /// 旧実装の `fcmToken` も読み込むため、既存データやFunctionsとの後方互換を保てる。
+  /// 特定ユーザーに紐づくFCMトークンを全端末分取得する。
   Future<List<String>> getUserFcmTokens(String userId) async {
     try {
       AppLogger.debug('FCMトークン一覧取得: ユーザーID=$userId');
@@ -194,47 +160,15 @@ class UserFcmTokenService {
 
     final tokens = <String>{};
 
-    final platformTokens = data[_tokensField];
-    if (platformTokens is Map) {
-      for (final entry in platformTokens.values) {
-        if (entry is String && entry.isNotEmpty) {
-          tokens.add(entry);
-        } else if (entry is Map) {
-          final token = entry[_tokenValueField];
-          if (token is String && token.isNotEmpty) {
-            tokens.add(token);
-          }
+    final rawTokens = data[_tokensField];
+    if (rawTokens is Iterable) {
+      for (final token in rawTokens) {
+        if (token is String && token.isNotEmpty) {
+          tokens.add(token);
         }
       }
     }
 
-    final legacyToken = data[_legacyTokenField];
-    if (legacyToken is String && legacyToken.isNotEmpty) {
-      tokens.add(legacyToken);
-    }
-
     return tokens.toList(growable: false);
-  }
-
-  static String _currentPlatformKey() {
-    if (kIsWeb) {
-      return 'web';
-    }
-    if (Platform.isAndroid) {
-      return 'android';
-    }
-    if (Platform.isIOS) {
-      return 'ios';
-    }
-    if (Platform.isMacOS) {
-      return 'macos';
-    }
-    if (Platform.isWindows) {
-      return 'windows';
-    }
-    if (Platform.isLinux) {
-      return 'linux';
-    }
-    return 'unknown';
   }
 }

--- a/lib/presentation/debug/debug_notification_page.dart
+++ b/lib/presentation/debug/debug_notification_page.dart
@@ -17,7 +17,7 @@ class DebugNotificationPage extends StatefulWidget {
 
 class _DebugNotificationPageState extends State<DebugNotificationPage> {
   String? _fcmToken;
-  String? _firestoreToken;
+  List<String> _firestoreTokens = const [];
   String? _currentUserId;
   bool _isLoading = false;
   bool _isSimulator = false;
@@ -109,7 +109,7 @@ class _DebugNotificationPageState extends State<DebugNotificationPage> {
       }
 
       // Firestoreに保存されているトークンを取得
-      String? firestoreToken;
+      var firestoreTokens = const <String>[];
       try {
         final userDoc = await FirebaseFirestore.instance
             .collection('users')
@@ -117,7 +117,14 @@ class _DebugNotificationPageState extends State<DebugNotificationPage> {
             .get();
 
         if (userDoc.exists) {
-          firestoreToken = userDoc.data()?['fcmToken'];
+          final rawTokens = userDoc.data()?['fcmTokens'];
+          if (rawTokens is Iterable) {
+            firestoreTokens = rawTokens
+                .whereType<String>()
+                .where((token) => token.isNotEmpty)
+                .toSet()
+                .toList(growable: false);
+          }
         }
       } catch (e) {
         AppLogger.error('Firestoreからのトークン取得エラー: $e');
@@ -125,7 +132,7 @@ class _DebugNotificationPageState extends State<DebugNotificationPage> {
 
       setState(() {
         _fcmToken = token;
-        _firestoreToken = firestoreToken;
+        _firestoreTokens = firestoreTokens;
 
         // デバッグ情報を生成
         _debugInfo = _generateDebugInfo();
@@ -192,11 +199,11 @@ class _DebugNotificationPageState extends State<DebugNotificationPage> {
 
     buffer.writeln('');
     buffer.writeln('🗄️ Firestore保存状況:');
-    if (_firestoreToken != null) {
+    if (_firestoreTokens.isNotEmpty) {
       buffer.writeln('✅ Firestoreにトークン保存済み');
-      buffer.writeln('保存済みトークン長: ${_firestoreToken!.length}文字');
+      buffer.writeln('保存済みトークン数: ${_firestoreTokens.length}件');
 
-      if (_fcmToken != null && _fcmToken == _firestoreToken) {
+      if (_fcmToken != null && _firestoreTokens.contains(_fcmToken)) {
         buffer.writeln('✅ トークン一致: OK');
       } else {
         buffer.writeln('⚠️ トークン不一致: 要更新');
@@ -483,10 +490,11 @@ class _DebugNotificationPageState extends State<DebugNotificationPage> {
                           ),
                         ),
                         const Spacer(),
-                        if (_firestoreToken != null)
+                        if (_firestoreTokens.isNotEmpty)
                           IconButton(
                             icon: const Icon(Icons.copy),
-                            onPressed: () => _copyToClipboard(_firestoreToken!),
+                            onPressed: () =>
+                                _copyToClipboard(_firestoreTokens.join('\n')),
                             tooltip: 'コピー',
                           ),
                       ],
@@ -496,26 +504,30 @@ class _DebugNotificationPageState extends State<DebugNotificationPage> {
                       width: double.infinity,
                       padding: const EdgeInsets.all(12),
                       decoration: BoxDecoration(
-                        color: _firestoreToken != null
-                            ? (_fcmToken == _firestoreToken
+                        color: _firestoreTokens.isNotEmpty
+                            ? (_fcmToken != null &&
+                                    _firestoreTokens.contains(_fcmToken)
                                 ? Colors.green.shade50
                                 : Colors.orange.shade50)
                             : Colors.red.shade50,
                         borderRadius: BorderRadius.circular(8),
                         border: Border.all(
-                          color: _firestoreToken != null
-                              ? (_fcmToken == _firestoreToken
+                          color: _firestoreTokens.isNotEmpty
+                              ? (_fcmToken != null &&
+                                      _firestoreTokens.contains(_fcmToken)
                                   ? Colors.green.shade300
                                   : Colors.orange.shade300)
                               : Colors.red.shade300,
                         ),
                       ),
                       child: SelectableText(
-                        _firestoreToken ?? 'Firestoreにトークンが保存されていません',
+                        _firestoreTokens.isEmpty
+                            ? 'Firestoreにトークンが保存されていません'
+                            : _firestoreTokens.join('\n'),
                         style: TextStyle(
                           fontFamily: 'monospace',
                           fontSize: 12,
-                          color: _firestoreToken != null
+                          color: _firestoreTokens.isNotEmpty
                               ? Colors.black87
                               : Colors.red,
                         ),

--- a/test/infrastructure/push_notification_sender_test.dart
+++ b/test/infrastructure/push_notification_sender_test.dart
@@ -1,0 +1,89 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:lakiite/infrastructure/firebase/push_notification_sender.dart';
+
+void main() {
+  group('PushNotificationSender', () {
+    test('宛先ユーザーの全FCMトークンへ通知を送る', () async {
+      final postedPayloads = <Map<String, dynamic>>[];
+      final sender = PushNotificationSender(
+        cloudFunctionUrl: 'https://example.com/sendNotification',
+        tokenResolver: (_) async => [
+          'android-token',
+          'ios-token',
+          'android-token',
+        ],
+        httpClient: MockClient((request) async {
+          postedPayloads.add(jsonDecode(request.body) as Map<String, dynamic>);
+          return http.Response('{"success":true}', 200);
+        }),
+      );
+
+      final result = await sender.sendFriendRequestNotification(
+        toUserId: 'to-user',
+        fromUserId: 'from-user',
+        fromUserName: '送信者',
+      );
+
+      expect(result, isTrue);
+      expect(postedPayloads, hasLength(2));
+      expect(postedPayloads.map((payload) => payload['token']),
+          ['android-token', 'ios-token']);
+      final firstData = postedPayloads.first['data'] as Map<String, dynamic>;
+      expect(firstData['type'], 'friend_request');
+    });
+
+    test('一部のトークン送信に失敗しても1件以上成功すれば成功扱いにする', () async {
+      var requestCount = 0;
+      final sender = PushNotificationSender(
+        cloudFunctionUrl: 'https://example.com/sendNotification',
+        tokenResolver: (_) async => ['android-token', 'ios-token'],
+        httpClient: MockClient((request) async {
+          requestCount++;
+          final payload = jsonDecode(request.body) as Map<String, dynamic>;
+          if (payload['token'] == 'android-token') {
+            return http.Response('server error', 500);
+          }
+          return http.Response('{"success":true}', 200);
+        }),
+      );
+
+      final result = await sender.sendReactionNotification(
+        toUserId: 'to-user',
+        fromUserId: 'from-user',
+        fromUserName: '送信者',
+        scheduleId: 'schedule-id',
+        interactionId: 'reaction-id',
+      );
+
+      expect(result, isTrue);
+      expect(requestCount, 2);
+    });
+
+    test('FCMトークンがない場合は送信しない', () async {
+      var didPost = false;
+      final sender = PushNotificationSender(
+        cloudFunctionUrl: 'https://example.com/sendNotification',
+        tokenResolver: (_) async => [],
+        httpClient: MockClient((request) async {
+          didPost = true;
+          return http.Response('{"success":true}', 200);
+        }),
+      );
+
+      final result = await sender.sendGroupInvitationNotification(
+        toUserId: 'to-user',
+        fromUserId: 'from-user',
+        fromUserName: '送信者',
+        groupId: 'group-id',
+        groupName: 'group',
+      );
+
+      expect(result, isFalse);
+      expect(didPost, isFalse);
+    });
+  });
+}

--- a/test/infrastructure/user_fcm_token_service_test.dart
+++ b/test/infrastructure/user_fcm_token_service_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lakiite/infrastructure/user_fcm_token_service.dart';
+
+void main() {
+  group('UserFcmTokenService.extractFcmTokens', () {
+    test('platform別トークンとlegacyトークンを重複排除して返す', () {
+      final tokens = UserFcmTokenService.extractFcmTokens({
+        'fcmToken': 'legacy-ios-token',
+        'fcmTokens': {
+          'android': {
+            'token': 'android-token',
+            'platform': 'android',
+          },
+          'ios': {
+            'token': 'legacy-ios-token',
+            'platform': 'ios',
+          },
+        },
+      });
+
+      expect(tokens, ['android-token', 'legacy-ios-token']);
+    });
+
+    test('legacyトークンのみの既存データも読み込める', () {
+      final tokens = UserFcmTokenService.extractFcmTokens({
+        'fcmToken': 'legacy-token',
+      });
+
+      expect(tokens, ['legacy-token']);
+    });
+
+    test('空文字や不正な形式は除外する', () {
+      final tokens = UserFcmTokenService.extractFcmTokens({
+        'fcmToken': '',
+        'fcmTokens': {
+          'android': {'token': ''},
+          'ios': {'value': 'missing-token-key'},
+          'web': 'web-token',
+        },
+      });
+
+      expect(tokens, ['web-token']);
+    });
+  });
+}

--- a/test/infrastructure/user_fcm_token_service_test.dart
+++ b/test/infrastructure/user_fcm_token_service_test.dart
@@ -3,40 +3,34 @@ import 'package:lakiite/infrastructure/user_fcm_token_service.dart';
 
 void main() {
   group('UserFcmTokenService.extractFcmTokens', () {
-    test('platform別トークンとlegacyトークンを重複排除して返す', () {
+    test('fcmTokens配列から重複排除して返す', () {
       final tokens = UserFcmTokenService.extractFcmTokens({
-        'fcmToken': 'legacy-ios-token',
-        'fcmTokens': {
-          'android': {
-            'token': 'android-token',
-            'platform': 'android',
-          },
-          'ios': {
-            'token': 'legacy-ios-token',
-            'platform': 'ios',
-          },
-        },
+        'fcmTokens': [
+          'android-token',
+          'ios-token',
+          'android-token',
+        ],
       });
 
-      expect(tokens, ['android-token', 'legacy-ios-token']);
+      expect(tokens, ['android-token', 'ios-token']);
     });
 
-    test('legacyトークンのみの既存データも読み込める', () {
+    test('legacy fcmTokenのみの既存データは読み込まない', () {
       final tokens = UserFcmTokenService.extractFcmTokens({
         'fcmToken': 'legacy-token',
       });
 
-      expect(tokens, ['legacy-token']);
+      expect(tokens, isEmpty);
     });
 
     test('空文字や不正な形式は除外する', () {
       final tokens = UserFcmTokenService.extractFcmTokens({
         'fcmToken': '',
-        'fcmTokens': {
-          'android': {'token': ''},
-          'ios': {'value': 'missing-token-key'},
-          'web': 'web-token',
-        },
+        'fcmTokens': [
+          '',
+          123,
+          'web-token',
+        ],
       });
 
       expect(tokens, ['web-token']);


### PR DESCRIPTION
## 概要
- FCMトークン保存を `users/{uid}.fcmTokens` の配列に統一しました
- ZENと同じく、ログイン/起動時は `arrayUnion` で現在端末のトークンを追加し、ログアウト時は `arrayRemove` で現在端末のトークンだけ削除します
- Push送信時に宛先ユーザーの `fcmTokens` 全件を取得し、iOS/Android/複数端末へ送れるようにしました
- `users/{uid}.fcmToken` の後方互換読み書きは削除しました

## 原因
- これまでFCMトークン保存先が `users/{uid}.fcmToken` の単一フィールドでした
- 同じユーザーでiOSとAndroidにログインすると、最後に保存した端末のトークンで上書きされます
- iOSで通知が来てAndroid prodに来ない場合、Firestore上の宛先トークンがiOS側に寄っている可能性が高い状態でした

## 既にログイン済み端末への影響
- 更新後のアプリ起動/ログイン時にFCMトークン更新が走れば `fcmTokens` に登録されます
- 旧 `fcmToken` は参照しないため、古い単一トークンが残っていても送信対象には入りません
- 本番ユーザーがまだいない前提なので、後方互換は持たせていません

## 確認
- `fvm flutter analyze`
- `fvm flutter test test/application/schedule/schedule_interaction_notifier_test.dart test/infrastructure/user_fcm_token_service_test.dart test/infrastructure/push_notification_sender_test.dart`
- `git diff --check`

## 注意
- この修正はFlutterアプリ内からCloud Function `sendNotification` に送るPush通知を複数トークン対応します
- 前日通知はリリース要件から除外する方針のため、このPRでは対象外です