### PR TITLE
ログイン失敗時の認証エラー表示をユーザー向け文言に修正

### DIFF
--- a/lib/application/auth/auth_notifier.dart
+++ b/lib/application/auth/auth_notifier.dart
@@ -149,7 +149,7 @@ class AuthNotifier extends _$AuthNotifier {
     state = const AsyncLoading();
 
     // ユーザー登録処理を実行
-    state = await AsyncValue.guard(() async {
+    final signUpResult = await AsyncValue.guard(() async {
       // AuthRepositoryは従来通りnameのみを受け取るため、
       // displayNameの処理は後でupdateProfileで対応する
       final user = await _authRepository.signUp(email, password, name);
@@ -183,6 +183,7 @@ class AuthNotifier extends _$AuthNotifier {
         return AuthState.unauthenticated();
       }
     });
+    state = signUpResult;
 
     state.whenOrNull(
       data: (authState) => AppLogger.debugOnly(
@@ -190,6 +191,13 @@ class AuthNotifier extends _$AuthNotifier {
       error: (error, stackTrace) =>
           AppLogger.errorOnly('signUp失敗', error, stackTrace),
     );
+
+    if (signUpResult.hasError) {
+      Error.throwWithStackTrace(
+        signUpResult.error!,
+        signUpResult.stackTrace ?? StackTrace.current,
+      );
+    }
   }
 
   /// サインアウトを行う

--- a/lib/application/auth/auth_notifier.dart
+++ b/lib/application/auth/auth_notifier.dart
@@ -91,7 +91,7 @@ class AuthNotifier extends _$AuthNotifier {
     state = const AsyncLoading();
 
     // サインイン処理を実行
-    state = await AsyncValue.guard(() async {
+    final signInResult = await AsyncValue.guard(() async {
       final user = await _authRepository.signIn(email, password);
       // サインイン結果に応じて状態を更新
       if (user != null) {
@@ -112,6 +112,7 @@ class AuthNotifier extends _$AuthNotifier {
         return AuthState.unauthenticated();
       }
     });
+    state = signInResult;
 
     state.whenOrNull(
       data: (authState) => AppLogger.debugOnly(
@@ -119,6 +120,13 @@ class AuthNotifier extends _$AuthNotifier {
       error: (error, stackTrace) =>
           AppLogger.errorOnly('signIn失敗', error, stackTrace),
     );
+
+    if (signInResult.hasError) {
+      Error.throwWithStackTrace(
+        signInResult.error!,
+        signInResult.stackTrace ?? StackTrace.current,
+      );
+    }
   }
 
   /// 新規ユーザー登録を行う

--- a/lib/infrastructure/auth_repository.dart
+++ b/lib/infrastructure/auth_repository.dart
@@ -166,20 +166,9 @@ class AuthRepository implements IAuthRepository {
       }
 
       if (e is FirebaseAuthException) {
-        switch (e.code) {
-          case 'email-already-in-use':
-            throw Exception('このメールアドレスは既に使用されています');
-          case 'invalid-email':
-            throw Exception('無効なメールアドレスです');
-          case 'operation-not-allowed':
-            throw Exception('メール/パスワード認証が無効になっています');
-          case 'weak-password':
-            throw Exception('パスワードが脆弱です');
-          default:
-            throw Exception('認証エラーが発生しました: ${e.message}');
-        }
+        throw UserFacingException(signUpErrorMessage(e));
       }
-      throw Exception('アカウント作成に失敗しました: ${e.toString()}');
+      throw UserFacingException(signUpErrorMessage(e));
     }
   }
 

--- a/lib/infrastructure/auth_repository.dart
+++ b/lib/infrastructure/auth_repository.dart
@@ -2,6 +2,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import '../domain/interfaces/i_auth_repository.dart';
 import '../domain/interfaces/i_user_repository.dart';
 import '../domain/entity/user.dart';
+import '../utils/auth_error_message.dart';
 import '../utils/logger.dart';
 
 class AuthRepository implements IAuthRepository {
@@ -89,6 +90,9 @@ class AuthRepository implements IAuthRepository {
       // エラーが発生した場合は認証をクリア
       AppLogger.errorOnly('AuthRepository.signIn例外', e);
       await _auth.signOut();
+      if (e is FirebaseAuthException) {
+        throw UserFacingException(signInErrorMessage(e));
+      }
       rethrow;
     }
   }

--- a/lib/presentation/login/login_page.dart
+++ b/lib/presentation/login/login_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../presentation_provider.dart';
 import '../signup/signup.dart';
+import '../../utils/auth_error_message.dart';
 import '../../utils/logger.dart';
 
 class LoginPage extends ConsumerStatefulWidget {
@@ -42,16 +43,12 @@ class _LoginPageState extends ConsumerState<LoginPage> {
       AppLogger.debugOnly('LoginPage._handleLogin後 state=$authState');
       if (mounted && authState.hasError) {
         final error = authState.error;
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('ログインに失敗しました: ${error.toString()}')),
-        );
+        _showLoginError(error);
       }
     } catch (e) {
       AppLogger.errorOnly('LoginPage._handleLogin例外', e);
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('ログインに失敗しました: ${e.toString()}')),
-        );
+        _showLoginError(e);
       }
     } finally {
       if (mounted) {
@@ -60,6 +57,12 @@ class _LoginPageState extends ConsumerState<LoginPage> {
         });
       }
     }
+  }
+
+  void _showLoginError(Object? error) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(signInErrorMessage(error))),
+    );
   }
 
   void _navigateToSignup() {

--- a/lib/presentation/signup/signup.dart
+++ b/lib/presentation/signup/signup.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../presentation_provider.dart';
+import '../../utils/auth_error_message.dart';
 import '../../utils/logger.dart';
 
 class SignupPage extends ConsumerStatefulWidget {
@@ -48,16 +49,12 @@ class _SignupPageState extends ConsumerState<SignupPage> {
       AppLogger.debugOnly('SignupPage._handleSignup後 state=$authState');
       if (mounted && authState.hasError) {
         final error = authState.error;
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('サインアップに失敗しました: ${error.toString()}')),
-        );
+        _showSignupError(error);
       }
     } catch (e) {
       AppLogger.errorOnly('SignupPage._handleSignup例外', e);
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('サインアップに失敗しました: ${e.toString()}')),
-        );
+        _showSignupError(e);
       }
     } finally {
       if (mounted) {
@@ -66,6 +63,12 @@ class _SignupPageState extends ConsumerState<SignupPage> {
         });
       }
     }
