### PR TITLE
退会済みユーザーの表示文言をリアクションでも統一する

### DIFF
--- a/lib/presentation/calendar/schedule_detail_logic.dart
+++ b/lib/presentation/calendar/schedule_detail_logic.dart
@@ -2,6 +2,7 @@ import 'package:intl/intl.dart';
 import 'package:lakiite/domain/entity/notification.dart' as domain;
 import 'package:lakiite/domain/entity/schedule_comment.dart';
 import 'package:lakiite/domain/entity/user.dart';
+import 'package:lakiite/presentation/user_display_text.dart';
 
 /// 予定詳細画面で使う表示判定と抽出処理を担う純粋ロジック。
 ///
@@ -106,6 +107,6 @@ class ScheduleDetailLogic {
 
   /// コメント投稿者名を表示用に返す。
   static String commentAuthorDisplayName(ScheduleComment comment) {
-    return comment.userDisplayName ?? '退会済みユーザー';
+    return comment.userDisplayName ?? retiredUserDisplayName;
   }
 }

--- a/lib/presentation/calendar/widgets/reaction_users_sheet.dart
+++ b/lib/presentation/calendar/widgets/reaction_users_sheet.dart
@@ -3,6 +3,7 @@ import 'dart:developer' as developer;
 import 'package:flutter/material.dart';
 import 'package:lakiite/domain/entity/reaction.dart';
 import 'package:lakiite/domain/entity/user.dart';
+import 'package:lakiite/presentation/user_display_text.dart';
 import 'package:lakiite/presentation/widgets/default_user_icon.dart';
 import 'package:lakiite/presentation/widgets/reaction_type_view_extension.dart';
 
@@ -64,7 +65,7 @@ class ReactionUsersSheet extends StatelessWidget {
                     final reaction = reactions[index];
                     final user = usersById[reaction.userId];
                     final displayName =
-                        user?.displayName ?? reaction.userDisplayName;
+                        user?.displayName ?? retiredUserDisplayName;
                     final iconUrl = user?.iconUrl ?? reaction.userPhotoUrl;
                     developer.log('リアクションオブジェクト: $reaction');
                     developer.log(

--- a/lib/presentation/friend/friend_request_list_page.dart
+++ b/lib/presentation/friend/friend_request_list_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import '../../application/notification/notification_notifier.dart';
 import '../../domain/entity/notification.dart' as domain;
+import '../../presentation/user_display_text.dart';
 import '../../utils/logger.dart';
 import 'friend_providers.dart';
 
@@ -136,7 +137,7 @@ class FriendRequestCard extends StatelessWidget {
   /// 友達申請カードの主文言。
   String get _title {
     if (_isExpired) {
-      return '退会済みユーザーからの友達申請です';
+      return '$retiredUserDisplayNameからの友達申請です';
     }
 
     final senderName = request.sendUserDisplayName ?? request.sendUserId;

--- a/lib/presentation/notification/notification_item_logic.dart
+++ b/lib/presentation/notification/notification_item_logic.dart
@@ -1,4 +1,5 @@
 import '../../domain/entity/notification.dart' as domain;
+import '../user_display_text.dart';
 
 /// 通知一覧アイテムの表示文言を決める純粋ロジック。
 class NotificationItemLogic {
@@ -21,7 +22,7 @@ class NotificationItemLogic {
         notification.sendUserDisplayName ?? notification.sendUserId;
     return switch ((notification.type, notification.status)) {
       (domain.NotificationType.friend, domain.NotificationStatus.expired) =>
-        '退会済みユーザーからのフレンド申請です',
+        '$retiredUserDisplayNameからのフレンド申請です',
       (domain.NotificationType.friend, _) => '$fromNameさんからフレンド申請が届いています',
       (domain.NotificationType.groupInvitation, _) =>
         '$fromNameさんからグループ招待が届いています',

--- a/lib/presentation/user_display_text.dart
+++ b/lib/presentation/user_display_text.dart
@@ -1,0 +1,2 @@
+/// 退会済みユーザーを示す表示名。
+const retiredUserDisplayName = '退会済みユーザー';

--- a/test/presentation/schedule/reaction_users_sheet_test.dart
+++ b/test/presentation/schedule/reaction_users_sheet_test.dart
@@ -50,7 +50,7 @@ void main() {
     expect(find.text('🤔'), findsOneWidget);
   });
 
-  testWidgets('リアクションしたユーザーが削除済みでもsnapshotの名前で表示する', (tester) async {
+  testWidgets('リアクションしたユーザーが削除済みの場合は退会済みユーザーとして表示する', (tester) async {
     final reactions = [
       Reaction(
         id: 'reaction-1',
@@ -75,8 +75,8 @@ void main() {
 
     await tester.pump();
 
-    expect(find.text('削除前の名前'), findsOneWidget);
-    expect(find.text('退会済みユーザー'), findsNothing);
+    expect(find.text('退会済みユーザー'), findsOneWidget);
+    expect(find.text('削除前の名前'), findsNothing);
     expect(find.text('🙋'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## 概要

退会済みユーザーの表示文言を presentation 側で共通化し、リアクション一覧でユーザーdocが取得できない場合は保存済み表示名ではなく「退会済みユーザー」と表示します。

## 変更内容

- `retiredUserDisplayName` を presentation 共通定数として追加
- リアクションユーザー欠損時の表示を「退会済みユーザー」に変更
- コメント/通知/友達申請で使う退会済みユーザー文言を共通定数へ寄せる
- リアクション表示テストをTOBE仕様へ更新

## 関連

- commons側PRで、ユーザー削除時にコメント/リアクション/通知/友達リストの参照をクリーンアップします。

## 確認

- `fvm flutter test --dart-define=FLUTTER_TEST=true test/presentation/schedule/reaction_users_sheet_test.dart test/presentation/schedule/schedule_detail_logic_test.dart test/presentation/friend/friend_request_card_test.dart test/presentation/notification/notification_item_logic_test.dart`
- `fvm flutter analyze`

