### PR TITLE
[codex] Simplify presentation provider exports

### DIFF
--- a/lib/presentation/presentation_provider.dart
+++ b/lib/presentation/presentation_provider.dart
@@ -2,10 +2,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lakiite/app/di/providers.dart';
 import 'package:lakiite/application/auth/auth_notifier.dart';
 import 'package:lakiite/application/auth/auth_state.dart';
-import 'package:lakiite/application/list/list_notifier.dart';
-import 'package:lakiite/application/list/list_state.dart';
-import 'package:lakiite/application/schedule/schedule_notifier.dart';
-import 'package:lakiite/application/schedule/schedule_state.dart';
 import 'package:lakiite/domain/entity/list.dart';
 import 'package:lakiite/domain/entity/user.dart';
 import '../domain/entity/schedule.dart';
@@ -15,6 +11,10 @@ export 'package:lakiite/application/notification/notification_notifier.dart'
     show currentUserIdProvider;
 export 'package:lakiite/application/auth/auth_notifier.dart'
     show authNotifierProvider, authRepositoryProvider;
+export 'package:lakiite/application/list/list_notifier.dart'
+    show listNotifierProvider;
+export 'package:lakiite/application/schedule/schedule_notifier.dart'
+    show scheduleNotifierProvider;
 
 /// 認証状態プロバイダー群
 // 認証状態の変更を監視するプロバイダー
@@ -22,20 +22,6 @@ final authStateProvider = StreamProvider.autoDispose((ref) {
   final authRepository = ref.watch(authRepositoryProvider);
   return authRepository.authStateChanges();
 });
-
-/// スケジュール状態プロバイダー群
-// スケジュール状態を管理するNotifierプロバイダー
-final scheduleNotifierProvider =
-    AutoDisposeAsyncNotifierProvider<ScheduleNotifier, ScheduleState>(
-  ScheduleNotifier.new,
-);
-
-/// リスト状態プロバイダー群
-// リスト状態を管理するNotifierプロバイダー
-final listNotifierProvider =
-    AutoDisposeAsyncNotifierProvider<ListNotifier, ListState>(
-  ListNotifier.new,
-);
 
 /// 認証済みユーザーのリストを監視するStreamプロバイダー
 ///

--- a/lib/presentation/presentation_provider.dart
+++ b/lib/presentation/presentation_provider.dart
@@ -10,18 +10,11 @@ export 'package:lakiite/app/di/providers.dart';
 export 'package:lakiite/application/notification/notification_notifier.dart'
     show currentUserIdProvider;
 export 'package:lakiite/application/auth/auth_notifier.dart'
-    show authNotifierProvider, authRepositoryProvider;
+    show authNotifierProvider, authRepositoryProvider, authStateStreamProvider;
 export 'package:lakiite/application/list/list_notifier.dart'
     show listNotifierProvider;
 export 'package:lakiite/application/schedule/schedule_notifier.dart'
     show scheduleNotifierProvider;
-
-/// 認証状態プロバイダー群
-// 認証状態の変更を監視するプロバイダー
-final authStateProvider = StreamProvider.autoDispose((ref) {
-  final authRepository = ref.watch(authRepositoryProvider);
-  return authRepository.authStateChanges();
-});
 
 /// 認証済みユーザーのリストを監視するStreamプロバイダー
 ///

--- a/test/presentation/presentation_provider_test.dart
+++ b/test/presentation/presentation_provider_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:lakiite/application/auth/auth_notifier.dart' as auth_app;
 import 'package:lakiite/application/list/list_notifier.dart' as list_app;
 import 'package:lakiite/application/schedule/schedule_notifier.dart'
     as schedule_app;
@@ -185,6 +186,10 @@ void main() {
 
     test('application notifier providers are re-exported without redefining',
         () {
+      expect(
+        identical(authStateStreamProvider, auth_app.authStateStreamProvider),
+        isTrue,
+      );
       expect(
         identical(
             scheduleNotifierProvider, schedule_app.scheduleNotifierProvider),

--- a/test/presentation/presentation_provider_test.dart
+++ b/test/presentation/presentation_provider_test.dart
@@ -2,6 +2,9 @@ import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:lakiite/application/list/list_notifier.dart' as list_app;
+import 'package:lakiite/application/schedule/schedule_notifier.dart'
+    as schedule_app;
 import 'package:lakiite/domain/entity/list.dart';
 import 'package:lakiite/domain/entity/schedule.dart';
 import 'package:lakiite/domain/entity/user.dart';
@@ -178,6 +181,19 @@ void main() {
       scheduleRepository.dispose();
       mockAuthRepository.dispose();
       container.dispose();
+    });
+
+    test('application notifier providers are re-exported without redefining',
+        () {
+      expect(
+        identical(
+            scheduleNotifierProvider, schedule_app.scheduleNotifierProvider),
+        isTrue,
+      );
+      expect(
+        identical(listNotifierProvider, list_app.listNotifierProvider),
+        isTrue,
+      );
     });
 
     test('userSchedulesStreamProvider はログアウト時に空配列へ切り替わる', () async {


### PR DESCRIPTION
## Summary
- Re-export generated application notifier providers from `presentation_provider.dart` instead of redefining them.
- Remove the unused presentation-level `authStateProvider` and re-export `authStateStreamProvider`.
- Add tests that lock `presentation_provider.dart` to the application provider instances.

## Why
This continues Issue #153 by reducing provider duplication and making provider ownership clearer: application providers live in application files, while presentation keeps only UI selector providers.

## Validation
- `fvm flutter analyze`
- `fvm flutter test test/presentation/presentation_provider_test.dart`
- `fvm flutter test --dart-define=FLUTTER_TEST=true test/application/`
- `fvm flutter test test/presentation/ --dart-define=FLUTTER_TEST=true`