### PR TITLE
Firebase Emulatorで主要フローのIntegration Testを追加する

### DIFF
--- a/.github/workflows/firebase_emulator_integration_tests.yml
+++ b/.github/workflows/firebase_emulator_integration_tests.yml
@@ -1,0 +1,197 @@
+name: Firebase Emulator Integration Tests
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  FLUTTER_VERSION: "3.41.5"
+  FIREBASE_EMULATOR_PROJECT_ID: demo-lakiite-emulator-test
+
+jobs:
+  android:
+    name: Android Firebase Emulator Smoke Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5.0.1
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2.9.1
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+          cache: false
+
+      - name: Setup Java 21
+        uses: actions/setup-java@v5.2.0
+        with:
+          distribution: zulu
+          java-version: "21"
+
+      - name: Install Firebase CLI
+        run: npm install -g firebase-tools
+
+      - name: Create emulator Firebase config files
+        run: |
+          mkdir -p android/app/src/dev lib
+          cat > android/app/src/dev/google-services.json <<'EOF'
+          {
+            "project_info": {
+              "project_number": "1234567890",
+              "project_id": "demo-lakiite-emulator-test",
+              "storage_bucket": "demo-lakiite-emulator-test.appspot.com"
+            },
+            "client": [
+              {
+                "client_info": {
+                  "mobilesdk_app_id": "1:1234567890:android:demo",
+                  "android_client_info": {
+                    "package_name": "com.inoworl.lakiite.dev"
+                  }
+                },
+                "api_key": [
+                  {
+                    "current_key": "demo-api-key"
+                  }
+                ]
+              }
+            ],
+            "configuration_version": "1"
+          }
+          EOF
+          cat > lib/firebase_options.dart <<'EOF'
+          import 'package:firebase_core/firebase_core.dart';
+
+          class DefaultFirebaseOptions {
+            static FirebaseOptions get currentPlatform => const FirebaseOptions(
+                  apiKey: 'demo-api-key',
+                  appId: '1:1234567890:android:demo',
+                  messagingSenderId: '1234567890',
+                  projectId: 'demo-lakiite-emulator-test',
+                  storageBucket: 'demo-lakiite-emulator-test.appspot.com',
+                );
+          }
+          EOF
+
+      - name: Install Flutter dependencies
+        run: |
+          flutter pub get
+          flutter packages pub run build_runner build --delete-conflicting-outputs
+
+      - name: Run Android integration test
+        uses: reactivecircus/android-emulator-runner@v2.35.0
+        with:
+          api-level: 35
+          target: google_apis
+          arch: x86_64
+          profile: pixel_6
+          script: |
+            firebase emulators:start --only auth,firestore,storage --project "$FIREBASE_EMULATOR_PROJECT_ID" &
+            FIREBASE_PID=$!
+            trap 'kill "$FIREBASE_PID" || true' EXIT
+            npx wait-on tcp:127.0.0.1:9099 tcp:127.0.0.1:8080 tcp:127.0.0.1:9199
+            flutter test integration_test/firebase_emulator_smoke_test.dart integration_test/auth_emulator_flow_test.dart integration_test/social_schedule_emulator_flow_test.dart \
+              -d emulator-5554 \
+              --flavor dev \
+              --dart-define=USE_FIREBASE_EMULATOR=true \
+              --dart-define=FIREBASE_EMULATOR_HOST=10.0.2.2 \
+              --dart-define=TEST_MODE=true \
+              --dart-define=FLAVOR=development
+
+  ios:
+    name: iOS Firebase Emulator Smoke Test
+    runs-on: macos-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5.0.1
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2.9.1
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+          cache: false
+
+      - name: Setup Java 21
+        uses: actions/setup-java@v5.2.0
+        with:
+          distribution: zulu
+          java-version: "21"
+
+      - name: Install Firebase CLI
+        run: npm install -g firebase-tools
+
+      - name: Create emulator Firebase config files
+        run: |
+          mkdir -p ios/Runner/Firebase/Dev lib
+          cat > ios/Runner/Firebase/Dev/GoogleService-Info.plist <<'EOF'
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+            <key>API_KEY</key>
+            <string>demo-api-key</string>
+            <key>GCM_SENDER_ID</key>
+            <string>1234567890</string>
+            <key>GOOGLE_APP_ID</key>
+            <string>1:1234567890:ios:demo</string>
+            <key>PROJECT_ID</key>
+            <string>demo-lakiite-emulator-test</string>
+            <key>STORAGE_BUCKET</key>
+            <string>demo-lakiite-emulator-test.appspot.com</string>
+            <key>BUNDLE_ID</key>
+            <string>com.inoworl.lakiite.dev</string>
+          </dict>
+          </plist>
+          EOF
+          cat > lib/firebase_options.dart <<'EOF'
+          import 'package:firebase_core/firebase_core.dart';
+
+          class DefaultFirebaseOptions {
+            static FirebaseOptions get currentPlatform => const FirebaseOptions(
+                  apiKey: 'demo-api-key',
+                  appId: '1:1234567890:ios:demo',
+                  messagingSenderId: '1234567890',
+                  projectId: 'demo-lakiite-emulator-test',
+                  storageBucket: 'demo-lakiite-emulator-test.appspot.com',
+                  iosBundleId: 'com.inoworl.lakiite.dev',
+                );
+          }
+          EOF
+
+      - name: Install Flutter dependencies
+        run: |
+          flutter pub get
+          flutter packages pub run build_runner build --delete-conflicting-outputs
+
+      - name: Boot iOS simulator
+        run: |
+          DEVICE_ID=$(xcrun simctl list devices available | awk -F '[()]' '/iPhone/ { print $2; exit }')
+          if [ -z "$DEVICE_ID" ]; then
+            echo "::error ::No available iPhone simulator found"
+            xcrun simctl list devices available
+            exit 1
+          fi
+          echo "IOS_SIMULATOR_ID=$DEVICE_ID" >> "$GITHUB_ENV"
+          xcrun simctl boot "$DEVICE_ID" || true
+          xcrun simctl bootstatus "$DEVICE_ID" -b
+
+      - name: Run iOS integration test
+        run: |
+          firebase emulators:start --only auth,firestore,storage --project "$FIREBASE_EMULATOR_PROJECT_ID" &
+          FIREBASE_PID=$!
+          trap 'kill "$FIREBASE_PID" || true' EXIT
+          npx wait-on tcp:127.0.0.1:9099 tcp:127.0.0.1:8080 tcp:127.0.0.1:9199
+          flutter test integration_test/firebase_emulator_smoke_test.dart integration_test/auth_emulator_flow_test.dart integration_test/social_schedule_emulator_flow_test.dart \
+            -d "$IOS_SIMULATOR_ID" \
+            --flavor dev \
+            --dart-define=USE_FIREBASE_EMULATOR=true \
+            --dart-define=FIREBASE_EMULATOR_HOST=localhost \
+            --dart-define=TEST_MODE=true \
+            --dart-define=FLAVOR=development

