### PR TITLE
Firebase Emulator CI のデバイス接続設定を修正

### DIFF
--- a/.github/workflows/firebase_emulator_integration_tests.yml
+++ b/.github/workflows/firebase_emulator_integration_tests.yml
@@ -87,6 +87,27 @@ jobs:
                 );
           }
           EOF
+          cat > firebase.ci.json <<'EOF'
+          {
+            "emulators": {
+              "auth": {
+                "host": "0.0.0.0",
+                "port": 9099
+              },
+              "firestore": {
+                "host": "0.0.0.0",
+                "port": 8080
+              },
+              "storage": {
+                "host": "0.0.0.0",
+                "port": 9199
+              },
+              "ui": {
+                "enabled": false
+              }
+            }
+          }
+          EOF
 
       - name: Install Flutter dependencies
         run: |
@@ -101,10 +122,7 @@ jobs:
           arch: x86_64
           profile: pixel_6
           script: |
-            adb reverse tcp:9099 tcp:9099
-            adb reverse tcp:8080 tcp:8080
-            adb reverse tcp:9199 tcp:9199
-            firebase emulators:exec --only auth,firestore,storage --project "$FIREBASE_EMULATOR_PROJECT_ID" "flutter test integration_test/social_schedule_emulator_flow_test.dart -d emulator-5554 --flavor dev --dart-define=USE_FIREBASE_EMULATOR=true --dart-define=FIREBASE_EMULATOR_HOST=127.0.0.1 --dart-define=TEST_MODE=true --dart-define=FLAVOR=development"
+            firebase --config firebase.ci.json emulators:exec --only auth,firestore,storage --project "$FIREBASE_EMULATOR_PROJECT_ID" "flutter test integration_test/social_schedule_emulator_flow_test.dart -d emulator-5554 --flavor dev --dart-define=USE_FIREBASE_EMULATOR=true --dart-define=FIREBASE_EMULATOR_HOST=10.0.2.2 --dart-define=TEST_MODE=true --dart-define=FLAVOR=development"
 
   ios:
     name: iOS Firebase Emulator Smoke Test
@@ -168,6 +186,27 @@ jobs:
                 );
           }
           EOF
+          cat > firebase.ci.json <<'EOF'
+          {
+            "emulators": {
+              "auth": {
+                "host": "0.0.0.0",
+                "port": 9099
+              },
+              "firestore": {
+                "host": "0.0.0.0",
+                "port": 8080
+              },
+              "storage": {
+                "host": "0.0.0.0",
+                "port": 9199
+              },
+              "ui": {
+                "enabled": false
+              }
+            }
+          }
+          EOF
 
       - name: Install Flutter dependencies
         run: |
@@ -188,4 +227,4 @@ jobs:
 
       - name: Run iOS integration test
         run: |
-          firebase emulators:exec --only auth,firestore,storage --project "$FIREBASE_EMULATOR_PROJECT_ID" "flutter test integration_test/social_schedule_emulator_flow_test.dart -d $IOS_SIMULATOR_ID --flavor dev --dart-define=USE_FIREBASE_EMULATOR=true --dart-define=FIREBASE_EMULATOR_HOST=localhost --dart-define=TEST_MODE=true --dart-define=FLAVOR=development"
+          firebase --config firebase.ci.json emulators:exec --only auth,firestore,storage --project "$FIREBASE_EMULATOR_PROJECT_ID" "flutter test integration_test/social_schedule_emulator_flow_test.dart -d $IOS_SIMULATOR_ID --no-dds --flavor dev --dart-define=USE_FIREBASE_EMULATOR=true --dart-define=FIREBASE_EMULATOR_HOST=localhost --dart-define=TEST_MODE=true --dart-define=FLAVOR=development"


### PR DESCRIPTION
## 概要
- Firebase Emulator Integration Tests の CI 専用 config `firebase.ci.json` を生成し、Auth/Firestore/Storage を `0.0.0.0` で listen させます
- Android は Firebase SDK の localhost 再マップを避けるため、`FIREBASE_EMULATOR_HOST=10.0.2.2` に戻しました
- iOS は VM service 接続拒否の緩和として `flutter test` に `--no-dds` を追加しました

## 背景
#166 では `adb reverse + 127.0.0.1` にしましたが、Firebase Android SDK が内部で `127.0.0.1` を `10.0.2.2` へ再マップしていました。

```text
Mapping Auth Emulator host "127.0.0.1" to "10.0.2.2".
Failed to connect to /10.0.2.2:9099
```

そのため、CI の Firebase Emulator 自体を `0.0.0.0` で listen させ、Android emulator から `10.0.2.2` で接続する構成に戻します。

iOS は Xcode build 後に VM service の WebSocket 接続が拒否されていたため、DDS を無効化して接続経路を単純化します。

## 確認
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/firebase_emulator_integration_tests.yml"); puts "yaml ok"'`\n- `git diff --check`\n\n## 未確認\n- Android/iOS デバイスからの実接続は Actions 上で確認します\n