+  }
+
+  void _showSignupError(Object? error) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(signUpErrorMessage(error))),
+    );
   }
 
   void _navigateToLogin() {

--- a/lib/utils/auth_error_message.dart
+++ b/lib/utils/auth_error_message.dart
@@ -41,6 +41,35 @@ String signInErrorMessage(Object? error) {
   return message;
 }
 
+String signUpErrorMessage(Object? error) {
+  if (error is UserFacingException) {
+    return error.message;
+  }
+
+  if (error is FirebaseAuthException) {
+    switch (error.code) {
+      case 'email-already-in-use':
+        return 'このメールアドレスは既に使用されています';
+      case 'invalid-email':
+        return 'メールアドレスの形式が正しくありません';
+      case 'operation-not-allowed':
+        return 'メール/パスワード認証が無効になっています';
+      case 'weak-password':
+        return 'パスワードは6文字以上で入力してください';
+      case 'network-request-failed':
+        return 'ネットワーク接続を確認してから再度お試しください';
+      default:
+        return 'アカウント作成に失敗しました。入力内容を確認してください';
+    }
+  }
+
+  final message = _stripExceptionPrefix(error?.toString().trim() ?? '');
+  if (message.isEmpty || _looksLikeRawFirebaseMessage(message)) {
+    return 'アカウント作成に失敗しました。入力内容を確認してください';
+  }
+  return message;
+}
+
 String _stripExceptionPrefix(String message) {
   return message.replaceFirst(
     RegExp(r'^(Exception|ArgumentError):\s*'),

--- a/lib/utils/auth_error_message.dart
+++ b/lib/utils/auth_error_message.dart
@@ -1,0 +1,55 @@
+import 'package:firebase_auth/firebase_auth.dart';
+
+class UserFacingException implements Exception {
+  const UserFacingException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+String signInErrorMessage(Object? error) {
+  if (error is UserFacingException) {
+    return error.message;
+  }
+
+  if (error is FirebaseAuthException) {
+    switch (error.code) {
+      case 'wrong-password':
+      case 'invalid-credential':
+        return 'パスワードが間違っています';
+      case 'invalid-email':
+        return 'メールアドレスの形式が正しくありません';
+      case 'user-not-found':
+        return 'メールアドレスまたはパスワードが間違っています';
+      case 'user-disabled':
+        return 'このアカウントは無効化されています';
+      case 'too-many-requests':
+        return 'ログイン試行回数が多すぎます。しばらく時間をおいて再度お試しください';
+      case 'network-request-failed':
+        return 'ネットワーク接続を確認してから再度お試しください';
+      default:
+        return 'ログインに失敗しました。入力内容を確認してください';
+    }
+  }
+
+  final message = _stripExceptionPrefix(error?.toString().trim() ?? '');
+  if (message.isEmpty || _looksLikeRawFirebaseMessage(message)) {
+    return 'ログインに失敗しました。入力内容を確認してください';
+  }
+  return message;
+}
+
+String _stripExceptionPrefix(String message) {
+  return message.replaceFirst(
+    RegExp(r'^(Exception|ArgumentError):\s*'),
+    '',
+  );
+}
+
+bool _looksLikeRawFirebaseMessage(String message) {
+  return message.contains('[firebase_auth/') ||
+      message.contains('FirebaseAuthException') ||
+      message.contains('auth credential');
+}

--- a/test/infrastructure/auth_repository_test.dart
+++ b/test/infrastructure/auth_repository_test.dart
@@ -44,12 +44,36 @@ class MockUserCredential implements firebase_auth.UserCredential {
 
 class MockFirebaseAuth implements firebase_auth.FirebaseAuth {
   firebase_auth.User? _currentUser;
+  firebase_auth.FirebaseAuthException? _signInException;
+  bool didSignOut = false;
 
   @override
   firebase_auth.User? get currentUser => _currentUser;
 
   void setCurrentUser(firebase_auth.User? user) {
     _currentUser = user;
+  }
+
+  void setSignInException(firebase_auth.FirebaseAuthException exception) {
+    _signInException = exception;
+  }
+
+  @override
+  Future<firebase_auth.UserCredential> signInWithEmailAndPassword({
+    required String email,
+    required String password,
+  }) async {
+    final exception = _signInException;
+    if (exception != null) {
+      throw exception;
+    }
+    return MockUserCredential(MockUser());
+  }
+
+  @override
+  Future<void> signOut() async {
+    didSignOut = true;
+    _currentUser = null;
   }
 
   @override
@@ -156,6 +180,65 @@ class MockUserRepository implements IUserRepository {
 }
 
 void main() {
+  group('AuthRepository - ログインエラー', () {
+    late AuthRepository authRepository;
+    late MockFirebaseAuth mockFirebaseAuth;
+    late MockUserRepository mockUserRepository;
+
+    setUp(() {
+      mockFirebaseAuth = MockFirebaseAuth();
+      mockUserRepository = MockUserRepository();
+      authRepository = AuthRepository(mockFirebaseAuth, mockUserRepository);
+    });
+
+    test('invalid-credential はパスワード誤りとしてユーザー向け文言に変換する', () async {
+      mockFirebaseAuth.setSignInException(
+        firebase_auth.FirebaseAuthException(
+          code: 'invalid-credential',
+          message:
+              'The supplied auth credential is incorrect, malformed or has expired.',
+        ),
+      );
+
+      await expectLater(
+        authRepository.signIn('test@example.com', 'wrong-password'),
+        throwsA(isA<Exception>().having(
+          (e) => e.toString(),
+          'message',
+          allOf(
+            contains('パスワードが間違っています'),
+            isNot(contains('Firebase')),
+            isNot(contains('auth credential')),
+          ),
+        )),
+      );
+      expect(mockFirebaseAuth.didSignOut, isTrue);
+    });
+
+    test('invalid-email はメールアドレス形式のエラーとしてユーザー向け文言に変換する', () async {
+      mockFirebaseAuth.setSignInException(
+        firebase_auth.FirebaseAuthException(
+          code: 'invalid-email',
+          message: 'The email address is badly formatted.',
+        ),
+      );
+
+      await expectLater(
+        authRepository.signIn('invalid-email', 'password123'),
+        throwsA(isA<Exception>().having(
+          (e) => e.toString(),
+          'message',
+          allOf(
+            contains('メールアドレスの形式が正しくありません'),
+            isNot(contains('Firebase')),
+            isNot(contains('badly formatted')),
+          ),
+        )),
+      );
+      expect(mockFirebaseAuth.didSignOut, isTrue);
+    });
+  });
+
   group('AuthRepository - アカウント削除機能', () {
     late AuthRepository authRepository;
     late MockFirebaseAuth mockFirebaseAuth;

--- a/test/infrastructure/auth_repository_test.dart
+++ b/test/infrastructure/auth_repository_test.dart
@@ -45,6 +45,7 @@ class MockUserCredential implements firebase_auth.UserCredential {
 class MockFirebaseAuth implements firebase_auth.FirebaseAuth {
   firebase_auth.User? _currentUser;
   firebase_auth.FirebaseAuthException? _signInException;
+  firebase_auth.FirebaseAuthException? _signUpException;
   bool didSignOut = false;
 
   @override
@@ -58,12 +59,28 @@ class MockFirebaseAuth implements firebase_auth.FirebaseAuth {
     _signInException = exception;
   }
 
+  void setSignUpException(firebase_auth.FirebaseAuthException exception) {
+    _signUpException = exception;
+  }
+
   @override
   Future<firebase_auth.UserCredential> signInWithEmailAndPassword({
     required String email,
     required String password,
   }) async {
     final exception = _signInException;
+    if (exception != null) {
+      throw exception;
+    }
+    return MockUserCredential(MockUser());
+  }
+
+  @override
+  Future<firebase_auth.UserCredential> createUserWithEmailAndPassword({
+    required String email,
+    required String password,
+  }) async {
+    final exception = _signUpException;
     if (exception != null) {
       throw exception;
     }
@@ -236,6 +253,40 @@ void main() {
         )),
       );
       expect(mockFirebaseAuth.didSignOut, isTrue);
+    });
+  });
+
+  group('AuthRepository - サインアップエラー', () {
+    late AuthRepository authRepository;
+    late MockFirebaseAuth mockFirebaseAuth;
+    late MockUserRepository mockUserRepository;
+
+    setUp(() {
+      mockFirebaseAuth = MockFirebaseAuth();
+      mockUserRepository = MockUserRepository();
+      authRepository = AuthRepository(mockFirebaseAuth, mockUserRepository);
+    });
+
+    test('email-already-in-use はユーザー向け文言に変換する', () async {
+      mockFirebaseAuth.setSignUpException(
+        firebase_auth.FirebaseAuthException(
+          code: 'email-already-in-use',
+          message: 'The email address is already in use by another account.',
+        ),
+      );
+
+      await expectLater(
+        authRepository.signUp('test@example.com', 'password123', 'テストユーザー'),
+        throwsA(isA<Exception>().having(
+          (e) => e.toString(),
+          'message',
+          allOf(
+            contains('このメールアドレスは既に使用されています'),
+            isNot(contains('Firebase')),
+            isNot(contains('already in use')),
+          ),
+        )),
+      );
     });
   });
 

--- a/test/presentation/auth/login_widget_test.dart
+++ b/test/presentation/auth/login_widget_test.dart
@@ -118,6 +118,36 @@ void main() {
       expect(find.byType(LoginPage), findsOneWidget);
     });
 
+    testWidgets('ログイン失敗時はFirebaseの生エラーを表示しない', (tester) async {
+      TestProviders.mockAuthRepository.setShouldFailLogin(true);
+
+      await tester.pumpWidget(
+        TestUtils.createTestApp(
+          overrides: TestProviders.forLoginForm,
+          child: const LoginPage(),
+        ),
+      );
+
+      await tester.enterText(
+        find.widgetWithText(TextField, 'メールアドレス'),
+        'test@example.com',
+      );
+      await tester.enterText(
+        find.widgetWithText(TextField, 'パスワード'),
+        'wrong-password',
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byType(ElevatedButton));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+
+      expect(find.text('パスワードが間違っています'), findsOneWidget);
+      expect(find.textContaining('FirebaseAuthException'), findsNothing);
+      expect(find.textContaining('[firebase_auth/'), findsNothing);
+      expect(find.textContaining('Exception:'), findsNothing);
+    });
+
     testWidgets('パスワードフィールドが隠されている', (tester) async {
       await tester.pumpWidget(
         TestUtils.createTestApp(

--- a/test/presentation/auth/signup_widget_test.dart
+++ b/test/presentation/auth/signup_widget_test.dart
@@ -103,6 +103,45 @@ void main() {
       expect(find.byType(SignupPage), findsOneWidget);
     });
 
+    testWidgets('既存Emailの新規登録失敗時はFirebaseの生エラーを表示しない', (tester) async {
+      TestProviders.mockAuthRepository.setShouldFailSignUp(true);
+
+      await tester.pumpWidget(
+        TestUtils.createTestApp(
+          overrides: TestProviders.forSignupForm,
+          child: const SignupPage(),
+        ),
+      );
+
+      await tester.enterText(
+        find.widgetWithText(TextField, '名前(フルネーム)'),
+        'テストユーザー',
+      );
+      await tester.enterText(
+        find.widgetWithText(TextField, 'メールアドレス'),
+        'test@example.com',
+      );
+      await tester.enterText(
+        find.widgetWithText(TextField, 'パスワード'),
+        'password123',
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(
+        find.descendant(
+          of: find.byType(ElevatedButton),
+          matching: find.text('新規登録'),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 600));
+
+      expect(find.text('このメールアドレスは既に使用されています'), findsOneWidget);
+      expect(find.textContaining('FirebaseAuthException'), findsNothing);
+      expect(find.textContaining('[firebase_auth/'), findsNothing);
+      expect(find.textContaining('Exception:'), findsNothing);
+    });
+
     testWidgets('表示名が空の場合はnameが使用される', (tester) async {
       await tester.pumpWidget(
         TestUtils.createTestApp(


### PR DESCRIPTION
## 概要
- FirebaseAuthException のログイン/サインアップ失敗コードをユーザー向けの日本語文言へ変換する共通処理を追加
- ログイン画面と新規登録画面の SnackBar で `FirebaseAuthException` や `Exception:` などの生エラーを表示しないように修正
- `AuthNotifier.signIn` / `AuthNotifier.signUp` が失敗時に state を error に残しつつ、呼び出し元へ例外を返すように修正

## 修正内容
### ログイン
- `invalid-credential` / `wrong-password`: `パスワードが間違っています`
- `invalid-email`: `メールアドレスの形式が正しくありません`
- その他の代表的なログイン失敗もユーザー向け文言に変換

### 新規登録
- `email-already-in-use`: `このメールアドレスは既に使用されています`
- `invalid-email`: `メールアドレスの形式が正しくありません`
- `weak-password`: `パスワードは6文字以上で入力してください`
- その他の代表的な新規登録失敗もユーザー向け文言に変換

## テスト
- `fvm flutter test test/infrastructure/auth_repository_test.dart`
- `fvm flutter test test/presentation/auth/login_widget_test.dart`
- `fvm flutter test test/presentation/auth/signup_widget_test.dart`
- `fvm flutter test test/application/auth/auth_notifier_test.dart`
- `fvm flutter test test/infrastructure/auth_repository_test.dart test/presentation/auth/login_widget_test.dart test/presentation/auth/signup_widget_test.dart test/application/auth/auth_notifier_test.dart`
- `fvm flutter analyze`

補足: この worktree には生成対象の `lib/firebase_options.dart` が存在しないため、Widget テストと analyze は検証用のダミー `firebase_options.dart` を一時作成して実行し、コミット前に削除しています。

Closes #138