--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -1,7 +1,13 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.inoworl.lakiite">
     <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
+
+    <application
+        android:networkSecurityConfig="@xml/network_security_config"
+        android:usesCleartextTraffic="true"
+        tools:replace="android:networkSecurityConfig,android:usesCleartextTraffic" />
 </manifest>

--- a/android/app/src/debug/res/xml/network_security_config.xml
+++ b/android/app/src/debug/res/xml/network_security_config.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="false">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="false">10.0.2.2</domain>
+        <domain includeSubdomains="false">localhost</domain>
+        <domain includeSubdomains="false">127.0.0.1</domain>
+    </domain-config>
+</network-security-config>

--- a/firebase.json
+++ b/firebase.json
@@ -1,1 +1,62 @@
-{"functions":{"source":"functions","predeploy":["cd \"$RESOURCE_DIR\" && npm --prefer-offline --no-audit --progress=false install"]},"flutter":{"platforms":{"android":{"default":{"projectId":"lakiite-flutter-app-dev","appId":"1:3311967889:android:6e3182d1b0e0c49038a930","fileOutput":"android/app/google-services.json"},"buildConfigurations":{"src/dev":{"projectId":"lakiite-flutter-app-dev","appId":"1:3311967889:android:6e3182d1b0e0c49038a930","fileOutput":"android/app/src/dev/google-services.json"}}},"ios":{"default":{"projectId":"lakiite-flutter-app-dev","appId":"1:3311967889:ios:21a515f971715adc38a930","uploadDebugSymbols":false,"fileOutput":"ios/Runner/GoogleService-Info.plist"}},"dart":{"lib/firebase_options.dart":{"projectId":"lakiite-flutter-app-dev","configurations":{"android":"1:3311967889:android:6e3182d1b0e0c49038a930"}},"lib/firebase_options_dev.dart":{"projectId":"lakiite-flutter-app-dev","configurations":{"android":"1:3311967889:android:6e3182d1b0e0c49038a930"}}}}}}
+{
+  "functions": {
+    "source": "functions",
+    "predeploy": [
+      "cd \"$RESOURCE_DIR\" && npm --prefer-offline --no-audit --progress=false install"
+    ]
+  },
+  "flutter": {
+    "platforms": {
+      "android": {
+        "default": {
+          "projectId": "lakiite-flutter-app-dev",
+          "appId": "1:3311967889:android:6e3182d1b0e0c49038a930",
+          "fileOutput": "android/app/google-services.json"
+        },
+        "buildConfigurations": {
+          "src/dev": {
+            "projectId": "lakiite-flutter-app-dev",
+            "appId": "1:3311967889:android:6e3182d1b0e0c49038a930",
+            "fileOutput": "android/app/src/dev/google-services.json"
+          }
+        }
+      },
+      "ios": {
+        "default": {
+          "projectId": "lakiite-flutter-app-dev",
+          "appId": "1:3311967889:ios:21a515f971715adc38a930",
+          "uploadDebugSymbols": false,
+          "fileOutput": "ios/Runner/GoogleService-Info.plist"
+        }
+      },
+      "dart": {
+        "lib/firebase_options.dart": {
+          "projectId": "lakiite-flutter-app-dev",
+          "configurations": {
+            "android": "1:3311967889:android:6e3182d1b0e0c49038a930"
+          }
+        },
+        "lib/firebase_options_dev.dart": {
+          "projectId": "lakiite-flutter-app-dev",
+          "configurations": {
+            "android": "1:3311967889:android:6e3182d1b0e0c49038a930"
+          }
+        }
+      }
+    }
+  },
+  "emulators": {
+    "auth": {
+      "port": 9099
+    },
+    "firestore": {
+      "port": 8080
+    },
+    "storage": {
+      "port": 9199
+    },
+    "ui": {
+      "enabled": true
+    }
+  }
+}

