### PR TITLE
Firebase Emulator Integration Tests のタイムアウトと起動方式を修正

### DIFF
--- a/.github/workflows/firebase_emulator_integration_tests.yml
+++ b/.github/workflows/firebase_emulator_integration_tests.yml
@@ -13,7 +13,7 @@ jobs:
   android:
     name: Android Firebase Emulator Smoke Test
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 90
 
     steps:
       - name: Checkout repository
@@ -90,22 +90,12 @@ jobs:
           arch: x86_64
           profile: pixel_6
           script: |
-            firebase emulators:start --only auth,firestore,storage --project "$FIREBASE_EMULATOR_PROJECT_ID" &
-            FIREBASE_PID=$!
-            trap 'kill "$FIREBASE_PID" || true' EXIT
-            npx wait-on tcp:127.0.0.1:9099 tcp:127.0.0.1:8080 tcp:127.0.0.1:9199
-            flutter test integration_test/social_schedule_emulator_flow_test.dart \
-              -d emulator-5554 \
-              --flavor dev \
-              --dart-define=USE_FIREBASE_EMULATOR=true \
-              --dart-define=FIREBASE_EMULATOR_HOST=10.0.2.2 \
-              --dart-define=TEST_MODE=true \
-              --dart-define=FLAVOR=development
+            firebase emulators:exec --only auth,firestore,storage --project "$FIREBASE_EMULATOR_PROJECT_ID" "flutter test integration_test/social_schedule_emulator_flow_test.dart -d emulator-5554 --flavor dev --dart-define=USE_FIREBASE_EMULATOR=true --dart-define=FIREBASE_EMULATOR_HOST=10.0.2.2 --dart-define=TEST_MODE=true --dart-define=FLAVOR=development"
 
   ios:
     name: iOS Firebase Emulator Smoke Test
     runs-on: macos-latest
-    timeout-minutes: 45
+    timeout-minutes: 90
 
     steps:
       - name: Checkout repository
@@ -184,14 +174,4 @@ jobs:
 
       - name: Run iOS integration test
         run: |
-          firebase emulators:start --only auth,firestore,storage --project "$FIREBASE_EMULATOR_PROJECT_ID" &
-          FIREBASE_PID=$!
-          trap 'kill "$FIREBASE_PID" || true' EXIT
-          npx wait-on tcp:127.0.0.1:9099 tcp:127.0.0.1:8080 tcp:127.0.0.1:9199
-          flutter test integration_test/social_schedule_emulator_flow_test.dart \
-            -d "$IOS_SIMULATOR_ID" \
-            --flavor dev \
-            --dart-define=USE_FIREBASE_EMULATOR=true \
-            --dart-define=FIREBASE_EMULATOR_HOST=localhost \
-            --dart-define=TEST_MODE=true \
-            --dart-define=FLAVOR=development
+          firebase emulators:exec --only auth,firestore,storage --project "$FIREBASE_EMULATOR_PROJECT_ID" "flutter test integration_test/social_schedule_emulator_flow_test.dart -d $IOS_SIMULATOR_ID --flavor dev --dart-define=USE_FIREBASE_EMULATOR=true --dart-define=FIREBASE_EMULATOR_HOST=localhost --dart-define=TEST_MODE=true --dart-define=FLAVOR=development"


### PR DESCRIPTION
## 概要
- Firebase Emulator Integration Tests の Android/iOS job timeout を 90 分に延長しました
- Firebase Emulator の起動を `emulators:start` + background process から `emulators:exec` に変更しました
- Android runner の script 行分割で `trap` や複数行 `flutter test` が崩れる問題を避けるため、実行コマンドを1行にしました

## 背景
main の `Firebase Emulator Integration Tests` は job 開始から約45分でキャンセルされていました。iOS は `pod install` と `Xcode build` だけで約25分以上かかっており、45分では代表 integration test 完了まで届いていません。

また Android は timeout 到達前に `flutter test` の複数行コマンドが runner 側で分割され、単一ファイル指定後も Flutter の integration test invocation エラーが出ていました。

## 確認
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/firebase_emulator_integration_tests.yml"); puts "yaml ok"'`\n- `git diff --check`\n\n## 未確認\n- ローカル integration test は JDK 21 が未検出のため未実行です\n- 実際の Android/iOS integration test は Actions の Java 21 環境で確認します\n