### PR TITLE
ci: Android prod内部テストを自動公開する

### DIFF
--- a/.github/workflows/deploy_prod_android.yml
+++ b/.github/workflows/deploy_prod_android.yml
@@ -17,9 +17,6 @@ jobs:
       - name: Setup CI
         uses: ./.github/actions/setup
 
-      - name: Install Firebase CLI
-        run: npm install -g firebase-tools
-
       - name: Setup Java
         uses: actions/setup-java@v3.9.0
         with:
@@ -104,9 +101,6 @@ jobs:
             --build-name=$(grep 'version:' pubspec.yaml | cut -d ' ' -f 2 | cut -d '+' -f 1) \
             --build-number="${{ steps.calculate_build_number.outputs.buildNumber }}"
 
-      - name: Get latest 10 commit messages
-        run: echo "LATEST_COMMIT_MESSAGES=$(git log -n 10 --pretty=format:'%s' | tr '\n' '; ')" >> $GITHUB_ENV
-
       - name: Decode Google Play Console API Service Account Key
         run: echo "${{ secrets.GOOGLE_PLAY_CONSOLE_API_SERVICE_ACCOUNT_KEY_JSON_BASE64 }}" | base64 --decode > /tmp/google_play_console_api_service_account_key.json
 
@@ -117,18 +111,4 @@ jobs:
           packageName: ${{ secrets.PROD_ANDROID_PACKAGE_NAME }}
           releaseFiles: build/app/outputs/bundle/prodRelease/app-prod-release.aab
           track: internal
-          status: draft
-
-      # 事前に Firebase プロジェクトの Project Settings > Integrations から Google Play Console と連携しておく必要がある。
-      - name: Deploy to Firebase App Distribution
-        continue-on-error: true
-        env:
-          PROD_FIREBASE_SERVICE_ACCOUNT_KEY_BASE64: ${{ secrets.PROD_FIREBASE_SERVICE_ACCOUNT_KEY_BASE64 }}
-        run: |
-          echo $PROD_FIREBASE_SERVICE_ACCOUNT_KEY_BASE64 | base64 -d > /tmp/prod_firebase_service_account_key.json
-          export GOOGLE_APPLICATION_CREDENTIALS=/tmp/prod_firebase_service_account_key.json
-          firebase use --project ${{ secrets.PROD_FIREBASE_PROJECT_ID }}
-          firebase appdistribution:distribute ./build/app/outputs/bundle/prodRelease/app-prod-release.aab \
-            --app ${{ secrets.PROD_FIREBASE_ANDROID_APP_ID }} \
-            --groups internal-testers  \
-            --release-notes "${LATEST_COMMIT_MESSAGES}"
+          status: completed


### PR DESCRIPTION
## 概要
- Prod Android の Play Console 内部テスト配信を `draft` ではなく `completed` でアップロードするよう変更
- 未連携の Firebase App Distribution へ AAB を配信するステップを削除
- Firebase App Distribution の `This project is not linked to a Google Play account.` エラーがActions上で発生しないよう整理

## 背景
- Actions は成功していたが、Play Console 上では最新versionCodeが未公開リリースとして残っていた
- 原因は `r0adkll/upload-google-play` の `status: draft` 設定
- Prod Android はPlay内部テストを正規のテスト配信経路にするため、Firebase App DistributionへのAAB配信は使わない

## 確認
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy_prod_android.yml"); puts "yaml ok"'`\n- `git diff --check`\n\n## 補足\n- 次回の `[Release] Prod Android` 実行後、内部テストの最新リリースが公開状態で更新される想定\n- 既に未公開で残っている `10385` は、Play Console上で手動公開または次回Actions実行で新しいversionCodeを公開する必要があります