### PR TITLE
[codex] Refactor domain data responsibilities

### DIFF
--- a/lib/domain/entity/notification.dart
+++ b/lib/domain/entity/notification.dart
@@ -1,74 +1,60 @@
-import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
 
-import '../../utils/logger.dart';
+part 'notification.freezed.dart';
 
+/// アプリ内通知の種類。
+///
+/// 種類ごとに参照する補助 ID が異なる。グループ招待では [Notification.groupId]、
+/// リアクションとコメントでは [Notification.relatedItemId] と
+/// [Notification.interactionId] を使用する。
 enum NotificationType {
+  /// フレンド申請通知。
   friend,
+
+  /// グループへの招待通知。
   groupInvitation,
-  reaction, // リアクション通知
-  comment, // コメント通知
+
+  /// スケジュールへのリアクション通知。
+  reaction,
+
+  /// スケジュールへのコメント通知。
+  comment,
 }
 
+/// ユーザー操作が必要な通知の処理状態。
 enum NotificationStatus {
+  /// 承認または拒否の操作待ち。
   pending,
+
+  /// 承認済み。
   accepted,
+
+  /// 拒否済み。
   rejected,
 }
 
-class Notification {
-  // リアクション・コメントのID
-
-  const Notification({
-    required this.id,
-    required this.type,
-    required this.sendUserId,
-    required this.receiveUserId,
-    this.sendUserDisplayName,
-    this.receiveUserDisplayName,
-    required this.status,
-    required this.createdAt,
-    required this.updatedAt,
-    this.rejectionCount = 0,
-    this.isRead = false,
-    this.groupId,
-    this.relatedItemId,
-    this.interactionId,
-  });
-  factory Notification.fromJson(Map<String, dynamic> json) {
-    // createdAtとupdatedAtのデバッグ出力
-    final createdAtTimestamp = json['createdAt'] as Timestamp;
-    final updatedAtTimestamp = json['updatedAt'] as Timestamp;
-
-    final createdAtDate = createdAtTimestamp.toDate();
-    final updatedAtDate = updatedAtTimestamp.toDate();
-
-    AppLogger.debug(
-        'Notification fromJson - createdAt timestamp: ${createdAtTimestamp.seconds}');
-    AppLogger.debug('Notification fromJson - createdAt date: $createdAtDate');
-
-    return Notification(
-      id: json['id'] as String,
-      type: NotificationType.values.firstWhere(
-        (e) => e.name == (json['type'] as String),
-      ),
-      sendUserId: json['sendUserId'] as String,
-      receiveUserId: json['receiveUserId'] as String,
-      sendUserDisplayName: json['sendUserDisplayName'] as String?,
-      receiveUserDisplayName: json['receiveUserDisplayName'] as String?,
-      status: NotificationStatus.values.firstWhere(
-        (e) =>
-            e.name ==
-            (json['status'] as String? ?? NotificationStatus.pending.name),
-      ),
-      createdAt: createdAtDate,
-      updatedAt: updatedAtDate,
-      rejectionCount: json['rejectionCount'] as int? ?? 0,
-      isRead: json['isRead'] as bool? ?? false,
-      groupId: json['groupId'] as String?,
-      relatedItemId: json['relatedItemId'] as String?,
-      interactionId: json['interactionId'] as String?,
-    );
-  }
+/// アプリ内でユーザーに届ける通知を表すドメインモデル。
+///
+/// Firestore の Timestamp や FieldValue などの保存形式は持たず、
+/// domain では通知種別・状態・関連 ID を型付きの値として扱う。
+@freezed
+class Notification with _$Notification {
+  const factory Notification({
+    required String id,
+    required NotificationType type,
+    required String sendUserId,
+    required String receiveUserId,
+    String? sendUserDisplayName,
+    String? receiveUserDisplayName,
+    required NotificationStatus status,
+    required DateTime createdAt,
+    required DateTime updatedAt,
+    @Default(0) int rejectionCount,
+    @Default(false) bool isRead,
+    String? groupId,
+    String? relatedItemId,
+    String? interactionId,
+  }) = _Notification;
 
   factory Notification.createCommentNotification({
     required String fromUserId,
@@ -79,15 +65,14 @@ class Notification {
   }) {
     final now = DateTime.now();
     return Notification(
-      id: '', // Firestoreで自動生成
+      id: '',
       type: NotificationType.comment,
       sendUserId: fromUserId,
       receiveUserId: toUserId,
       sendUserDisplayName: fromUserDisplayName,
-      status: NotificationStatus.accepted, // コメントは自動承認
+      status: NotificationStatus.accepted,
       createdAt: now,
       updatedAt: now,
-      isRead: false,
       relatedItemId: relatedItemId,
       interactionId: interactionId,
     );
@@ -102,15 +87,14 @@ class Notification {
   }) {
     final now = DateTime.now();
     return Notification(
-      id: '', // Firestoreで自動生成
+      id: '',
       type: NotificationType.reaction,
       sendUserId: fromUserId,
       receiveUserId: toUserId,
       sendUserDisplayName: fromUserDisplayName,
-      status: NotificationStatus.accepted, // リアクションは自動承認
+      status: NotificationStatus.accepted,
       createdAt: now,
       updatedAt: now,
-      isRead: false,
       relatedItemId: relatedItemId,
       interactionId: interactionId,
     );
@@ -125,7 +109,7 @@ class Notification {
   }) {
     final now = DateTime.now();
     return Notification(
-      id: '', // Firestoreで自動生成
+      id: '',
       type: NotificationType.groupInvitation,
       sendUserId: fromUserId,
       receiveUserId: toUserId,
@@ -134,8 +118,6 @@ class Notification {
       status: NotificationStatus.pending,
       createdAt: now,
       updatedAt: now,
-      rejectionCount: 0,
-      isRead: false,
       groupId: groupId,
     );
   }
@@ -148,7 +130,7 @@ class Notification {
   }) {
     final now = DateTime.now();
     return Notification(
-      id: '', // Firestoreで自動生成
+      id: '',
       type: NotificationType.friend,
       sendUserId: fromUserId,
       receiveUserId: toUserId,
@@ -157,86 +139,6 @@ class Notification {
       status: NotificationStatus.pending,
       createdAt: now,
       updatedAt: now,
-      rejectionCount: 0,
-      isRead: false,
     );
   }
-  final String id;
-  final NotificationType type;
-  final String sendUserId;
-  final String receiveUserId;
-  final String? sendUserDisplayName;
-  final String? receiveUserDisplayName;
-  final NotificationStatus status;
-  final DateTime createdAt;
-  final DateTime updatedAt;
-  final int rejectionCount;
-  final bool isRead;
-  final String? groupId; // グループ招待の場合に使用
-  final String? relatedItemId; // 投稿ID等の関連アイテムID
-  final String? interactionId;
-
-  Map<String, dynamic> toJson() => {
-        'id': id,
-        'type': type.name,
-        'sendUserId': sendUserId,
-        'receiveUserId': receiveUserId,
-        'sendUserDisplayName': sendUserDisplayName,
-        'receiveUserDisplayName': receiveUserDisplayName,
-        'status': status.name,
-        'createdAt': Timestamp.fromDate(createdAt),
-        'updatedAt': Timestamp.fromDate(updatedAt),
-        'rejectionCount': rejectionCount,
-        'isRead': isRead,
-        if (groupId != null) 'groupId': groupId,
-        if (relatedItemId != null) 'relatedItemId': relatedItemId,
-        if (interactionId != null) 'interactionId': interactionId,
-      };
-
-  Map<String, dynamic> toFirestore() {
-    final json = toJson();
-    json.remove('id'); // idはドキュメントIDとして使用するため、データから除外
-    return {
-      ...json,
-      'createdAt': FieldValue.serverTimestamp(),
-      'updatedAt': FieldValue.serverTimestamp(),
-    };
-  }
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is Notification &&
-          runtimeType == other.runtimeType &&
-          id == other.id &&
-          type == other.type &&
-          sendUserId == other.sendUserId &&
-          receiveUserId == other.receiveUserId &&
-          status == other.status &&
-          createdAt == other.createdAt &&
-          updatedAt == other.updatedAt &&
-          rejectionCount == other.rejectionCount &&
-          isRead == other.isRead &&
-          groupId == other.groupId &&
-          relatedItemId == other.relatedItemId &&
-          interactionId == other.interactionId;
-
-  @override
-  int get hashCode =>
-      id.hashCode ^
-      type.hashCode ^
-      sendUserId.hashCode ^
-      receiveUserId.hashCode ^
-      status.hashCode ^
-      createdAt.hashCode ^
-      updatedAt.hashCode ^
-      rejectionCount.hashCode ^
-      isRead.hashCode ^
-      (groupId?.hashCode ?? 0) ^
-      (relatedItemId?.hashCode ?? 0) ^
-      (interactionId?.hashCode ?? 0);
-
-  @override
-  String toString() =>
-      'Notification(id: $id, type: $type, sendUserId: $sendUserId, receiveUserId: $receiveUserId, status: $status, createdAt: $createdAt, updatedAt: $updatedAt, rejectionCount: $rejectionCount, isRead: $isRead, groupId: $groupId, relatedItemId: $relatedItemId, interactionId: $interactionId)';
 }

--- a/lib/domain/entity/notification.freezed.dart
+++ b/lib/domain/entity/notification.freezed.dart
@@ -1,0 +1,433 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'notification.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$Notification {
+  String get id => throw _privateConstructorUsedError;
+  NotificationType get type => throw _privateConstructorUsedError;
+  String get sendUserId => throw _privateConstructorUsedError;
+  String get receiveUserId => throw _privateConstructorUsedError;
+  String? get sendUserDisplayName => throw _privateConstructorUsedError;
+  String? get receiveUserDisplayName => throw _privateConstructorUsedError;
+  NotificationStatus get status => throw _privateConstructorUsedError;
+  DateTime get createdAt => throw _privateConstructorUsedError;
+  DateTime get updatedAt => throw _privateConstructorUsedError;
+  int get rejectionCount => throw _privateConstructorUsedError;
+  bool get isRead => throw _privateConstructorUsedError;
+  String? get groupId => throw _privateConstructorUsedError;
+  String? get relatedItemId => throw _privateConstructorUsedError;
+  String? get interactionId => throw _privateConstructorUsedError;
+
+  /// Create a copy of Notification
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $NotificationCopyWith<Notification> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $NotificationCopyWith<$Res> {
+  factory $NotificationCopyWith(
+          Notification value, $Res Function(Notification) then) =
+      _$NotificationCopyWithImpl<$Res, Notification>;
+  @useResult
+  $Res call(
+      {String id,
+      NotificationType type,
+      String sendUserId,
+      String receiveUserId,
+      String? sendUserDisplayName,
+      String? receiveUserDisplayName,
+      NotificationStatus status,
+      DateTime createdAt,
+      DateTime updatedAt,
+      int rejectionCount,
+      bool isRead,
+      String? groupId,
+      String? relatedItemId,
+      String? interactionId});
+}
+
+/// @nodoc
+class _$NotificationCopyWithImpl<$Res, $Val extends Notification>
+    implements $NotificationCopyWith<$Res> {
+  _$NotificationCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of Notification
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? type = null,
+    Object? sendUserId = null,
+    Object? receiveUserId = null,
+    Object? sendUserDisplayName = freezed,
+    Object? receiveUserDisplayName = freezed,
+    Object? status = null,
+    Object? createdAt = null,
+    Object? updatedAt = null,
+    Object? rejectionCount = null,
+    Object? isRead = null,
+    Object? groupId = freezed,
+    Object? relatedItemId = freezed,
+    Object? interactionId = freezed,
+  }) {
+    return _then(_value.copyWith(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      type: null == type
+          ? _value.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as NotificationType,
+      sendUserId: null == sendUserId
+          ? _value.sendUserId
+          : sendUserId // ignore: cast_nullable_to_non_nullable
+              as String,
+      receiveUserId: null == receiveUserId
+          ? _value.receiveUserId
+          : receiveUserId // ignore: cast_nullable_to_non_nullable
+              as String,
+      sendUserDisplayName: freezed == sendUserDisplayName
+          ? _value.sendUserDisplayName
+          : sendUserDisplayName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      receiveUserDisplayName: freezed == receiveUserDisplayName
+          ? _value.receiveUserDisplayName
+          : receiveUserDisplayName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      status: null == status
+          ? _value.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as NotificationStatus,
+      createdAt: null == createdAt
+          ? _value.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      updatedAt: null == updatedAt
+          ? _value.updatedAt
+          : updatedAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      rejectionCount: null == rejectionCount
+          ? _value.rejectionCount
+          : rejectionCount // ignore: cast_nullable_to_non_nullable
+              as int,
+      isRead: null == isRead
+          ? _value.isRead
+          : isRead // ignore: cast_nullable_to_non_nullable
+              as bool,
+      groupId: freezed == groupId
+          ? _value.groupId
+          : groupId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      relatedItemId: freezed == relatedItemId
+          ? _value.relatedItemId
+          : relatedItemId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      interactionId: freezed == interactionId
+          ? _value.interactionId
+          : interactionId // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$NotificationImplCopyWith<$Res>
+    implements $NotificationCopyWith<$Res> {
+  factory _$$NotificationImplCopyWith(
+          _$NotificationImpl value, $Res Function(_$NotificationImpl) then) =
+      __$$NotificationImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String id,
+      NotificationType type,
+      String sendUserId,
+      String receiveUserId,
+      String? sendUserDisplayName,
+      String? receiveUserDisplayName,
+      NotificationStatus status,
+      DateTime createdAt,
+      DateTime updatedAt,
+      int rejectionCount,
+      bool isRead,
+      String? groupId,
+      String? relatedItemId,
+      String? interactionId});
+}
+
+/// @nodoc
+class __$$NotificationImplCopyWithImpl<$Res>
+    extends _$NotificationCopyWithImpl<$Res, _$NotificationImpl>
+    implements _$$NotificationImplCopyWith<$Res> {
+  __$$NotificationImplCopyWithImpl(
+      _$NotificationImpl _value, $Res Function(_$NotificationImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of Notification
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? type = null,
+    Object? sendUserId = null,
+    Object? receiveUserId = null,
+    Object? sendUserDisplayName = freezed,
+    Object? receiveUserDisplayName = freezed,
+    Object? status = null,
+    Object? createdAt = null,
+    Object? updatedAt = null,
+    Object? rejectionCount = null,
+    Object? isRead = null,
+    Object? groupId = freezed,
+    Object? relatedItemId = freezed,
+    Object? interactionId = freezed,
+  }) {
+    return _then(_$NotificationImpl(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      type: null == type
+          ? _value.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as NotificationType,
+      sendUserId: null == sendUserId
+          ? _value.sendUserId
+          : sendUserId // ignore: cast_nullable_to_non_nullable
+              as String,
+      receiveUserId: null == receiveUserId
+          ? _value.receiveUserId
+          : receiveUserId // ignore: cast_nullable_to_non_nullable
+              as String,
+      sendUserDisplayName: freezed == sendUserDisplayName
+          ? _value.sendUserDisplayName
+          : sendUserDisplayName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      receiveUserDisplayName: freezed == receiveUserDisplayName
+          ? _value.receiveUserDisplayName
+          : receiveUserDisplayName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      status: null == status
+          ? _value.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as NotificationStatus,
+      createdAt: null == createdAt
+          ? _value.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      updatedAt: null == updatedAt
+          ? _value.updatedAt
+          : updatedAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      rejectionCount: null == rejectionCount
+          ? _value.rejectionCount
+          : rejectionCount // ignore: cast_nullable_to_non_nullable
+              as int,
+      isRead: null == isRead
+          ? _value.isRead
+          : isRead // ignore: cast_nullable_to_non_nullable
+              as bool,
+      groupId: freezed == groupId
+          ? _value.groupId
+          : groupId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      relatedItemId: freezed == relatedItemId
+          ? _value.relatedItemId
+          : relatedItemId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      interactionId: freezed == interactionId
+          ? _value.interactionId
+          : interactionId // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$NotificationImpl implements _Notification {
+  const _$NotificationImpl(
+      {required this.id,
+      required this.type,
+      required this.sendUserId,
+      required this.receiveUserId,
+      this.sendUserDisplayName,
+      this.receiveUserDisplayName,
+      required this.status,
+      required this.createdAt,
+      required this.updatedAt,
+      this.rejectionCount = 0,
+      this.isRead = false,
+      this.groupId,
+      this.relatedItemId,
+      this.interactionId});
+
+  @override
+  final String id;
+  @override
+  final NotificationType type;
+  @override
+  final String sendUserId;
+  @override
+  final String receiveUserId;
+  @override
+  final String? sendUserDisplayName;
+  @override
+  final String? receiveUserDisplayName;
+  @override
+  final NotificationStatus status;
+  @override
+  final DateTime createdAt;
+  @override
+  final DateTime updatedAt;
+  @override
+  @JsonKey()
+  final int rejectionCount;
+  @override
+  @JsonKey()
+  final bool isRead;
+  @override
+  final String? groupId;
+  @override
+  final String? relatedItemId;
+  @override
+  final String? interactionId;
+
+  @override
+  String toString() {
+    return 'Notification(id: $id, type: $type, sendUserId: $sendUserId, receiveUserId: $receiveUserId, sendUserDisplayName: $sendUserDisplayName, receiveUserDisplayName: $receiveUserDisplayName, status: $status, createdAt: $createdAt, updatedAt: $updatedAt, rejectionCount: $rejectionCount, isRead: $isRead, groupId: $groupId, relatedItemId: $relatedItemId, interactionId: $interactionId)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$NotificationImpl &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.type, type) || other.type == type) &&
+            (identical(other.sendUserId, sendUserId) ||
+                other.sendUserId == sendUserId) &&
+            (identical(other.receiveUserId, receiveUserId) ||
+                other.receiveUserId == receiveUserId) &&
+            (identical(other.sendUserDisplayName, sendUserDisplayName) ||
+                other.sendUserDisplayName == sendUserDisplayName) &&
+            (identical(other.receiveUserDisplayName, receiveUserDisplayName) ||
+                other.receiveUserDisplayName == receiveUserDisplayName) &&
+            (identical(other.status, status) || other.status == status) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt) &&
+            (identical(other.updatedAt, updatedAt) ||
+                other.updatedAt == updatedAt) &&
+            (identical(other.rejectionCount, rejectionCount) ||
+                other.rejectionCount == rejectionCount) &&
+            (identical(other.isRead, isRead) || other.isRead == isRead) &&
+            (identical(other.groupId, groupId) || other.groupId == groupId) &&
+            (identical(other.relatedItemId, relatedItemId) ||
+                other.relatedItemId == relatedItemId) &&
+            (identical(other.interactionId, interactionId) ||
+                other.interactionId == interactionId));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      id,
+      type,
+      sendUserId,
+      receiveUserId,
+      sendUserDisplayName,
+      receiveUserDisplayName,
+      status,
+      createdAt,
+      updatedAt,
+      rejectionCount,
+      isRead,
+      groupId,
+      relatedItemId,
+      interactionId);
+
+  /// Create a copy of Notification
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$NotificationImplCopyWith<_$NotificationImpl> get copyWith =>
+      __$$NotificationImplCopyWithImpl<_$NotificationImpl>(this, _$identity);
+}
+
+abstract class _Notification implements Notification {
+  const factory _Notification(
+      {required final String id,
+      required final NotificationType type,
+      required final String sendUserId,
+      required final String receiveUserId,
+      final String? sendUserDisplayName,
+      final String? receiveUserDisplayName,
+      required final NotificationStatus status,
+      required final DateTime createdAt,
+      required final DateTime updatedAt,
+      final int rejectionCount,
+      final bool isRead,
+      final String? groupId,
+      final String? relatedItemId,
+      final String? interactionId}) = _$NotificationImpl;
+
+  @override
+  String get id;
+  @override
+  NotificationType get type;
+  @override
+  String get sendUserId;
+  @override
+  String get receiveUserId;
+  @override
+  String? get sendUserDisplayName;
+  @override
+  String? get receiveUserDisplayName;
+  @override
+  NotificationStatus get status;
+  @override
+  DateTime get createdAt;
+  @override
+  DateTime get updatedAt;
+  @override
+  int get rejectionCount;
+  @override
+  bool get isRead;
+  @override
+  String? get groupId;
+  @override
+  String? get relatedItemId;
+  @override
+  String? get interactionId;
+
+  /// Create a copy of Notification
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$NotificationImplCopyWith<_$NotificationImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/domain/entity/reaction.dart
+++ b/lib/domain/entity/reaction.dart
@@ -1,16 +1,24 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
+import 'schedule_reaction.dart';
+
 part 'reaction.freezed.dart';
 part 'reaction.g.dart';
 
+@freezed
+
+/// スケジュールに対するユーザーのリアクションを表すドメインモデル。
+///
+/// Firestore 上ではリアクション種別は文字列で保存されるが、domain では
+/// [ReactionType] として扱うことで取り得る値を型で表現する。
 @freezed
 class Reaction with _$Reaction {
   const factory Reaction({
     required String id,
     required String scheduleId,
     required String userId,
-    required String type,
+    required ReactionType type,
     required String userDisplayName,
     String? userPhotoUrl,
     @TimestampConverter() required DateTime createdAt,

--- a/lib/domain/entity/reaction.freezed.dart
+++ b/lib/domain/entity/reaction.freezed.dart
@@ -23,14 +23,18 @@ mixin _$Reaction {
   String get id => throw _privateConstructorUsedError;
   String get scheduleId => throw _privateConstructorUsedError;
   String get userId => throw _privateConstructorUsedError;
-  String get type => throw _privateConstructorUsedError;
+  ReactionType get type => throw _privateConstructorUsedError;
   String get userDisplayName => throw _privateConstructorUsedError;
   String? get userPhotoUrl => throw _privateConstructorUsedError;
   @TimestampConverter()
   DateTime get createdAt => throw _privateConstructorUsedError;
 
+  /// Serializes this Reaction to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
+
+  /// Create a copy of Reaction
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   $ReactionCopyWith<Reaction> get copyWith =>
       throw _privateConstructorUsedError;
 }
@@ -44,7 +48,7 @@ abstract class $ReactionCopyWith<$Res> {
       {String id,
       String scheduleId,
       String userId,
-      String type,
+      ReactionType type,
       String userDisplayName,
       String? userPhotoUrl,
       @TimestampConverter() DateTime createdAt});
@@ -60,6 +64,8 @@ class _$ReactionCopyWithImpl<$Res, $Val extends Reaction>
   // ignore: unused_field
   final $Res Function($Val) _then;
 
+  /// Create a copy of Reaction
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -87,7 +93,7 @@ class _$ReactionCopyWithImpl<$Res, $Val extends Reaction>
       type: null == type
           ? _value.type
           : type // ignore: cast_nullable_to_non_nullable
-              as String,
+              as ReactionType,
       userDisplayName: null == userDisplayName
           ? _value.userDisplayName
           : userDisplayName // ignore: cast_nullable_to_non_nullable
@@ -116,7 +122,7 @@ abstract class _$$ReactionImplCopyWith<$Res>
       {String id,
       String scheduleId,
       String userId,
-      String type,
+      ReactionType type,
       String userDisplayName,
       String? userPhotoUrl,
       @TimestampConverter() DateTime createdAt});
@@ -130,6 +136,8 @@ class __$$ReactionImplCopyWithImpl<$Res>
       _$ReactionImpl _value, $Res Function(_$ReactionImpl) _then)
       : super(_value, _then);
 
+  /// Create a copy of Reaction
+  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
   @override
   $Res call({
@@ -157,7 +165,7 @@ class __$$ReactionImplCopyWithImpl<$Res>
       type: null == type
           ? _value.type
           : type // ignore: cast_nullable_to_non_nullable
-              as String,
+              as ReactionType,
       userDisplayName: null == userDisplayName
           ? _value.userDisplayName
           : userDisplayName // ignore: cast_nullable_to_non_nullable
@@ -196,7 +204,7 @@ class _$ReactionImpl implements _Reaction {
   @override
   final String userId;
   @override
-  final String type;
+  final ReactionType type;
   @override
   final String userDisplayName;
   @override
@@ -228,12 +236,14 @@ class _$ReactionImpl implements _Reaction {
                 other.createdAt == createdAt));
   }
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, id, scheduleId, userId, type,
       userDisplayName, userPhotoUrl, createdAt);
 
-  @JsonKey(ignore: true)
+  /// Create a copy of Reaction
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
   _$$ReactionImplCopyWith<_$ReactionImpl> get copyWith =>
@@ -252,7 +262,7 @@ abstract class _Reaction implements Reaction {
           {required final String id,
           required final String scheduleId,
           required final String userId,
-          required final String type,
+          required final ReactionType type,
           required final String userDisplayName,
           final String? userPhotoUrl,
           @TimestampConverter() required final DateTime createdAt}) =
@@ -268,7 +278,7 @@ abstract class _Reaction implements Reaction {
   @override
   String get userId;
   @override
-  String get type;
+  ReactionType get type;
   @override
   String get userDisplayName;
   @override
@@ -276,8 +286,11 @@ abstract class _Reaction implements Reaction {
   @override
   @TimestampConverter()
   DateTime get createdAt;
+
+  /// Create a copy of Reaction
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   _$$ReactionImplCopyWith<_$ReactionImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/domain/entity/reaction.g.dart
+++ b/lib/domain/entity/reaction.g.dart
@@ -11,7 +11,7 @@ _$ReactionImpl _$$ReactionImplFromJson(Map<String, dynamic> json) =>
       id: json['id'] as String,
       scheduleId: json['scheduleId'] as String,
       userId: json['userId'] as String,
-      type: json['type'] as String,
+      type: $enumDecode(_$ReactionTypeEnumMap, json['type']),
       userDisplayName: json['userDisplayName'] as String,
       userPhotoUrl: json['userPhotoUrl'] as String?,
       createdAt:
@@ -23,8 +23,13 @@ Map<String, dynamic> _$$ReactionImplToJson(_$ReactionImpl instance) =>
       'id': instance.id,
       'scheduleId': instance.scheduleId,
       'userId': instance.userId,
-      'type': instance.type,
+      'type': _$ReactionTypeEnumMap[instance.type]!,
       'userDisplayName': instance.userDisplayName,
       'userPhotoUrl': instance.userPhotoUrl,
       'createdAt': const TimestampConverter().toJson(instance.createdAt),
     };
+
+const _$ReactionTypeEnumMap = {
+  ReactionType.going: 'going',
+  ReactionType.thinking: 'thinking',
+};

--- a/lib/domain/entity/schedule_reaction.dart
+++ b/lib/domain/entity/schedule_reaction.dart
@@ -5,11 +5,17 @@ import 'package:lakiite/utils/logger.dart';
 part 'schedule_reaction.freezed.dart';
 part 'schedule_reaction.g.dart';
 
+/// スケジュール投稿に対してユーザーが選択できるリアクション種別。
+///
+/// Firestore には [JsonValue] の文字列で保存される。
 enum ReactionType {
+  /// 参加意思を示すリアクション。
   @JsonValue('going')
-  going, // 行きます！🙋
+  going,
+
+  /// 検討中であることを示すリアクション。
   @JsonValue('thinking')
-  thinking, // 考え中！🤔
+  thinking,
 }
 
 @freezed

--- a/lib/domain/entity/user_profile.dart
+++ b/lib/domain/entity/user_profile.dart
@@ -1,121 +1,40 @@
-import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
 
-class PublicProfile {
-  const PublicProfile({
-    required this.displayName,
-    required this.searchId,
-    this.iconUrl,
-    this.shortBio,
-  });
+part 'user_profile.freezed.dart';
 
-  factory PublicProfile.fromFirestore(Map<String, dynamic> data) {
-    return PublicProfile(
-      displayName: data['displayName'] as String,
-      searchId: data['searchId'] as String,
-      iconUrl: data['iconUrl'] as String?,
-      shortBio: data['shortBio'] as String?,
-    );
-  }
-  final String displayName;
-  final String searchId;
-  final String? iconUrl;
-  final String? shortBio;
-
-  Map<String, dynamic> toFirestore() {
-    return {
-      'displayName': displayName,
-      'searchId': searchId,
-      if (iconUrl != null) 'iconUrl': iconUrl,
-      if (shortBio != null) 'shortBio': shortBio,
-    };
-  }
+/// 他ユーザーにも公開されるプロフィール情報。
+@freezed
+class PublicProfile with _$PublicProfile {
+  const factory PublicProfile({
+    required String displayName,
+    required String searchId,
+    String? iconUrl,
+    String? shortBio,
+  }) = _PublicProfile;
 }
 
-class PrivateProfile {
-  const PrivateProfile({
-    required this.name,
-    required this.lists,
-    required this.createdAt,
-    this.fcmToken,
-  });
-
-  factory PrivateProfile.fromFirestore(Map<String, dynamic> data) {
-    return PrivateProfile(
-      name: data['name'] as String? ?? '',
-      lists: List<String>.from(data['lists'] ?? []),
-      createdAt: data['createdAt'] != null
-          ? (data['createdAt'] as Timestamp).toDate()
-          : DateTime.now(),
-      fcmToken: data['fcmToken'] as String?,
-    );
-  }
-  final String name;
-  final List<String> lists;
-  final DateTime createdAt;
-  final String? fcmToken;
-
-  Map<String, dynamic> toFirestore() {
-    return {
-      'name': name,
-      'lists': lists,
-      'createdAt': Timestamp.fromDate(createdAt),
-      if (fcmToken != null) 'fcmToken': fcmToken,
-    };
-  }
-}
-
-class UserProfile {
-  const UserProfile({
-    required this.id,
-    required this.publicProfile,
-    required this.privateProfile,
-    required this.friends,
-    required this.groups,
-    this.fcmToken,
-  });
-
-  factory UserProfile.fromFirestore(Map<String, dynamic> data, String id) {
-    return UserProfile(
-      id: id,
-      publicProfile: PublicProfile.fromFirestore(data),
-      privateProfile: PrivateProfile.fromFirestore(data['private'] ?? {}),
-      friends: List<String>.from(data['friends'] ?? []),
-      groups: List<String>.from(data['groups'] ?? []),
-      fcmToken: data['fcmToken'],
-    );
-  }
-  final String id;
-  final PublicProfile publicProfile;
-  final PrivateProfile privateProfile;
-  final List<String> friends;
-  final List<String> groups;
-  final String? fcmToken;
-
-  Map<String, dynamic> toFirestore() {
-    return {
-      ...publicProfile.toFirestore(),
-      'private': privateProfile.toFirestore(),
-      'friends': friends,
-      'groups': groups,
-      if (fcmToken != null) 'fcmToken': fcmToken,
-    };
-  }
-
-  UserProfile copyWith({
-    String? id,
-    PublicProfile? publicProfile,
-    PrivateProfile? privateProfile,
-    List<String>? friends,
-    List<String>? groups,
+/// 本人と内部処理で扱う非公開プロフィール情報。
+@freezed
+class PrivateProfile with _$PrivateProfile {
+  const factory PrivateProfile({
+    required String name,
+    required List<String> lists,
+    required DateTime createdAt,
     String? fcmToken,
-  }) {
-    return UserProfile(
-      id: id ?? this.id,
-      publicProfile: publicProfile ?? this.publicProfile,
-      privateProfile: privateProfile ?? this.privateProfile,
-      friends: friends ?? this.friends,
-      groups: groups ?? this.groups,
-      fcmToken: fcmToken ?? this.fcmToken,
-    );
-  }
+  }) = _PrivateProfile;
+}
+
+/// 公開プロフィール、非公開プロフィール、所属関係をまとめたユーザープロフィール。
+///
+/// Firestore の保存形式は持たず、変換は infrastructure の mapper が担当する。
+@freezed
+class UserProfile with _$UserProfile {
+  const factory UserProfile({
+    required String id,
+    required PublicProfile publicProfile,
+    required PrivateProfile privateProfile,
+    required List<String> friends,
+    required List<String> groups,
+    String? fcmToken,
+  }) = _UserProfile;
 }

--- a/lib/domain/entity/user_profile.freezed.dart
+++ b/lib/domain/entity/user_profile.freezed.dart
@@ -1,0 +1,686 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'user_profile.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$PublicProfile {
+  String get displayName => throw _privateConstructorUsedError;
+  String get searchId => throw _privateConstructorUsedError;
+  String? get iconUrl => throw _privateConstructorUsedError;
+  String? get shortBio => throw _privateConstructorUsedError;
+
+  /// Create a copy of PublicProfile
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $PublicProfileCopyWith<PublicProfile> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $PublicProfileCopyWith<$Res> {
+  factory $PublicProfileCopyWith(
+          PublicProfile value, $Res Function(PublicProfile) then) =
+      _$PublicProfileCopyWithImpl<$Res, PublicProfile>;
+  @useResult
+  $Res call(
+      {String displayName, String searchId, String? iconUrl, String? shortBio});
+}
+
+/// @nodoc
+class _$PublicProfileCopyWithImpl<$Res, $Val extends PublicProfile>
+    implements $PublicProfileCopyWith<$Res> {
+  _$PublicProfileCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of PublicProfile
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? displayName = null,
+    Object? searchId = null,
+    Object? iconUrl = freezed,
+    Object? shortBio = freezed,
+  }) {
+    return _then(_value.copyWith(
+      displayName: null == displayName
+          ? _value.displayName
+          : displayName // ignore: cast_nullable_to_non_nullable
+              as String,
+      searchId: null == searchId
+          ? _value.searchId
+          : searchId // ignore: cast_nullable_to_non_nullable
+              as String,
+      iconUrl: freezed == iconUrl
+          ? _value.iconUrl
+          : iconUrl // ignore: cast_nullable_to_non_nullable
+              as String?,
+      shortBio: freezed == shortBio
+          ? _value.shortBio
+          : shortBio // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$PublicProfileImplCopyWith<$Res>
+    implements $PublicProfileCopyWith<$Res> {
+  factory _$$PublicProfileImplCopyWith(
+          _$PublicProfileImpl value, $Res Function(_$PublicProfileImpl) then) =
+      __$$PublicProfileImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String displayName, String searchId, String? iconUrl, String? shortBio});
+}
+
+/// @nodoc
+class __$$PublicProfileImplCopyWithImpl<$Res>
+    extends _$PublicProfileCopyWithImpl<$Res, _$PublicProfileImpl>
+    implements _$$PublicProfileImplCopyWith<$Res> {
+  __$$PublicProfileImplCopyWithImpl(
+      _$PublicProfileImpl _value, $Res Function(_$PublicProfileImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of PublicProfile
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? displayName = null,
+    Object? searchId = null,
+    Object? iconUrl = freezed,
+    Object? shortBio = freezed,
+  }) {
+    return _then(_$PublicProfileImpl(
+      displayName: null == displayName
+          ? _value.displayName
+          : displayName // ignore: cast_nullable_to_non_nullable
+              as String,
+      searchId: null == searchId
+          ? _value.searchId
+          : searchId // ignore: cast_nullable_to_non_nullable
+              as String,
+      iconUrl: freezed == iconUrl
+          ? _value.iconUrl
+          : iconUrl // ignore: cast_nullable_to_non_nullable
+              as String?,
+      shortBio: freezed == shortBio
+          ? _value.shortBio
+          : shortBio // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$PublicProfileImpl implements _PublicProfile {
+  const _$PublicProfileImpl(
+      {required this.displayName,
+      required this.searchId,
+      this.iconUrl,
+      this.shortBio});
+
+  @override
+  final String displayName;
+  @override
+  final String searchId;
+  @override
+  final String? iconUrl;
+  @override
+  final String? shortBio;
+
+  @override
+  String toString() {
+    return 'PublicProfile(displayName: $displayName, searchId: $searchId, iconUrl: $iconUrl, shortBio: $shortBio)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$PublicProfileImpl &&
+            (identical(other.displayName, displayName) ||
+                other.displayName == displayName) &&
+            (identical(other.searchId, searchId) ||
+                other.searchId == searchId) &&
+            (identical(other.iconUrl, iconUrl) || other.iconUrl == iconUrl) &&
+            (identical(other.shortBio, shortBio) ||
+                other.shortBio == shortBio));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, displayName, searchId, iconUrl, shortBio);
+
+  /// Create a copy of PublicProfile
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$PublicProfileImplCopyWith<_$PublicProfileImpl> get copyWith =>
+      __$$PublicProfileImplCopyWithImpl<_$PublicProfileImpl>(this, _$identity);
+}
+
+abstract class _PublicProfile implements PublicProfile {
+  const factory _PublicProfile(
+      {required final String displayName,
+      required final String searchId,
+      final String? iconUrl,
+      final String? shortBio}) = _$PublicProfileImpl;
+
+  @override
+  String get displayName;
+  @override
+  String get searchId;
+  @override
+  String? get iconUrl;
+  @override
+  String? get shortBio;
+
+  /// Create a copy of PublicProfile
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$PublicProfileImplCopyWith<_$PublicProfileImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+mixin _$PrivateProfile {
+  String get name => throw _privateConstructorUsedError;
+  List<String> get lists => throw _privateConstructorUsedError;
+  DateTime get createdAt => throw _privateConstructorUsedError;
+  String? get fcmToken => throw _privateConstructorUsedError;
+
+  /// Create a copy of PrivateProfile
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $PrivateProfileCopyWith<PrivateProfile> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $PrivateProfileCopyWith<$Res> {
+  factory $PrivateProfileCopyWith(
+          PrivateProfile value, $Res Function(PrivateProfile) then) =
+      _$PrivateProfileCopyWithImpl<$Res, PrivateProfile>;
+  @useResult
+  $Res call(
+      {String name, List<String> lists, DateTime createdAt, String? fcmToken});
+}
+
+/// @nodoc
+class _$PrivateProfileCopyWithImpl<$Res, $Val extends PrivateProfile>
+    implements $PrivateProfileCopyWith<$Res> {
+  _$PrivateProfileCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of PrivateProfile
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? name = null,
+    Object? lists = null,
+    Object? createdAt = null,
+    Object? fcmToken = freezed,
+  }) {
+    return _then(_value.copyWith(
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      lists: null == lists
+          ? _value.lists
+          : lists // ignore: cast_nullable_to_non_nullable
+              as List<String>,
+      createdAt: null == createdAt
+          ? _value.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      fcmToken: freezed == fcmToken
+          ? _value.fcmToken
+          : fcmToken // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$PrivateProfileImplCopyWith<$Res>
+    implements $PrivateProfileCopyWith<$Res> {
+  factory _$$PrivateProfileImplCopyWith(_$PrivateProfileImpl value,
+          $Res Function(_$PrivateProfileImpl) then) =
+      __$$PrivateProfileImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String name, List<String> lists, DateTime createdAt, String? fcmToken});
+}
+
+/// @nodoc
+class __$$PrivateProfileImplCopyWithImpl<$Res>
+    extends _$PrivateProfileCopyWithImpl<$Res, _$PrivateProfileImpl>
+    implements _$$PrivateProfileImplCopyWith<$Res> {
+  __$$PrivateProfileImplCopyWithImpl(
+      _$PrivateProfileImpl _value, $Res Function(_$PrivateProfileImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of PrivateProfile
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? name = null,
+    Object? lists = null,
+    Object? createdAt = null,
+    Object? fcmToken = freezed,
+  }) {
+    return _then(_$PrivateProfileImpl(
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      lists: null == lists
+          ? _value._lists
+          : lists // ignore: cast_nullable_to_non_nullable
+              as List<String>,
+      createdAt: null == createdAt
+          ? _value.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      fcmToken: freezed == fcmToken
+          ? _value.fcmToken
+          : fcmToken // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$PrivateProfileImpl implements _PrivateProfile {
+  const _$PrivateProfileImpl(
+      {required this.name,
+      required final List<String> lists,
+      required this.createdAt,
+      this.fcmToken})
+      : _lists = lists;
+
+  @override
+  final String name;
+  final List<String> _lists;
+  @override
+  List<String> get lists {
+    if (_lists is EqualUnmodifiableListView) return _lists;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_lists);
+  }
+
+  @override
+  final DateTime createdAt;
+  @override
+  final String? fcmToken;
+
+  @override
+  String toString() {
+    return 'PrivateProfile(name: $name, lists: $lists, createdAt: $createdAt, fcmToken: $fcmToken)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$PrivateProfileImpl &&
+            (identical(other.name, name) || other.name == name) &&
+            const DeepCollectionEquality().equals(other._lists, _lists) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt) &&
+            (identical(other.fcmToken, fcmToken) ||
+                other.fcmToken == fcmToken));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, name,
+      const DeepCollectionEquality().hash(_lists), createdAt, fcmToken);
+
+  /// Create a copy of PrivateProfile
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$PrivateProfileImplCopyWith<_$PrivateProfileImpl> get copyWith =>
+      __$$PrivateProfileImplCopyWithImpl<_$PrivateProfileImpl>(
+          this, _$identity);
+}
+
+abstract class _PrivateProfile implements PrivateProfile {
+  const factory _PrivateProfile(
+      {required final String name,
+      required final List<String> lists,
+      required final DateTime createdAt,
+      final String? fcmToken}) = _$PrivateProfileImpl;
+
+  @override
+  String get name;
+  @override
+  List<String> get lists;
+  @override
+  DateTime get createdAt;
+  @override
+  String? get fcmToken;
+
+  /// Create a copy of PrivateProfile
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$PrivateProfileImplCopyWith<_$PrivateProfileImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+mixin _$UserProfile {
+  String get id => throw _privateConstructorUsedError;
+  PublicProfile get publicProfile => throw _privateConstructorUsedError;
+  PrivateProfile get privateProfile => throw _privateConstructorUsedError;
+  List<String> get friends => throw _privateConstructorUsedError;
+  List<String> get groups => throw _privateConstructorUsedError;
+  String? get fcmToken => throw _privateConstructorUsedError;
+
+  /// Create a copy of UserProfile
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $UserProfileCopyWith<UserProfile> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $UserProfileCopyWith<$Res> {
+  factory $UserProfileCopyWith(
+          UserProfile value, $Res Function(UserProfile) then) =
+      _$UserProfileCopyWithImpl<$Res, UserProfile>;
+  @useResult
+  $Res call(
+      {String id,
+      PublicProfile publicProfile,
+      PrivateProfile privateProfile,
+      List<String> friends,
+      List<String> groups,
+      String? fcmToken});
+
+  $PublicProfileCopyWith<$Res> get publicProfile;
+  $PrivateProfileCopyWith<$Res> get privateProfile;
+}
+
+/// @nodoc
+class _$UserProfileCopyWithImpl<$Res, $Val extends UserProfile>
+    implements $UserProfileCopyWith<$Res> {
+  _$UserProfileCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of UserProfile
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? publicProfile = null,
+    Object? privateProfile = null,
+    Object? friends = null,
+    Object? groups = null,
+    Object? fcmToken = freezed,
+  }) {
+    return _then(_value.copyWith(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      publicProfile: null == publicProfile
+          ? _value.publicProfile
+          : publicProfile // ignore: cast_nullable_to_non_nullable
+              as PublicProfile,
+      privateProfile: null == privateProfile
+          ? _value.privateProfile
+          : privateProfile // ignore: cast_nullable_to_non_nullable
+              as PrivateProfile,
+      friends: null == friends
+          ? _value.friends
+          : friends // ignore: cast_nullable_to_non_nullable
+              as List<String>,
+      groups: null == groups
+          ? _value.groups
+          : groups // ignore: cast_nullable_to_non_nullable
+              as List<String>,
+      fcmToken: freezed == fcmToken
+          ? _value.fcmToken
+          : fcmToken // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+
+  /// Create a copy of UserProfile
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $PublicProfileCopyWith<$Res> get publicProfile {
+    return $PublicProfileCopyWith<$Res>(_value.publicProfile, (value) {
+      return _then(_value.copyWith(publicProfile: value) as $Val);
+    });
+  }
+
+  /// Create a copy of UserProfile
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $PrivateProfileCopyWith<$Res> get privateProfile {
+    return $PrivateProfileCopyWith<$Res>(_value.privateProfile, (value) {
+      return _then(_value.copyWith(privateProfile: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$UserProfileImplCopyWith<$Res>
+    implements $UserProfileCopyWith<$Res> {
+  factory _$$UserProfileImplCopyWith(
+          _$UserProfileImpl value, $Res Function(_$UserProfileImpl) then) =
+      __$$UserProfileImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String id,
+      PublicProfile publicProfile,
+      PrivateProfile privateProfile,
+      List<String> friends,
+      List<String> groups,
+      String? fcmToken});
+
+  @override
+  $PublicProfileCopyWith<$Res> get publicProfile;
+  @override
+  $PrivateProfileCopyWith<$Res> get privateProfile;
+}
+
+/// @nodoc
+class __$$UserProfileImplCopyWithImpl<$Res>
+    extends _$UserProfileCopyWithImpl<$Res, _$UserProfileImpl>
+    implements _$$UserProfileImplCopyWith<$Res> {
+  __$$UserProfileImplCopyWithImpl(
+      _$UserProfileImpl _value, $Res Function(_$UserProfileImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of UserProfile
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? publicProfile = null,
+    Object? privateProfile = null,
+    Object? friends = null,
+    Object? groups = null,
+    Object? fcmToken = freezed,
+  }) {
+    return _then(_$UserProfileImpl(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      publicProfile: null == publicProfile
+          ? _value.publicProfile
+          : publicProfile // ignore: cast_nullable_to_non_nullable
+              as PublicProfile,
+      privateProfile: null == privateProfile
+          ? _value.privateProfile
+          : privateProfile // ignore: cast_nullable_to_non_nullable
+              as PrivateProfile,
+      friends: null == friends
+          ? _value._friends
+          : friends // ignore: cast_nullable_to_non_nullable
+              as List<String>,
+      groups: null == groups
+          ? _value._groups
+          : groups // ignore: cast_nullable_to_non_nullable
+              as List<String>,
+      fcmToken: freezed == fcmToken
+          ? _value.fcmToken
+          : fcmToken // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$UserProfileImpl implements _UserProfile {
+  const _$UserProfileImpl(
+      {required this.id,
+      required this.publicProfile,
+      required this.privateProfile,
+      required final List<String> friends,
+      required final List<String> groups,
+      this.fcmToken})
+      : _friends = friends,
+        _groups = groups;
+
+  @override
+  final String id;
+  @override
+  final PublicProfile publicProfile;
+  @override
+  final PrivateProfile privateProfile;
+  final List<String> _friends;
+  @override
+  List<String> get friends {
+    if (_friends is EqualUnmodifiableListView) return _friends;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_friends);
+  }
+
+  final List<String> _groups;
+  @override
+  List<String> get groups {
+    if (_groups is EqualUnmodifiableListView) return _groups;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_groups);
+  }
+
+  @override
+  final String? fcmToken;
+
+  @override
+  String toString() {
+    return 'UserProfile(id: $id, publicProfile: $publicProfile, privateProfile: $privateProfile, friends: $friends, groups: $groups, fcmToken: $fcmToken)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$UserProfileImpl &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.publicProfile, publicProfile) ||
+                other.publicProfile == publicProfile) &&
+            (identical(other.privateProfile, privateProfile) ||
+                other.privateProfile == privateProfile) &&
+            const DeepCollectionEquality().equals(other._friends, _friends) &&
+            const DeepCollectionEquality().equals(other._groups, _groups) &&
+            (identical(other.fcmToken, fcmToken) ||
+                other.fcmToken == fcmToken));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      id,
+      publicProfile,
+      privateProfile,
+      const DeepCollectionEquality().hash(_friends),
+      const DeepCollectionEquality().hash(_groups),
+      fcmToken);
+
+  /// Create a copy of UserProfile
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$UserProfileImplCopyWith<_$UserProfileImpl> get copyWith =>
+      __$$UserProfileImplCopyWithImpl<_$UserProfileImpl>(this, _$identity);
+}
+
+abstract class _UserProfile implements UserProfile {
+  const factory _UserProfile(
+      {required final String id,
+      required final PublicProfile publicProfile,
+      required final PrivateProfile privateProfile,
+      required final List<String> friends,
+      required final List<String> groups,
+      final String? fcmToken}) = _$UserProfileImpl;
+
+  @override
+  String get id;
+  @override
+  PublicProfile get publicProfile;
+  @override
+  PrivateProfile get privateProfile;
+  @override
+  List<String> get friends;
+  @override
+  List<String> get groups;
+  @override
+  String? get fcmToken;
+
+  /// Create a copy of UserProfile
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$UserProfileImplCopyWith<_$UserProfileImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/domain/repository/reaction_repository.dart
+++ b/lib/domain/repository/reaction_repository.dart
@@ -1,7 +1,18 @@
 import 'package:lakiite/domain/entity/reaction.dart';
+import 'package:lakiite/domain/entity/schedule_reaction.dart';
 
+/// スケジュールリアクションの永続化を抽象化する repository。
 abstract class ReactionRepository {
+  /// 指定したスケジュールに紐づくリアクション一覧を取得する。
   Future<List<Reaction>> getReactionsForSchedule(String scheduleId);
-  Future<void> addReaction(String scheduleId, String userId, String type);
+
+  /// 指定したユーザーのリアクションを追加または更新する。
+  Future<void> addReaction(
+    String scheduleId,
+    String userId,
+    ReactionType type,
+  );
+
+  /// 指定したユーザーのリアクションを削除する。
   Future<void> removeReaction(String scheduleId, String userId);
 }

--- a/lib/infrastructure/mapper/notification_mapper.dart
+++ b/lib/infrastructure/mapper/notification_mapper.dart
@@ -1,0 +1,59 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:lakiite/domain/entity/notification.dart';
+
+/// Firestore の通知ドキュメントと domain の [Notification] を相互変換する mapper。
+class NotificationMapper {
+  const NotificationMapper._();
+
+  /// Firestore のドキュメント ID とデータから [Notification] を生成する。
+  static Notification fromFirestore({
+    required String id,
+    required Map<String, dynamic> data,
+  }) {
+    return Notification(
+      id: id,
+      type: NotificationType.values.firstWhere(
+        (type) => type.name == data['type'] as String,
+      ),
+      sendUserId: data['sendUserId'] as String,
+      receiveUserId: data['receiveUserId'] as String,
+      sendUserDisplayName: data['sendUserDisplayName'] as String?,
+      receiveUserDisplayName: data['receiveUserDisplayName'] as String?,
+      status: NotificationStatus.values.firstWhere(
+        (status) =>
+            status.name ==
+            (data['status'] as String? ?? NotificationStatus.pending.name),
+      ),
+      createdAt: (data['createdAt'] as Timestamp).toDate(),
+      updatedAt: (data['updatedAt'] as Timestamp).toDate(),
+      rejectionCount: data['rejectionCount'] as int? ?? 0,
+      isRead: data['isRead'] as bool? ?? false,
+      groupId: data['groupId'] as String?,
+      relatedItemId: data['relatedItemId'] as String?,
+      interactionId: data['interactionId'] as String?,
+    );
+  }
+
+  /// [Notification] を Firestore 保存用の Map に変換する。
+  ///
+  /// ドキュメント ID として扱う [Notification.id] は保存データに含めない。
+  static Map<String, dynamic> toFirestore(Notification notification) {
+    return {
+      'type': notification.type.name,
+      'sendUserId': notification.sendUserId,
+      'receiveUserId': notification.receiveUserId,
+      'sendUserDisplayName': notification.sendUserDisplayName,
+      'receiveUserDisplayName': notification.receiveUserDisplayName,
+      'status': notification.status.name,
+      'createdAt': FieldValue.serverTimestamp(),
+      'updatedAt': FieldValue.serverTimestamp(),
+      'rejectionCount': notification.rejectionCount,
+      'isRead': notification.isRead,
+      if (notification.groupId != null) 'groupId': notification.groupId,
+      if (notification.relatedItemId != null)
+        'relatedItemId': notification.relatedItemId,
+      if (notification.interactionId != null)
+        'interactionId': notification.interactionId,
+    };
+  }
+}

--- a/lib/infrastructure/mapper/user_profile_mapper.dart
+++ b/lib/infrastructure/mapper/user_profile_mapper.dart
@@ -1,0 +1,77 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:lakiite/domain/entity/user_profile.dart';
+
+/// Firestore のユーザープロフィールデータと domain model を相互変換する mapper。
+class UserProfileMapper {
+  const UserProfileMapper._();
+
+  /// Firestore のドキュメント ID とデータから [UserProfile] を生成する。
+  static UserProfile fromFirestore({
+    required String id,
+    required Map<String, dynamic> data,
+  }) {
+    return UserProfile(
+      id: id,
+      publicProfile: PublicProfile(
+        displayName: data['displayName'] as String,
+        searchId: data['searchId'] as String,
+        iconUrl: data['iconUrl'] as String?,
+        shortBio: data['shortBio'] as String?,
+      ),
+      privateProfile: _privateProfileFromFirestore(
+        data['private'] as Map<String, dynamic>? ?? const {},
+      ),
+      friends: List<String>.from(data['friends'] ?? []),
+      groups: List<String>.from(data['groups'] ?? []),
+      fcmToken: data['fcmToken'] as String?,
+    );
+  }
+
+  /// [UserProfile] を Firestore 保存用の Map に変換する。
+  ///
+  /// ドキュメント ID として扱う [UserProfile.id] は保存データに含めない。
+  static Map<String, dynamic> toFirestore(UserProfile profile) {
+    return {
+      ..._publicProfileToFirestore(profile.publicProfile),
+      'private': _privateProfileToFirestore(profile.privateProfile),
+      'friends': profile.friends,
+      'groups': profile.groups,
+      if (profile.fcmToken != null) 'fcmToken': profile.fcmToken,
+    };
+  }
+
+  static PrivateProfile _privateProfileFromFirestore(
+    Map<String, dynamic> data,
+  ) {
+    return PrivateProfile(
+      name: data['name'] as String? ?? '',
+      lists: List<String>.from(data['lists'] ?? []),
+      createdAt: data['createdAt'] != null
+          ? (data['createdAt'] as Timestamp).toDate()
+          : DateTime.now(),
+      fcmToken: data['fcmToken'] as String?,
+    );
+  }
+
+  static Map<String, dynamic> _publicProfileToFirestore(
+    PublicProfile profile,
+  ) {
+    return {
+      'displayName': profile.displayName,
+      'searchId': profile.searchId,
+      if (profile.iconUrl != null) 'iconUrl': profile.iconUrl,
+      if (profile.shortBio != null) 'shortBio': profile.shortBio,
+    };
+  }
+
+  static Map<String, dynamic> _privateProfileToFirestore(
+    PrivateProfile profile,
+  ) {
+    return {
+      'name': profile.name,
+      'lists': profile.lists,
+      'createdAt': Timestamp.fromDate(profile.createdAt),
+      if (profile.fcmToken != null) 'fcmToken': profile.fcmToken,
+    };
+  }
+}

--- a/lib/infrastructure/notification_repository.dart
+++ b/lib/infrastructure/notification_repository.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import '../domain/entity/notification.dart';
 import '../domain/interfaces/i_notification_repository.dart';
+import 'mapper/notification_mapper.dart';
 import 'notification_repository_update_data.dart';
 import '../utils/logger.dart';
 
@@ -15,10 +16,10 @@ class NotificationRepository implements INotificationRepository {
   /// [notification] 作成する通知オブジェクト
   @override
   Future<void> createNotification(Notification notification) async {
-    AppLogger.debug('Creating notification: ${notification.toFirestore()}');
+    AppLogger.debug('Creating notification: $notification');
     try {
       final docRef = _firestore.collection('notifications').doc();
-      final data = notification.toFirestore();
+      final data = NotificationMapper.toFirestore(notification);
       AppLogger.debug('Notification data to save: $data');
       await docRef.set(data);
       AppLogger.debug(
@@ -41,7 +42,7 @@ class NotificationRepository implements INotificationRepository {
       await _firestore
           .collection('notifications')
           .doc(notification.id)
-          .update(notification.toFirestore());
+          .update(NotificationMapper.toFirestore(notification));
       AppLogger.debug('Notification updated successfully: ${notification.id}');
     } catch (e) {
       AppLogger.error('Error updating notification: $e');
@@ -66,9 +67,8 @@ class NotificationRepository implements INotificationRepository {
         return null;
       }
       final data = doc.data()!;
-      data['id'] = doc.id;
       AppLogger.debug('Notification retrieved successfully: $notificationId');
-      return Notification.fromJson(data);
+      return NotificationMapper.fromFirestore(id: doc.id, data: data);
     } catch (e) {
       AppLogger.error('Error getting notification: $e');
       rethrow;
@@ -159,8 +159,7 @@ class NotificationRepository implements INotificationRepository {
   List<Notification> _mapQuerySnapshotToNotifications(QuerySnapshot snapshot) {
     final notifications = snapshot.docs.map((doc) {
       final data = doc.data() as Map<String, dynamic>;
-      data['id'] = doc.id;
-      return Notification.fromJson(data);
+      return NotificationMapper.fromFirestore(id: doc.id, data: data);
     }).toList();
     AppLogger.debug('Received ${notifications.length} notifications');
     return notifications;

--- a/lib/infrastructure/repository/reaction_repository_impl.dart
+++ b/lib/infrastructure/repository/reaction_repository_impl.dart
@@ -1,7 +1,9 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:lakiite/domain/entity/reaction.dart';
 import 'package:lakiite/domain/repository/reaction_repository.dart';
+import 'package:lakiite/domain/entity/schedule_reaction.dart';
 
+/// Firestore を使ってスケジュールリアクションを読み書きする repository 実装。
 class ReactionRepositoryImpl implements ReactionRepository {
   ReactionRepositoryImpl(this._firestore);
   final FirebaseFirestore _firestore;
@@ -30,7 +32,10 @@ class ReactionRepositoryImpl implements ReactionRepository {
 
   @override
   Future<void> addReaction(
-      String scheduleId, String userId, String type) async {
+    String scheduleId,
+    String userId,
+    ReactionType type,
+  ) async {
     final userDoc = await _firestore.collection('users').doc(userId).get();
     final userData = userDoc.data();
 
@@ -41,7 +46,10 @@ class ReactionRepositoryImpl implements ReactionRepository {
         .doc(userId)
         .set({
       'userId': userId,
-      'type': type,
+      'type': switch (type) {
+        ReactionType.going => 'going',
+        ReactionType.thinking => 'thinking',
+      },
       'userDisplayName': userData?['displayName'] as String,
       'userPhotoUrl': userData?['iconUrl'] as String?,
       'createdAt': FieldValue.serverTimestamp(),

--- a/lib/presentation/calendar/schedule_detail_page.dart
+++ b/lib/presentation/calendar/schedule_detail_page.dart
@@ -16,6 +16,7 @@ import 'package:lakiite/presentation/widgets/default_user_icon.dart';
 import 'package:lakiite/domain/entity/notification.dart' as domain;
 import 'package:lakiite/application/notification/notification_notifier.dart';
 import 'package:lakiite/presentation/widgets/reaction_icon_widget.dart';
+import 'package:lakiite/presentation/widgets/reaction_type_view_extension.dart';
 
 /// スケジュールの詳細情報を表示するページ
 ///
@@ -434,10 +435,7 @@ class ScheduleDetailPage extends HookConsumerWidget {
                                               const SizedBox(width: 4),
                                               Text(
                                                 userReaction != null
-                                                    ? (userReaction.type ==
-                                                            ReactionType.going
-                                                        ? '行きます！'
-                                                        : '考え中！')
+                                                    ? userReaction.type.label
                                                     : 'リアクション',
                                                 style: TextStyle(
                                                   color: userReaction != null
@@ -468,7 +466,7 @@ class ScheduleDetailPage extends HookConsumerWidget {
                                             child: Row(
                                               children: [
                                                 const Text('🙋 '),
-                                                const Text('行きます！'),
+                                                Text(ReactionType.going.label),
                                                 const Spacer(),
                                                 if (userReaction?.type ==
                                                     ReactionType.going)
@@ -487,7 +485,8 @@ class ScheduleDetailPage extends HookConsumerWidget {
                                             child: Row(
                                               children: [
                                                 const Text('🤔 '),
-                                                const Text('考え中！'),
+                                                Text(ReactionType
+                                                    .thinking.label),
                                                 const Spacer(),
                                                 if (userReaction?.type ==
                                                     ReactionType.thinking)
@@ -707,7 +706,7 @@ class ScheduleDetailPage extends HookConsumerWidget {
                               right: 0,
                               bottom: 0,
                               child: Text(
-                                reaction.type == 'going' ? '🙋' : '🤔',
+                                reaction.type.emoji,
                                 style: const TextStyle(fontSize: 16),
                               ),
                             ),

--- a/lib/presentation/widgets/reaction_type_view_extension.dart
+++ b/lib/presentation/widgets/reaction_type_view_extension.dart
@@ -1,0 +1,16 @@
+import 'package:lakiite/domain/entity/schedule_reaction.dart';
+
+/// [ReactionType] を UI 表示用の値に変換する拡張。
+extension ReactionTypeViewX on ReactionType {
+  /// リアクション選択 UI や表示テキストで使うラベル。
+  String get label => switch (this) {
+        ReactionType.going => '行きます！',
+        ReactionType.thinking => '考え中！',
+      };
+
+  /// リアクションを短く表現する絵文字。
+  String get emoji => switch (this) {
+        ReactionType.going => '🙋',
+        ReactionType.thinking => '🤔',
+      };
+}

--- a/test/domain/entity/reaction_test.dart
+++ b/test/domain/entity/reaction_test.dart
@@ -1,0 +1,35 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lakiite/domain/entity/reaction.dart';
+import 'package:lakiite/domain/entity/schedule_reaction.dart';
+
+void main() {
+  group('Reaction', () {
+    test('Firestore JSONのtypeをReactionTypeとして復元する', () {
+      final reaction = Reaction.fromJson({
+        'id': 'reaction-1',
+        'scheduleId': 'schedule-1',
+        'userId': 'user-1',
+        'type': 'going',
+        'userDisplayName': 'User One',
+        'userPhotoUrl': null,
+        'createdAt': Timestamp.fromDate(DateTime(2026)),
+      });
+
+      expect(reaction.type, ReactionType.going);
+    });
+
+    test('ReactionTypeをFirestore JSONのtype文字列へ変換する', () {
+      final reaction = Reaction(
+        id: 'reaction-1',
+        scheduleId: 'schedule-1',
+        userId: 'user-1',
+        type: ReactionType.thinking,
+        userDisplayName: 'User One',
+        createdAt: DateTime(2026),
+      );
+
+      expect(reaction.toJson()['type'], 'thinking');
+    });
+  });
+}

--- a/test/infrastructure/notification_mapper_test.dart
+++ b/test/infrastructure/notification_mapper_test.dart
@@ -1,0 +1,58 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lakiite/domain/entity/notification.dart';
+import 'package:lakiite/infrastructure/mapper/notification_mapper.dart';
+
+void main() {
+  group('NotificationMapper', () {
+    test('Firestore dataからNotificationを復元する', () {
+      final createdAt = DateTime(2026);
+      final updatedAt = DateTime(2026, 1, 2);
+
+      final notification = NotificationMapper.fromFirestore(
+        id: 'notification-1',
+        data: {
+          'type': 'reaction',
+          'sendUserId': 'sender-1',
+          'receiveUserId': 'receiver-1',
+          'sendUserDisplayName': 'Sender',
+          'status': 'accepted',
+          'createdAt': Timestamp.fromDate(createdAt),
+          'updatedAt': Timestamp.fromDate(updatedAt),
+          'isRead': true,
+          'relatedItemId': 'schedule-1',
+          'interactionId': 'reaction-1',
+        },
+      );
+
+      expect(notification.id, 'notification-1');
+      expect(notification.type, NotificationType.reaction);
+      expect(notification.status, NotificationStatus.accepted);
+      expect(notification.createdAt, createdAt);
+      expect(notification.updatedAt, updatedAt);
+      expect(notification.relatedItemId, 'schedule-1');
+      expect(notification.interactionId, 'reaction-1');
+    });
+
+    test('NotificationをFirestore保存用dataへ変換する', () {
+      final notification = Notification.createGroupInvitation(
+        fromUserId: 'sender-1',
+        toUserId: 'receiver-1',
+        groupId: 'group-1',
+        fromUserDisplayName: 'Sender',
+        toUserDisplayName: 'Receiver',
+      );
+
+      final data = NotificationMapper.toFirestore(notification);
+
+      expect(data, isNot(contains('id')));
+      expect(data['type'], 'groupInvitation');
+      expect(data['status'], 'pending');
+      expect(data['sendUserId'], 'sender-1');
+      expect(data['receiveUserId'], 'receiver-1');
+      expect(data['groupId'], 'group-1');
+      expect(data['createdAt'], isA<FieldValue>());
+      expect(data['updatedAt'], isA<FieldValue>());
+    });
+  });
+}

--- a/test/infrastructure/user_profile_mapper_test.dart
+++ b/test/infrastructure/user_profile_mapper_test.dart
@@ -1,0 +1,71 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lakiite/domain/entity/user_profile.dart';
+import 'package:lakiite/infrastructure/mapper/user_profile_mapper.dart';
+
+void main() {
+  group('UserProfileMapper', () {
+    test('Firestore dataからUserProfileを復元する', () {
+      final createdAt = DateTime(2026);
+
+      final profile = UserProfileMapper.fromFirestore(
+        id: 'user-1',
+        data: {
+          'displayName': 'Display Name',
+          'searchId': 'SEARCH01',
+          'iconUrl': 'https://example.com/icon.png',
+          'shortBio': 'bio',
+          'private': {
+            'name': 'Private Name',
+            'lists': ['list-1'],
+            'createdAt': Timestamp.fromDate(createdAt),
+            'fcmToken': 'token-1',
+          },
+          'friends': ['friend-1'],
+          'groups': ['group-1'],
+          'fcmToken': 'root-token',
+        },
+      );
+
+      expect(profile.id, 'user-1');
+      expect(profile.publicProfile.displayName, 'Display Name');
+      expect(profile.publicProfile.searchId, 'SEARCH01');
+      expect(profile.privateProfile.name, 'Private Name');
+      expect(profile.privateProfile.createdAt, createdAt);
+      expect(profile.friends, ['friend-1']);
+      expect(profile.groups, ['group-1']);
+    });
+
+    test('UserProfileをFirestore保存用dataへ変換する', () {
+      final createdAt = DateTime(2026);
+      const publicProfile = PublicProfile(
+        displayName: 'Display Name',
+        searchId: 'SEARCH01',
+        shortBio: 'bio',
+      );
+      final privateProfile = PrivateProfile(
+        name: 'Private Name',
+        lists: const ['list-1'],
+        createdAt: createdAt,
+      );
+      final profile = UserProfile(
+        id: 'user-1',
+        publicProfile: publicProfile,
+        privateProfile: privateProfile,
+        friends: const ['friend-1'],
+        groups: const ['group-1'],
+      );
+
+      final data = UserProfileMapper.toFirestore(profile);
+
+      expect(data, isNot(contains('id')));
+      expect(data['displayName'], 'Display Name');
+      expect(data['searchId'], 'SEARCH01');
+      expect(data['private'], isA<Map<String, dynamic>>());
+      expect((data['private'] as Map<String, dynamic>)['createdAt'],
+          Timestamp.fromDate(createdAt));
+      expect(data['friends'], ['friend-1']);
+      expect(data['groups'], ['group-1']);
+    });
+  });
+}

--- a/test/presentation/widgets/reaction_type_view_extension_test.dart
+++ b/test/presentation/widgets/reaction_type_view_extension_test.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lakiite/domain/entity/schedule_reaction.dart';
+import 'package:lakiite/presentation/widgets/reaction_type_view_extension.dart';
+
+void main() {
+  group('ReactionTypeViewX', () {
+    test('UI表示に必要なラベルと絵文字をenumから取得できる', () {
+      expect(ReactionType.going.label, '行きます！');
+      expect(ReactionType.going.emoji, '🙋');
+      expect(ReactionType.thinking.label, '考え中！');
+      expect(ReactionType.thinking.emoji, '🤔');
+    });
+  });
+}


### PR DESCRIPTION
## 概要

PR #735 のレビュー観点をこのプロジェクトにも適用し、domain / infrastructure / presentation の責務が混ざっていた箇所をTDDで整理しました。

## 変更内容

- `Notification` と `UserProfile` をFreezed data class化
- Firestoreの `Timestamp` / `FieldValue` 変換を `infrastructure/mapper` へ分離
- `Reaction.type` を `String` から `ReactionType` enum に変更
- `ReactionType` のUI表示ラベル・絵文字をpresentation層のextensionへ移動
- entity / enum / repository interfaceへdoc commentを追加
- mapperと表示extensionのテストを追加

## 影響

- domain entityからFirestore保存形式の知識を減らし、層の責務を明確化しました。
- 既存の通知・プロフィール保存処理はmapper経由で同等のFirestore形式を維持しています。
- reaction種別は文字列比較ではなくenumで扱うようになります。

## 検証

- `fvm flutter analyze`
- `fvm flutter test`
- `git diff --check`

全体テストは `All tests passed!` まで確認済みです。