--- a/integration_test/auth_emulator_flow_test.dart
+++ b/integration_test/auth_emulator_flow_test.dart
@@ -1,0 +1,47 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:lakiite/config/app_config.dart';
+import 'package:lakiite/infrastructure/auth_repository.dart';
+import 'package:lakiite/infrastructure/user_repository.dart';
+import 'package:lakiite/main.dart' as app;
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('Firebase Emulatorで新規登録してログインできる', (tester) async {
+    await app.startApp(Environment.development);
+    await tester.pumpAndSettle();
+
+    final unique = DateTime.now().microsecondsSinceEpoch;
+    final email = 'auth-flow-$unique@example.com';
+    const password = 'password123';
+    const name = 'Integration User';
+
+    final authRepository = AuthRepository(
+      FirebaseAuth.instance,
+      UserRepository(),
+    );
+
+    final signedUpUser = await authRepository.signUp(email, password, name);
+    expect(signedUpUser, isNotNull);
+    expect(signedUpUser!.name, name);
+
+    final userDoc = await FirebaseFirestore.instance
+        .collection('users')
+        .doc(signedUpUser.id)
+        .get();
+    expect(userDoc.exists, isTrue);
+
+    await authRepository.signOut();
+    expect(FirebaseAuth.instance.currentUser, isNull);
+
+    final signedInUser = await authRepository.signIn(email, password);
+    expect(signedInUser, isNotNull);
+    expect(signedInUser!.id, signedUpUser.id);
+    expect(FirebaseAuth.instance.currentUser?.uid, signedUpUser.id);
+
+    await authRepository.signOut();
+  });
+}

