### PR TITLE
Android Integration Test から Firebase Emulator へ接続できるようにする

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,21 @@ name: PR Tests
 on:
   pull_request:
     branches: [main, develop]
+    paths:
+      - "lib/**"
+      - "test/**"
+      - "integration_test/**"
+      - "android/**"
+      - "ios/**"
+      - "assets/**"
+      - "pubspec.yaml"
+      - "pubspec.lock"
+      - "analysis_options.yaml"
+      - "build.yaml"
+      - "firebase.json"
+      - ".firebaserc"
+      - ".github/workflows/ci.yml"
+      - ".github/workflows/firebase_emulator_integration_tests.yml"
 
 env:
   FLUTTER_VERSION: "3.41.5"

--- a/.github/workflows/firebase_emulator_integration_tests.yml
+++ b/.github/workflows/firebase_emulator_integration_tests.yml
@@ -3,6 +3,17 @@ name: Firebase Emulator Integration Tests
 on:
   push:
     branches: [main]
+    paths:
+      - "lib/**"
+      - "integration_test/**"
+      - "android/**"
+      - "ios/**"
+      - "assets/**"
+      - "pubspec.yaml"
+      - "pubspec.lock"
+      - "firebase.json"
+      - ".firebaserc"
+      - ".github/workflows/firebase_emulator_integration_tests.yml"
   workflow_dispatch:
 
 env:

--- a/.github/workflows/firebase_emulator_integration_tests.yml
+++ b/.github/workflows/firebase_emulator_integration_tests.yml
@@ -90,7 +90,10 @@ jobs:
           arch: x86_64
           profile: pixel_6
           script: |
-            firebase emulators:exec --only auth,firestore,storage --project "$FIREBASE_EMULATOR_PROJECT_ID" "flutter test integration_test/social_schedule_emulator_flow_test.dart -d emulator-5554 --flavor dev --dart-define=USE_FIREBASE_EMULATOR=true --dart-define=FIREBASE_EMULATOR_HOST=10.0.2.2 --dart-define=TEST_MODE=true --dart-define=FLAVOR=development"
+            adb reverse tcp:9099 tcp:9099
+            adb reverse tcp:8080 tcp:8080
+            adb reverse tcp:9199 tcp:9199
+            firebase emulators:exec --only auth,firestore,storage --project "$FIREBASE_EMULATOR_PROJECT_ID" "flutter test integration_test/social_schedule_emulator_flow_test.dart -d emulator-5554 --flavor dev --dart-define=USE_FIREBASE_EMULATOR=true --dart-define=FIREBASE_EMULATOR_HOST=127.0.0.1 --dart-define=TEST_MODE=true --dart-define=FLAVOR=development"
 
   ios:
     name: iOS Firebase Emulator Smoke Test


### PR DESCRIPTION
## 概要
- Android の Firebase Emulator Integration Tests で `adb reverse` を設定しました
- Android 側の `FIREBASE_EMULATOR_HOST` を `10.0.2.2` から `127.0.0.1` に変更しました
- PR Tests と Firebase Emulator Integration Tests に `paths` を追加し、Flutter アプリに関係する変更時だけ重い CI が走るようにしました

## 背景
#165 で Android integration test runner は正しく登録され、`No tests were found` は解消されました。

その後の main run ではテスト自体は1件として実行されましたが、Auth Emulator へ接続できずに失敗していました。

```text
[firebase_auth/unknown] An internal error has occurred.
[ Failed to connect to /10.0.2.2:9099
```

CI の Android emulator からホスト側 Firebase Emulator へ安定して接続するため、Auth/Firestore/Storage の各ポートを `adb reverse` で転送し、アプリ側は `127.0.0.1` を参照するようにします。

また、`.ai/` やドキュメントのみの変更で Flutter の PR Tests や merge 後の重い emulator tests が動かないよう、workflow trigger を関連ファイルに限定します。

## 確認
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/firebase_emulator_integration_tests.yml"); puts "yaml ok"'`\n- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "yaml ok"'`\n- `git diff --check`\n\n## 未確認\n- Android emulator と GitHub Actions runner 間の実接続は Actions 上で確認します\n