### PR TITLE
Android Integration Test の runner 登録を追加

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -91,6 +91,7 @@ android {
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         multiDexEnabled true
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
     }
 
@@ -127,4 +128,8 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.4'
+    testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation 'androidx.test:rules:1.2.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 }

--- a/android/app/src/androidTest/java/com/inoworl/lakiite/MainActivityTest.java
+++ b/android/app/src/androidTest/java/com/inoworl/lakiite/MainActivityTest.java
@@ -1,0 +1,13 @@
+package com.inoworl.lakiite;
+
+import androidx.test.rule.ActivityTestRule;
+import dev.flutter.plugins.integration_test.FlutterTestRunner;
+import org.junit.Rule;
+import org.junit.runner.RunWith;
+
+@RunWith(FlutterTestRunner.class)
+public class MainActivityTest {
+    @Rule
+    public ActivityTestRule<MainActivity> rule =
+            new ActivityTestRule<>(MainActivity.class, true, false);
+}


### PR DESCRIPTION
## 概要
- Android の integration test 用 `MainActivityTest` を追加しました
- `android/app/build.gradle` に `testInstrumentationRunner` と AndroidX test 依存を追加しました
- `integration_test` が要求する AndroidX test の strict constraint に合わせ、`runner:1.2.0`, `rules:1.2.0`, `espresso-core:3.2.0` を使っています

## 背景
main の Firebase Emulator Integration Tests で Android は主要フロー自体を最後まで実行できていましたが、最後に以下で失敗していました。

```text
✅ Firebase Emulatorで主要な共有フローを実行できる
🎉 0 tests passed.
No tests were found.
```

Android の instrumentation 側に Flutter integration test runner が登録されていなかったため、ネイティブ側がテストを検出できない状態でした。

## 確認
- `cd android && ./gradlew app:assembleDevDebugAndroidTest -Ptarget=../integration_test/social_schedule_emulator_flow_test.dart`
- `fvm flutter analyze --no-fatal-infos`
- `git diff --check`

## 補足
- Java ファイルに `dart format` を誤って実行したため失敗しましたが、これは検証コマンドの選択ミスです。Java ファイル自体は Gradle の Android test APK ビルドでコンパイル確認済みです。
- Firebase Emulator を使った実機相当の full run は Actions 上で確認します。