--- a/integration_test/firebase_emulator_smoke_test.dart
+++ b/integration_test/firebase_emulator_smoke_test.dart
@@ -1,0 +1,37 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:lakiite/config/app_config.dart';
+import 'package:lakiite/main.dart' as app;
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('Firebase Emulatorで認証とFirestoreを利用できる', (tester) async {
+    await app.startApp(Environment.development);
+    await tester.pumpAndSettle();
+
+    final unique = DateTime.now().microsecondsSinceEpoch;
+    final email = 'integration-$unique@example.com';
+    const password = 'password123';
+
+    final credential = await FirebaseAuth.instance
+        .createUserWithEmailAndPassword(email: email, password: password);
+    final uid = credential.user!.uid;
+
+    final docRef = FirebaseFirestore.instance
+        .collection('integration_test_smoke')
+        .doc(uid);
+    await docRef.set({
+      'email': email,
+      'createdAt': FieldValue.serverTimestamp(),
+    });
+
+    final snapshot = await docRef.get();
+    expect(snapshot.exists, isTrue);
+    expect(snapshot.data()?['email'], email);
+
+    await FirebaseAuth.instance.signOut();
+  });
+}

--- a/integration_test/social_schedule_emulator_flow_test.dart
+++ b/integration_test/social_schedule_emulator_flow_test.dart
@@ -1,0 +1,229 @@
+import 'dart:typed_data';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:lakiite/application/notification/accept_friend_request_use_case.dart';
+import 'package:lakiite/config/app_config.dart';
+import 'package:lakiite/domain/entity/notification.dart' as domain;
+import 'package:lakiite/domain/entity/schedule.dart';
+import 'package:lakiite/domain/entity/schedule_reaction.dart';
+import 'package:lakiite/infrastructure/auth_repository.dart';
+import 'package:lakiite/infrastructure/notification_repository.dart';
+import 'package:lakiite/infrastructure/schedule_interaction_repository.dart';
+import 'package:lakiite/infrastructure/schedule_repository.dart';
+import 'package:lakiite/infrastructure/user_repository.dart';
+import 'package:lakiite/main.dart' as app;
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('Firebase Emulatorで主要な共有フローを実行できる', (tester) async {
+    await app.startApp(Environment.development);
+    await tester.pumpAndSettle();
+
+    final unique = DateTime.now().microsecondsSinceEpoch;
+    final authRepository = AuthRepository(
+      FirebaseAuth.instance,
+      UserRepository(),
+    );
+    final userRepository = UserRepository();
+    final scheduleRepository = ScheduleRepository();
+    final interactionRepository = ScheduleInteractionRepository();
+    final notificationRepository = NotificationRepository();
+
+    final sender = await authRepository.signUp(
+      'sender-$unique@example.com',
+      'password123',
+      'Sender User',
+    );
+    expect(sender, isNotNull);
+
+    await authRepository.signOut();
+
+    final receiver = await authRepository.signUp(
+      'receiver-$unique@example.com',
+      'password123',
+      'Receiver User',
+    );
+    expect(receiver, isNotNull);
+
+    final friendRequest = domain.Notification.createFriendRequest(
+      fromUserId: sender!.id,
+      toUserId: receiver!.id,
+      fromUserDisplayName: sender.displayName,
+      toUserDisplayName: receiver.displayName,
+    );
+    await notificationRepository.createNotification(friendRequest);
+
+    final requestSnapshot = await FirebaseFirestore.instance
+        .collection('notifications')
+        .where('sendUserId', isEqualTo: sender.id)
+        .where('receiveUserId', isEqualTo: receiver.id)
+        .where('type', isEqualTo: domain.NotificationType.friend.name)
+        .limit(1)
+        .get();
+    expect(requestSnapshot.docs, hasLength(1));
+
+    final requestId = requestSnapshot.docs.single.id;
+    await AcceptFriendRequestUseCase(
+      notificationRepository: notificationRepository,
+      userRepository: userRepository,
+    ).execute(requestId);
+
+    final accepted = await notificationRepository.getNotification(requestId);
+    expect(accepted?.status, domain.NotificationStatus.accepted);
+    expect(accepted?.isRead, isTrue);
+
+    final receiverPrivate = await FirebaseFirestore.instance
+        .collection('users')
+        .doc(receiver.id)
+        .collection('private')
+        .doc('profile')
+        .get();
+    expect(receiverPrivate.data()?['lists'], contains(sender.id));
+
+    final start = DateTime.now().add(const Duration(days: 1));
+    final schedule = await scheduleRepository.createSchedule(
+      Schedule(
+        id: '',
+        title: 'Integration schedule $unique',
+        description: 'Created by integration test',
+        location: 'Emulator',
+        startDateTime: start,
+        endDateTime: start.add(const Duration(hours: 1)),
+        ownerId: receiver.id,
+        ownerDisplayName: receiver.displayName,
+        ownerPhotoUrl: receiver.iconUrl,
+        sharedLists: const [],
+        visibleTo: [receiver.id, sender.id],
+        createdAt: DateTime.now(),
+        updatedAt: DateTime.now(),
+      ),
+    );
+    expect(schedule.id, isNotEmpty);
+
+    final commentId = await interactionRepository.addComment(
+      schedule.id,
+      receiver.id,
+      'Integration comment',
+    );
+    expect(commentId, isNotEmpty);
+
+    final reactionId = await interactionRepository.addReaction(
+      schedule.id,
+      receiver.id,
+      ReactionType.going,
+    );
+    expect(reactionId, receiver.id);
+
+    final comments = await interactionRepository.getComments(schedule.id);
+    expect(comments.map((comment) => comment.content),
+        contains('Integration comment'));
+
+    final reactions = await interactionRepository.getReactions(schedule.id);
+    expect(reactions.map((reaction) => reaction.userId), contains(receiver.id));
+
+    final renamed = receiver.updateProfile(displayName: 'Renamed User');
+    await userRepository.updateUser(renamed);
+    final renamedDoc = await FirebaseFirestore.instance
+        .collection('users')
+        .doc(receiver.id)
+        .get();
+    expect(renamedDoc.data()?['displayName'], 'Renamed User');
+
+    final iconUrl = await userRepository.uploadUserIcon(
+      receiver.id,
+      Uint8List.fromList(_onePixelJpeg),
+    );
+    expect(iconUrl, isNotNull);
+    expect(iconUrl, contains('v1%2Fusers%2Ficon%2F${receiver.id}'));
+
+    final iconDoc = await FirebaseFirestore.instance
+        .collection('users')
+        .doc(receiver.id)
+        .get();
+    expect(iconDoc.data()?['iconUrl'], iconUrl);
+
+    await authRepository.signOut();
+  });
+}
+
+const _onePixelJpeg = <int>[
+  0xFF,
+  0xD8,
+  0xFF,
+  0xE0,
+  0x00,
+  0x10,
+  0x4A,
+  0x46,
+  0x49,
+  0x46,
+  0x00,
+  0x01,
+  0x01,
+  0x01,
+  0x00,
+  0x48,
+  0x00,
+  0x48,
+  0x00,
+  0x00,
+  0xFF,
+  0xDB,
+  0x00,
+  0x43,
+  0x00,
+  0xFF,
+  0xC0,
+  0x00,
+  0x0B,
+  0x08,
+  0x00,
+  0x01,
+  0x00,
+  0x01,
+  0x01,
+  0x01,
+  0x11,
+  0x00,
+  0xFF,
+  0xC4,
+  0x00,
+  0x14,
+  0x00,
+  0x01,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0xFF,
+  0xDA,
+  0x00,
+  0x08,
+  0x01,
+  0x01,
+  0x00,
+  0x00,
+  0x3F,
+  0x00,
+  0xD2,
+  0xCF,
+  0x20,
+  0xFF,
+  0xD9,
+];

