### PR TITLE
[codex] Add primary user flow tests

### DIFF
--- a/lib/application/notification/notification_notifier.dart
+++ b/lib/application/notification/notification_notifier.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../domain/entity/notification.dart' as domain;
 import '../../domain/interfaces/i_notification_repository.dart';
+import '../../domain/interfaces/i_user_repository.dart';
 import '../../infrastructure/notification_repository.dart';
 import '../../infrastructure/firebase/push_notification_service.dart';
 import '../../utils/logger.dart';
@@ -16,6 +17,11 @@ typedef NotificationType = domain.NotificationType;
 /// 通知リポジトリのインスタンスを提供する
 final notificationRepositoryProvider = Provider<INotificationRepository>((ref) {
   return NotificationRepository();
+});
+
+/// Push通知送信サービスのインスタンスを提供する
+final pushNotificationSenderProvider = Provider<PushNotificationSender>((ref) {
+  return PushNotificationSender();
 });
 
 /// 現在のユーザーIDを提供するプロバイダー
@@ -118,9 +124,11 @@ final sentNotificationsByTypeProvider =
 /// 各操作の実行中はローディング状態を提供し、
 /// エラーが発生した場合はエラー状態を提供する
 class NotificationNotifier extends StateNotifier<AsyncValue<void>> {
-  NotificationNotifier(this._repository, this._ref)
-      : _pushNotificationSender = PushNotificationSender(),
-        super(const AsyncValue.data(null));
+  NotificationNotifier(
+    this._repository,
+    this._pushNotificationSender,
+    this._ref,
+  ) : super(const AsyncValue.data(null));
   final INotificationRepository _repository;
   final PushNotificationSender _pushNotificationSender;
   final Ref _ref;
@@ -216,6 +224,11 @@ class NotificationNotifier extends StateNotifier<AsyncValue<void>> {
       // 通知の内容を取得して、通知タイプを確認
       final notification = await _repository.getNotification(notificationId);
 
+      if (notification != null &&
+          notification.type == NotificationType.friend) {
+        await _connectFriendUsers(notification);
+      }
+
       // 通知を承認
       await _repository.acceptNotification(notificationId);
 
@@ -244,6 +257,32 @@ class NotificationNotifier extends StateNotifier<AsyncValue<void>> {
     } catch (e, stack) {
       state = AsyncValue.error(e, stack);
     }
+  }
+
+  Future<void> _connectFriendUsers(Notification notification) async {
+    final userRepo = _ref.read(userRepositoryProvider);
+    await _addFriendIfNeeded(
+      userRepo,
+      userId: notification.receiveUserId,
+      friendId: notification.sendUserId,
+    );
+    await _addFriendIfNeeded(
+      userRepo,
+      userId: notification.sendUserId,
+      friendId: notification.receiveUserId,
+    );
+  }
+
+  Future<void> _addFriendIfNeeded(
+    IUserRepository userRepo, {
+    required String userId,
+    required String friendId,
+  }) async {
+    final user = await userRepo.getUser(userId);
+    if (user?.friends.contains(friendId) ?? false) {
+      return;
+    }
+    await userRepo.addToList(userId, friendId);
   }
 
   /// 通知を拒否する
@@ -387,5 +426,6 @@ class NotificationNotifier extends StateNotifier<AsyncValue<void>> {
 final notificationNotifierProvider =
     StateNotifierProvider<NotificationNotifier, AsyncValue<void>>((ref) {
   final repository = ref.watch(notificationRepositoryProvider);
-  return NotificationNotifier(repository, ref);
+  final pushNotificationSender = ref.watch(pushNotificationSenderProvider);
+  return NotificationNotifier(repository, pushNotificationSender, ref);
 });

--- a/test/application/flows/primary_user_flows_test.dart
+++ b/test/application/flows/primary_user_flows_test.dart
@@ -1,0 +1,346 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:lakiite/app/di/providers.dart' as di;
+import 'package:lakiite/application/auth/auth_notifier.dart' as auth_app;
+import 'package:lakiite/application/auth/auth_state.dart';
+import 'package:lakiite/application/notification/notification_notifier.dart'
+    as notification_app;
+import 'package:lakiite/application/schedule/schedule_notifier.dart';
+import 'package:lakiite/domain/entity/notification.dart';
+import 'package:lakiite/domain/entity/schedule_comment.dart';
+import 'package:lakiite/domain/entity/schedule_reaction.dart';
+import 'package:lakiite/domain/interfaces/i_friend_list_repository.dart';
+import 'package:lakiite/domain/interfaces/i_image_processor_service.dart';
+import 'package:lakiite/domain/interfaces/i_schedule_interaction_repository.dart';
+import 'package:lakiite/domain/interfaces/i_storage_service.dart';
+import 'package:lakiite/infrastructure/firebase/push_notification_sender.dart';
+import 'package:lakiite/infrastructure/providers.dart';
+import 'package:lakiite/presentation/my_page/my_page_view_model.dart';
+
+import '../../mock/base_mock.dart';
+import '../../mock/repository/mock_auth_repository.dart';
+import '../../mock/repository/mock_notification_repository.dart';
+import '../../mock/repository/mock_schedule_repository.dart';
+import '../../mock/repository/mock_user_repository.dart';
+
+void main() {
+  group('Primary user flows', () {
+    late MockAuthRepository authRepository;
+    late MockUserRepository userRepository;
+    late MockScheduleRepository scheduleRepository;
+    late MockNotificationRepository notificationRepository;
+    late _FakeFriendListRepository friendListRepository;
+    late _FakeScheduleInteractionRepository scheduleInteractionRepository;
+    late _FakeStorageService storageService;
+    late _FakeImageProcessorService imageProcessorService;
+    late ProviderContainer container;
+
+    setUp(() {
+      authRepository = MockAuthRepository();
+      userRepository = MockUserRepository();
+      scheduleRepository = MockScheduleRepository();
+      notificationRepository = MockNotificationRepository();
+      friendListRepository = _FakeFriendListRepository();
+      scheduleInteractionRepository = _FakeScheduleInteractionRepository();
+      storageService = _FakeStorageService();
+      imageProcessorService = _FakeImageProcessorService();
+
+      container = ProviderContainer(
+        overrides: [
+          auth_app.authRepositoryProvider.overrideWithValue(authRepository),
+          auth_app.authStateStreamProvider.overrideWith((ref) {
+            return authRepository.authStateChanges().map((user) {
+              if (user == null) {
+                return AuthState.unauthenticated();
+              }
+              return AuthState.authenticated(user);
+            });
+          }),
+          di.userRepositoryProvider.overrideWithValue(userRepository),
+          di.scheduleRepositoryProvider.overrideWithValue(scheduleRepository),
+          di.friendListRepositoryProvider
+              .overrideWithValue(friendListRepository),
+          di.scheduleInteractionRepositoryProvider
+              .overrideWithValue(scheduleInteractionRepository),
+          notification_app.notificationRepositoryProvider
+              .overrideWithValue(notificationRepository),
+          notification_app.pushNotificationSenderProvider.overrideWithValue(
+            PushNotificationSender(
+              cloudFunctionUrl: 'https://example.test/push',
+              tokenResolver: (_) async => const [],
+            ),
+          ),
+          storageServiceProvider.overrideWithValue(storageService),
+          imageProcessorServiceProvider
+              .overrideWithValue(imageProcessorService),
+        ],
+      );
+    });
+
+    tearDown(() {
+      container.dispose();
+      authRepository.dispose();
+    });
+
+    test('ログインすると認証済み状態になる', () async {
+      AsyncValue<AuthState>? latestState;
+      final subscription = container.listen(
+        auth_app.authNotifierProvider,
+        (_, next) => latestState = next,
+        fireImmediately: true,
+      );
+      addTearDown(subscription.close);
+
+      await container
+          .read(auth_app.authNotifierProvider.notifier)
+          .signIn(BaseMock.testEmail, 'password123');
+
+      final state = latestState;
+
+      expect(state?.hasValue, isTrue);
+      expect(state?.requireValue.isAuthenticated, isTrue);
+      expect(state?.requireValue.user?.id, BaseMock.testUserId);
+    });
+
+    test('新規作成すると表示名がユーザー情報へ反映される', () async {
+      userRepository.addTestUser(BaseMock.createTestUser());
+
+      await container.read(auth_app.authNotifierProvider.notifier).signUp(
+            'new-user@example.com',
+            'password123',
+            '登録名',
+            displayName: '表示名',
+          );
+
+      final createdUser = await userRepository.getUser(BaseMock.testUserId);
+
+      expect(createdUser?.name, '登録名');
+      expect(createdUser?.displayName, '表示名');
+    });
+
+    test('友達申請を作成できる', () async {
+      await container
+          .read(notification_app.notificationNotifierProvider.notifier)
+          .createFriendRequest(
+            fromUserId: 'sender-id',
+            toUserId: 'receiver-id',
+            fromUserDisplayName: '申請者',
+            toUserDisplayName: '受信者',
+          );
+
+      final sent = await notificationRepository
+          .watchSentNotifications('sender-id')
+          .first;
+
+      expect(sent, hasLength(1));
+      expect(sent.single.type, NotificationType.friend);
+      expect(sent.single.status, NotificationStatus.pending);
+    });
+
+    test('友達申請を承認すると通知と双方の友達リストが更新される', () async {
+      final sender = BaseMock.createTestUser(
+        id: 'sender-id',
+        name: '申請者',
+        displayName: '申請者',
+      );
+      final receiver = BaseMock.createTestUser(
+        id: 'receiver-id',
+        name: '受信者',
+        displayName: '受信者',
+      );
+      userRepository
+        ..addTestUser(sender)
+        ..addTestUser(receiver);
+      notificationRepository.addTestNotification(
+        Notification(
+          id: 'friend-request-id',
+          type: NotificationType.friend,
+          sendUserId: sender.id,
+          receiveUserId: receiver.id,
+          sendUserDisplayName: sender.displayName,
+          receiveUserDisplayName: receiver.displayName,
+          status: NotificationStatus.pending,
+          createdAt: DateTime(2026, 5, 22),
+          updatedAt: DateTime(2026, 5, 22),
+        ),
+      );
+
+      await container
+          .read(notification_app.notificationNotifierProvider.notifier)
+          .acceptNotification('friend-request-id');
+
+      final accepted =
+          await notificationRepository.getNotification('friend-request-id');
+      final updatedSender = await userRepository.getUser(sender.id);
+      final updatedReceiver = await userRepository.getUser(receiver.id);
+
+      expect(accepted?.status, NotificationStatus.accepted);
+      expect(updatedSender?.friends, contains(receiver.id));
+      expect(updatedReceiver?.friends, contains(sender.id));
+    });
+
+    test('予定を追加すると保存済み予定として取得できる', () async {
+      final owner = BaseMock.createTestUser();
+      authRepository.setCurrentUser(owner);
+      userRepository.addTestUser(owner);
+
+      final start = DateTime(2026, 6, 1, 10);
+      await container.read(scheduleNotifierProvider.notifier).createSchedule(
+        title: 'ランチ',
+        description: '友達とランチ',
+        location: '渋谷',
+        startDateTime: start,
+        endDateTime: start.add(const Duration(hours: 1)),
+        ownerId: owner.id,
+        sharedLists: const [],
+        visibleTo: const [],
+      );
+
+      final schedules = await scheduleRepository.getUserSchedules(owner.id);
+
+      expect(schedules, hasLength(1));
+      expect(schedules.single.title, 'ランチ');
+      expect(schedules.single.ownerDisplayName, owner.displayName);
+    });
+
+    test('プロフィール画像を変更するとStorage URLがユーザー情報へ反映される', () async {
+      final user = BaseMock.createTestUser();
+      userRepository.addTestUser(user);
+      final imageFile = File(
+        '${Directory.systemTemp.path}/lakiite-profile-flow-test.jpg',
+      );
+      await imageFile.writeAsBytes([1, 2, 3]);
+
+      final viewModel = container.read(myPageViewModelProvider.notifier);
+      await viewModel.loadUser(user.id);
+
+      await viewModel.updateProfile(
+        name: user.name,
+        displayName: user.displayName,
+        searchIdStr: user.searchId.toString(),
+        imageFile: imageFile,
+      );
+
+      final updatedUser = await userRepository.getUser(user.id);
+
+      expect(updatedUser?.iconUrl, storageService.uploadedUrl);
+      expect(storageService.uploadedPath, 'v1/users/icon/${user.id}');
+    });
+  });
+}
+
+class _FakeFriendListRepository implements IFriendListRepository {
+  final Map<String, List<String>> membersByListId = {};
+
+  @override
+  Future<List<String>?> getListMemberIds(String listId) async {
+    return membersByListId[listId];
+  }
+}
+
+class _FakeScheduleInteractionRepository
+    implements IScheduleInteractionRepository {
+  @override
+  Future<String> addComment(
+    String scheduleId,
+    String userId,
+    String content,
+  ) async {
+    return 'comment-id';
+  }
+
+  @override
+  Future<String> addReaction(
+    String scheduleId,
+    String userId,
+    ReactionType type,
+  ) async {
+    return 'reaction-id';
+  }
+
+  @override
+  Future<void> deleteComment(String scheduleId, String commentId) async {}
+
+  @override
+  Future<int> getCommentCount(String scheduleId) async {
+    return 0;
+  }
+
+  @override
+  Future<List<ScheduleComment>> getComments(String scheduleId) async {
+    return const [];
+  }
+
+  @override
+  Future<int> getReactionCount(String scheduleId) async {
+    return 0;
+  }
+
+  @override
+  Future<List<ScheduleReaction>> getReactions(String scheduleId) async {
+    return const [];
+  }
+
+  @override
+  Future<void> removeReaction(String scheduleId, String userId) async {}
+
+  @override
+  Future<void> updateComment(
+    String scheduleId,
+    String commentId,
+    String content,
+  ) async {}
+
+  @override
+  Stream<List<ScheduleComment>> watchComments(String scheduleId) {
+    return const Stream.empty();
+  }
+
+  @override
+  Stream<List<ScheduleReaction>> watchReactions(String scheduleId) {
+    return const Stream.empty();
+  }
+}
+
+class _FakeStorageService implements IStorageService {
+  final uploadedUrl = 'https://storage.example.test/profile.jpg';
+  String? uploadedPath;
+
+  @override
+  Future<String> uploadFile({
+    required String path,
+    required File file,
+    required Map<String, String> metadata,
+    String contentType = 'image/jpeg',
+  }) async {
+    uploadedPath = path;
+    return uploadedUrl;
+  }
+}
+
+class _FakeImageProcessorService implements IImageProcessorService {
+  @override
+  Future<File> compressImage(
+    File imageFile, {
+    int minWidth = 300,
+    int minHeight = 300,
+    int quality = 85,
+  }) async {
+    return imageFile;
+  }
+
+  @override
+  Future<Directory> createTempDirectory() {
+    return Directory.systemTemp.createTemp('lakiite-profile-flow-test');
+  }
+
+  @override
+  Future<File> createTempFile(List<int> data, String extension) async {
+    final directory = await createTempDirectory();
+    final file = File('${directory.path}/image.$extension');
+    return file.writeAsBytes(data);
+  }
+}

--- a/test/application/schedule/schedule_interaction_notifier_test.dart
+++ b/test/application/schedule/schedule_interaction_notifier_test.dart
@@ -19,6 +19,7 @@ import 'package:lakiite/domain/interfaces/i_schedule_interaction_repository.dart
 import 'package:lakiite/domain/interfaces/i_schedule_repository.dart';
 import 'package:lakiite/domain/interfaces/i_user_repository.dart';
 import 'package:lakiite/domain/value/user_id.dart';
+import 'package:lakiite/infrastructure/firebase/push_notification_sender.dart';
 import 'package:lakiite/presentation/presentation_provider.dart';
 
 class _StubAuthNotifier extends auth.AuthNotifier {
@@ -210,7 +211,14 @@ class _FakeNotificationRepository implements INotificationRepository {
 
 class _FakeNotificationNotifier extends notification.NotificationNotifier {
   _FakeNotificationNotifier(Ref ref)
-      : super(_FakeNotificationRepository(), ref);
+      : super(
+          _FakeNotificationRepository(),
+          PushNotificationSender(
+            cloudFunctionUrl: 'https://example.test/push',
+            tokenResolver: (_) async => const [],
+          ),
+          ref,
+        );
 
   @override
   Future<void> createReactionNotification({


### PR DESCRIPTION
## Summary
- Add application-level primary user flow tests for login, signup, friend request, approval, schedule creation, and profile image update.
- Make `NotificationNotifier` use an injectable push notification sender provider so tests do not require Firebase/AppConfig.
- Connect both users when a friend request notification is accepted.

## Why
Manual regression checks for core user flows were too costly. The friend approval flow also only marked the notification as accepted and did not update either user's friends list.

## Validation
- `fvm flutter test test/application/flows/primary_user_flows_test.dart`
- `fvm flutter test test/application/schedule/schedule_interaction_notifier_test.dart`
- `fvm flutter analyze`
- `fvm flutter test --dart-define=FLUTTER_TEST=true test/application/`