### PR TITLE
fix: Push通知タップと承認/否認の既読化を修正する

### DIFF
--- a/lib/config/router/app_router.dart
+++ b/lib/config/router/app_router.dart
@@ -14,6 +14,7 @@ import '../../presentation/settings/account_deletion_webview_page.dart';
 import '../../presentation/signup/signup.dart';
 import '../../presentation/splash/splash_screen.dart';
 import '../../presentation/presentation_provider.dart';
+import '../../infrastructure/notification_navigation_service.dart';
 
 /// アプリケーションのルーティング設定を提供するプロバイダー
 ///
@@ -30,6 +31,7 @@ final routerProvider = Provider<GoRouter>((ref) {
   final refreshNotifier = ref.watch(goRouterRefreshProvider);
 
   return GoRouter(
+    navigatorKey: NotificationNavigationService.instance.navigatorKey,
     refreshListenable: refreshNotifier,
     initialLocation: SplashScreen.path,
     redirect: (context, state) {

--- a/lib/infrastructure/firebase/push_notification_service.dart
+++ b/lib/infrastructure/firebase/push_notification_service.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import '../../firebase_options.dart';
 import '../user_fcm_token_service.dart';
+import '../notification_navigation_service.dart';
 import '../../utils/logger.dart';
 import '../../utils/notification_token_log_formatter.dart';
 
@@ -433,6 +434,7 @@ class PushNotificationService {
         AppLogger.info('🚀 通知本文: ${message.notification?.body}');
         AppLogger.info('🚀 データペイロード: ${message.data}');
         _handleMessage(message);
+        _openNotificationListFromNotification();
       } else {
         AppLogger.debug('🚀 アプリ起動時に処理すべき通知はありません');
       }
@@ -444,7 +446,12 @@ class PushNotificationService {
       AppLogger.info('👆 通知本文: ${message.notification?.body}');
       AppLogger.info('👆 データペイロード: ${message.data}');
       _handleMessage(message);
+      _openNotificationListFromNotification();
     });
+  }
+
+  void _openNotificationListFromNotification() {
+    NotificationNavigationService.instance.openNotificationList();
   }
 
   bool _isPhysicalDevice() {
@@ -475,7 +482,13 @@ class PushNotificationService {
       android: initializationSettingsAndroid,
     );
 
-    await _flutterLocalNotificationsPlugin.initialize(initializationSettings);
+    await _flutterLocalNotificationsPlugin.initialize(
+      initializationSettings,
+      onDidReceiveNotificationResponse: (_) {
+        AppLogger.info('👆 フォアグラウンド通知をタップしました');
+        _openNotificationListFromNotification();
+      },
+    );
     AppLogger.debug('ローカル通知を初期化しました');
   }
 

--- a/lib/infrastructure/notification_navigation_service.dart
+++ b/lib/infrastructure/notification_navigation_service.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+
+import '../utils/logger.dart';
+
+typedef NotificationListPageBuilder = WidgetBuilder;
+
+class NotificationNavigationService {
+  NotificationNavigationService({
+    GlobalKey<NavigatorState>? navigatorKey,
+    NotificationListPageBuilder? notificationListBuilder,
+  })  : navigatorKey = navigatorKey ?? GlobalKey<NavigatorState>(),
+        _notificationListBuilder = notificationListBuilder;
+
+  static final NotificationNavigationService instance =
+      NotificationNavigationService();
+
+  final GlobalKey<NavigatorState> navigatorKey;
+  NotificationListPageBuilder? _notificationListBuilder;
+
+  bool _hasPendingNotificationListOpen = false;
+
+  bool get hasPendingNotificationListOpen => _hasPendingNotificationListOpen;
+
+  void configureNotificationListBuilder(
+    NotificationListPageBuilder notificationListBuilder,
+  ) {
+    _notificationListBuilder = notificationListBuilder;
+  }
+
+  void openNotificationList() {
+    final navigator = navigatorKey.currentState;
+    if (navigator == null) {
+      AppLogger.debug('通知一覧への遷移を保留しました: Navigator未準備');
+      _hasPendingNotificationListOpen = true;
+      return;
+    }
+
+    final notificationListBuilder = _notificationListBuilder;
+    if (notificationListBuilder == null) {
+      AppLogger.warning('通知一覧への遷移を保留しました: builder未設定');
+      _hasPendingNotificationListOpen = true;
+      return;
+    }
+
+    _hasPendingNotificationListOpen = false;
+    navigator.push(
+      MaterialPageRoute(
+        builder: notificationListBuilder,
+      ),
+    );
+  }
+
+  void flushPendingNavigation() {
+    if (!_hasPendingNotificationListOpen) {
+      return;
+    }
+    openNotificationList();
+  }
+}

--- a/lib/infrastructure/notification_repository.dart
+++ b/lib/infrastructure/notification_repository.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import '../domain/entity/notification.dart';
 import '../domain/interfaces/i_notification_repository.dart';
+import 'notification_repository_update_data.dart';
 import '../utils/logger.dart';
 
 /// 通知関連のFirestoreとのデータアクセスを管理するリポジトリクラス
@@ -231,10 +232,10 @@ class NotificationRepository implements INotificationRepository {
   Future<void> acceptNotification(String notificationId) async {
     AppLogger.debug('Accepting notification: $notificationId');
     try {
-      await _firestore.collection('notifications').doc(notificationId).update({
-        'status': NotificationStatus.accepted.name,
-        'updatedAt': FieldValue.serverTimestamp(),
-      });
+      await _firestore
+          .collection('notifications')
+          .doc(notificationId)
+          .update(NotificationRepositoryUpdateData.accepted());
       AppLogger.debug('Notification accepted successfully: $notificationId');
     } catch (e) {
       AppLogger.error('Error accepting notification: $e');
@@ -249,11 +250,10 @@ class NotificationRepository implements INotificationRepository {
   Future<void> rejectNotification(String notificationId) async {
     AppLogger.debug('Rejecting notification: $notificationId');
     try {
-      await _firestore.collection('notifications').doc(notificationId).update({
-        'status': NotificationStatus.rejected.name,
-        'rejectionCount': FieldValue.increment(1),
-        'updatedAt': FieldValue.serverTimestamp(),
-      });
+      await _firestore
+          .collection('notifications')
+          .doc(notificationId)
+          .update(NotificationRepositoryUpdateData.rejected());
       AppLogger.debug('Notification rejected successfully: $notificationId');
     } catch (e) {
       AppLogger.error('Error rejecting notification: $e');

--- a/lib/infrastructure/notification_repository_update_data.dart
+++ b/lib/infrastructure/notification_repository_update_data.dart
@@ -1,0 +1,24 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import '../domain/entity/notification.dart';
+
+class NotificationRepositoryUpdateData {
+  const NotificationRepositoryUpdateData._();
+
+  static Map<String, Object> accepted() {
+    return {
+      'status': NotificationStatus.accepted.name,
+      'isRead': true,
+      'updatedAt': FieldValue.serverTimestamp(),
+    };
+  }
+
+  static Map<String, Object> rejected() {
+    return {
+      'status': NotificationStatus.rejected.name,
+      'rejectionCount': FieldValue.increment(1),
+      'isRead': true,
+      'updatedAt': FieldValue.serverTimestamp(),
+    };
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,8 @@ import 'config/admob_config.dart';
 import 'config/router/app_router.dart';
 import 'infrastructure/admob_service.dart';
 import 'infrastructure/firebase/push_notification_service.dart';
+import 'infrastructure/notification_navigation_service.dart';
+import 'presentation/notification/notification_list_page.dart';
 import 'presentation/theme/app_theme.dart';
 import 'application/app_lifecycle/app_lifecycle_notifier.dart';
 import 'utils/logger.dart';
@@ -143,6 +145,14 @@ class MyApp extends ConsumerWidget {
 
     // アプリライフサイクルの監視を開始
     ref.watch(appLifecycleProvider);
+
+    NotificationNavigationService.instance.configureNotificationListBuilder(
+      (_) => const NotificationListPage(),
+    );
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      NotificationNavigationService.instance.flushPendingNavigation();
+    });
 
     return MaterialApp.router(
       title: 'LaKiite',

--- a/lib/presentation/notification/notification_list_page.dart
+++ b/lib/presentation/notification/notification_list_page.dart
@@ -202,23 +202,10 @@ class _NotificationItem extends ConsumerWidget {
     final notifier = ref.watch(notificationNotifierProvider.notifier);
     final state = ref.watch(notificationNotifierProvider);
 
-    // 通知を既読にする関数
-    Future<void> markAsRead() async {
-      if (!notification.isRead) {
-        // 非同期で処理を実行し、結果を待たない
-        notifier.markAsRead(notification.id).catchError((e) {
-          AppLogger.error('既読処理でエラー発生: $e');
-          // エラーが発生しても処理を継続
-        });
-      }
-    }
-
     // 通知を承認する関数
     Future<void> acceptNotification() async {
       try {
-        // 既読処理を開始
-        markAsRead();
-        // 承認処理を実行
+        // 承認処理はRepository側で既読化も同時に行う
         await notifier.acceptNotification(notification.id);
       } catch (e) {
         if (context.mounted) {
@@ -235,9 +222,7 @@ class _NotificationItem extends ConsumerWidget {
     // 通知を拒否する関数
     Future<void> rejectNotification() async {
       try {
-        // 既読処理を開始
-        markAsRead();
-        // 拒否処理を実行
+        // 拒否処理はRepository側で既読化も同時に行う
         await notifier.rejectNotification(notification.id);
       } catch (e) {
         if (context.mounted) {

--- a/test/infrastructure/notification_navigation_service_test.dart
+++ b/test/infrastructure/notification_navigation_service_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lakiite/infrastructure/notification_navigation_service.dart';
+
+void main() {
+  group('NotificationNavigationService', () {
+    testWidgets('通知一覧をNavigatorへpushできる', (tester) async {
+      final service = NotificationNavigationService(
+        notificationListBuilder: (_) => const Scaffold(
+          body: Text('notification list'),
+        ),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          navigatorKey: service.navigatorKey,
+          home: const Scaffold(body: Text('home')),
+        ),
+      );
+
+      service.openNotificationList();
+      await tester.pumpAndSettle();
+
+      expect(find.text('notification list'), findsOneWidget);
+    });
+
+    testWidgets('Navigator準備前の通知タップは保留し、準備後に通知一覧を開く', (tester) async {
+      final service = NotificationNavigationService(
+        notificationListBuilder: (_) => const Scaffold(
+          body: Text('notification list'),
+        ),
+      );
+
+      service.openNotificationList();
+      expect(service.hasPendingNotificationListOpen, isTrue);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          navigatorKey: service.navigatorKey,
+          home: const Scaffold(body: Text('home')),
+        ),
+      );
+
+      service.flushPendingNavigation();
+      await tester.pumpAndSettle();
+
+      expect(service.hasPendingNotificationListOpen, isFalse);
+      expect(find.text('notification list'), findsOneWidget);
+    });
+  });
+}

--- a/test/infrastructure/notification_repository_update_data_test.dart
+++ b/test/infrastructure/notification_repository_update_data_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lakiite/infrastructure/notification_repository_update_data.dart';
+
+void main() {
+  group('NotificationRepositoryUpdateData', () {
+    test('承認更新はステータスと同時に既読へする', () {
+      final data = NotificationRepositoryUpdateData.accepted();
+
+      expect(data['status'], 'accepted');
+      expect(data['isRead'], isTrue);
+      expect(data, contains('updatedAt'));
+    });
+
+    test('拒否更新はステータス、拒否回数、既読を同時に更新する', () {
+      final data = NotificationRepositoryUpdateData.rejected();
+
+      expect(data['status'], 'rejected');
+      expect(data['isRead'], isTrue);
+      expect(data, contains('rejectionCount'));
+      expect(data, contains('updatedAt'));
+    });
+  });
+}


### PR DESCRIPTION
## 概要
- Push通知のバナー/通知タップ時に通知一覧を開く navigation service を追加しました
- FCM の `getInitialMessage` / `onMessageOpenedApp` と Android フォアグラウンド通知タップを通知一覧表示へ接続しました
- 通知の承認/拒否時に Firestore 更新で `isRead: true` を同時に保存するようにしました
- 通知一覧UI側の承認/拒否前の非同期既読呼び出しをやめ、Repository側の単一更新に寄せました

## 背景
- Push通知をタップしてもログ出力だけで画面遷移していませんでした
- 承認/否認ボタンでは `markAsRead` を待たずに承認/拒否を実行しており、実データ更新でも承認/拒否側が `isRead` を更新していませんでした

## 確認結果
- RED: 追加テストは未実装 import で失敗することを確認
- `fvm flutter test test/infrastructure/notification_navigation_service_test.dart test/infrastructure/notification_repository_update_data_test.dart --dart-define=FLUTTER_TEST=true`: 成功
- `fvm flutter analyze --no-fatal-infos`: 成功（CI と同じダミー `lib/firebase_options.dart` を一時作成して実行、検証後に削除済み）
- `git diff --check`: 成功

## 補足
- 実機Pushの最終確認は、PRマージ後に dev/prod 配信ビルドで通知を送って確認してください