--- a/lib/config/admob_config.dart
+++ b/lib/config/admob_config.dart
@@ -43,7 +43,9 @@ class AdMobConfig {
   static void initialize({bool forceTestMode = false}) {
     // テスト環境かどうかを確認
     const isTestEnvironment =
-        bool.fromEnvironment('FLUTTER_TEST', defaultValue: false);
+        bool.fromEnvironment('FLUTTER_TEST', defaultValue: false) ||
+            bool.fromEnvironment('TEST_MODE', defaultValue: false) ||
+            bool.fromEnvironment('USE_FIREBASE_EMULATOR', defaultValue: false);
 
     if (isTestEnvironment || forceTestMode) {
       // テスト環境ではダミー値を設定

--- a/lib/config/firebase_emulator_config.dart
+++ b/lib/config/firebase_emulator_config.dart
@@ -1,0 +1,84 @@
+import 'dart:io';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_storage/firebase_storage.dart';
+import 'package:flutter/foundation.dart';
+
+/// Firebase Emulator Suite への接続設定を表します。
+class FirebaseEmulatorConfig {
+  const FirebaseEmulatorConfig({
+    required this.enabled,
+    required this.host,
+    this.authPort = 9099,
+    this.firestorePort = 8080,
+    this.storagePort = 9199,
+  });
+
+  /// dart-define と実行プラットフォームから接続設定を解決します。
+  factory FirebaseEmulatorConfig.fromEnvironment() {
+    const enabled = bool.fromEnvironment(
+      'USE_FIREBASE_EMULATOR',
+      defaultValue: false,
+    );
+    const hostOverride = String.fromEnvironment('FIREBASE_EMULATOR_HOST');
+
+    return FirebaseEmulatorConfig.resolve(
+      enabled: enabled,
+      hostOverride: hostOverride,
+      isAndroid: !kIsWeb && Platform.isAndroid,
+    );
+  }
+
+  /// テストしやすい純粋関数として接続設定を解決します。
+  factory FirebaseEmulatorConfig.resolve({
+    required bool enabled,
+    required String hostOverride,
+    required bool isAndroid,
+  }) {
+    final host = hostOverride.isNotEmpty
+        ? hostOverride
+        : isAndroid
+            ? '10.0.2.2'
+            : 'localhost';
+
+    return FirebaseEmulatorConfig(enabled: enabled, host: host);
+  }
+
+  /// Firebase Emulator Suite に接続するかどうか。
+  final bool enabled;
+
+  /// Emulator のホスト名。
+  final String host;
+
+  /// Firebase Auth emulator のポート番号。
+  final int authPort;
+
+  /// Cloud Firestore emulator のポート番号。
+  final int firestorePort;
+
+  /// Firebase Storage emulator のポート番号。
+  final int storagePort;
+}
+
+/// Firebase SDK の接続先を Emulator Suite に切り替えます。
+Future<void> connectFirebaseEmulatorsIfNeeded() async {
+  final config = FirebaseEmulatorConfig.fromEnvironment();
+  if (!config.enabled) {
+    return;
+  }
+
+  FirebaseFirestore.instance.useFirestoreEmulator(
+    config.host,
+    config.firestorePort,
+  );
+  await FirebaseAuth.instance.useAuthEmulator(config.host, config.authPort);
+  await FirebaseStorage.instance.useStorageEmulator(
+    config.host,
+    config.storagePort,
+  );
+
+  FirebaseFirestore.instance.settings = const Settings(
+    persistenceEnabled: false,
+  );
+}

--- a/lib/infrastructure/user_repository.dart
+++ b/lib/infrastructure/user_repository.dart
@@ -188,8 +188,10 @@ class UserRepository implements IUserRepository {
 
     // トランザクションでアイコンURLを更新
     await _firestore.runTransaction((transaction) async {
-      // 公開プロフィールのiconUrlを更新
       final userDoc = await transaction.get(userRef);
+      final privateDoc = await transaction.get(privateRef);
+
+      // 公開プロフィールのiconUrlを更新
       if (userDoc.exists) {
         final userData = userDoc.data() ?? {};
         userData['iconUrl'] = downloadUrl;
@@ -197,14 +199,16 @@ class UserRepository implements IUserRepository {
       }
 
       // プライベートプロフィールにも同じURLを保存
-      final privateDoc = await transaction.get(privateRef);
       if (privateDoc.exists) {
         final privateData = privateDoc.data() ?? {};
         if (privateData['profile'] == null) {
           privateData['profile'] = {};
         }
-        final profile = privateData['profile'] as Map<String, dynamic>;
+        final profile = Map<String, dynamic>.from(
+          privateData['profile'] as Map,
+        );
         profile['iconUrl'] = downloadUrl;
+        privateData['profile'] = profile;
         transaction.update(privateRef, privateData);
       }
     });

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'config/app_config.dart';
 import 'config/admob_config.dart';
+import 'config/firebase_emulator_config.dart';
 import 'config/router/app_router.dart';
 import 'infrastructure/admob_service.dart';
 import 'infrastructure/firebase/push_notification_service.dart';
@@ -72,24 +73,34 @@ Future<void> startApp([
       AppLogger.info(
           'Firebase使用中アプリ: name=${defaultApp.name}, projectId=${defaultApp.options.projectId}, appId=${defaultApp.options.appId}, senderId=${defaultApp.options.messagingSenderId}, iosBundleId=${defaultApp.options.iosBundleId}');
 
-      // プッシュ通知サービスの初期化
-      AppLogger.info('🚀 プッシュ通知サービスの初期化を開始...');
-      await PushNotificationService.instance.initialize();
+      await connectFirebaseEmulatorsIfNeeded();
 
-      const forceRefreshFcmTokenOnStartup = bool.fromEnvironment(
-        'FORCE_REFRESH_FCM_TOKEN_ON_STARTUP',
-        defaultValue: false,
-      );
-      if (forceRefreshFcmTokenOnStartup) {
-        AppLogger.info('🔄 FCMトークンの強制更新を実行...');
-        await PushNotificationService.instance.forceUpdateFCMToken();
-        AppLogger.info('✅ FCMトークンの強制更新が完了');
+      const skipPushNotificationSetup = bool.fromEnvironment('TEST_MODE',
+              defaultValue: false) ||
+          bool.fromEnvironment('USE_FIREBASE_EMULATOR', defaultValue: false);
+
+      if (!skipPushNotificationSetup) {
+        // プッシュ通知サービスの初期化
+        AppLogger.info('🚀 プッシュ通知サービスの初期化を開始...');
+        await PushNotificationService.instance.initialize();
+
+        const forceRefreshFcmTokenOnStartup = bool.fromEnvironment(
+          'FORCE_REFRESH_FCM_TOKEN_ON_STARTUP',
+          defaultValue: false,
+        );
+        if (forceRefreshFcmTokenOnStartup) {
+          AppLogger.info('🔄 FCMトークンの強制更新を実行...');
+          await PushNotificationService.instance.forceUpdateFCMToken();
+          AppLogger.info('✅ FCMトークンの強制更新が完了');
+        }
+
+        // アプリ起動時にバッジカウントをクリア
+        AppLogger.info('🧹 アプリ起動時のバッジカウントクリアを実行...');
+        await PushNotificationService.instance.clearBadgeCount();
+        AppLogger.info('✅ バッジカウントクリアが完了');
+      } else {
+        AppLogger.info('テスト環境のためプッシュ通知初期化をスキップします');
       }
-
-      // アプリ起動時にバッジカウントをクリア
-      AppLogger.info('🧹 アプリ起動時のバッジカウントクリアを実行...');
-      await PushNotificationService.instance.clearBadgeCount();
-      AppLogger.info('✅ バッジカウントクリアが完了');
 
       // AdMobの初期化
       await AdMobService.initialize();

--- a/test/config/admob_config_test.dart
+++ b/test/config/admob_config_test.dart
@@ -1,0 +1,12 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lakiite/config/admob_config.dart';
+
+void main() {
+  group('AdMobConfig', () {
+    test('TEST_MODEではAdMobの実設定を要求しない', () {
+      expect(() => AdMobConfig.initialize(), returnsNormally);
+      expect(AdMobConfig.instance.androidAppId, 'ca-app-pub-test-android');
+      expect(AdMobConfig.instance.iosAppId, 'ca-app-pub-test-ios');
+    });
+  });
+}

--- a/test/config/firebase_emulator_config_test.dart
+++ b/test/config/firebase_emulator_config_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lakiite/config/firebase_emulator_config.dart';
+
+void main() {
+  group('FirebaseEmulatorConfig', () {
+    test('明示されたホストを優先する', () {
+      final config = FirebaseEmulatorConfig.resolve(
+        enabled: true,
+        hostOverride: '192.168.0.10',
+        isAndroid: true,
+      );
+
+      expect(config.enabled, isTrue);
+      expect(config.host, '192.168.0.10');
+      expect(config.authPort, 9099);
+      expect(config.firestorePort, 8080);
+      expect(config.storagePort, 9199);
+    });
+
+    test('Androidでは10.0.2.2を使う', () {
+      final config = FirebaseEmulatorConfig.resolve(
+        enabled: true,
+        hostOverride: '',
+        isAndroid: true,
+      );
+
+      expect(config.host, '10.0.2.2');
+    });
+
+    test('Android以外ではlocalhostを使う', () {
+      final config = FirebaseEmulatorConfig.resolve(
+        enabled: true,
+        hostOverride: '',
+        isAndroid: false,
+      );
+
+      expect(config.host, 'localhost');
+    });
+  });
+}


### PR DESCRIPTION
## 概要
- Firebase Emulator Suite 接続用の設定を追加しました。
- Android / iOS の merge 後 Actions で Firebase Emulator を起動し、integration test を実行する workflow を追加しました。
- Auth / Firestore / Storage Emulator を使い、実 Firebase データを汚さず主要フローを検証します。

## 追加したテスト
- `firebase_emulator_smoke_test.dart`
  - Auth でユーザー作成
  - Firestore 書き込み/読み取り
- `auth_emulator_flow_test.dart`
  - 新規登録
  - ログアウト
  - ログイン
- `social_schedule_emulator_flow_test.dart`
  - ユーザー2人作成
  - 友達申請 notification 作成
  - 友達申請承認
  - 予定追加
  - コメント追加
  - リアクション追加
  - プロフィール表示名変更
  - プロフィール画像アップロード/差し替え

## 実装メモ
- プロフィール画像差し替えは Patrol ではなく、Storage Emulator へテスト画像 bytes をアップロードして検証しています。
- `TEST_MODE=true` または `USE_FIREBASE_EMULATOR=true` の場合、Push 通知初期化をスキップして OS 権限ダイアログでテストが止まらないようにしました。
- Android debug build だけ Firebase Emulator 向けの cleartext 通信を許可しています。
- `UserRepository.uploadUserIcon` の Firestore transaction 順序と nested map cast の不具合も、追加した integration test で検出したため修正しています。

## ローカル検証
- Android `firebase_emulator_smoke_test.dart` → pass
- Android `auth_emulator_flow_test.dart` → pass
- Android `social_schedule_emulator_flow_test.dart` → pass
- iOS `firebase_emulator_smoke_test.dart` → pass
- iOS `auth_emulator_flow_test.dart` → pass
- iOS `social_schedule_emulator_flow_test.dart` → pass
- `fvm flutter test test/config/firebase_emulator_config_test.dart test/config/admob_config_test.dart --dart-define=FLUTTER_TEST=true --dart-define=TEST_MODE=true` → `4 passed`
- `fvm flutter analyze --no-fatal-infos` → `No issues found`
- workflow YAML parse → OK
- `git diff --check` → OK

## 補足
- FCM/APNs の実 push 到達確認は Firebase Emulator では再現できないため、この PR では通知 document / アプリ内処理の自動テスト範囲に留めています。
