### PR TITLE
予定作成フォームの必須バリデーション表示タイミングを修正

### DIFF
--- a/lib/presentation/calendar/schedule_form_logic.dart
+++ b/lib/presentation/calendar/schedule_form_logic.dart
@@ -2,6 +2,23 @@ import 'package:flutter/material.dart';
 import 'package:lakiite/domain/entity/list.dart';
 import 'package:lakiite/domain/entity/schedule.dart';
 
+/// 予定フォーム全体の検証結果。
+class ScheduleFormValidationResult {
+  const ScheduleFormValidationResult({
+    required this.hasRequiredFields,
+    required this.hasInvalidTimeRange,
+  });
+
+  /// タイトル・場所など保存に必要な項目が入力済みかどうか。
+  final bool hasRequiredFields;
+
+  /// 終了日時が開始日時より前かどうか。
+  final bool hasInvalidTimeRange;
+
+  /// 現在の入力値で保存できるかどうか。
+  bool get canSave => hasRequiredFields && !hasInvalidTimeRange;
+}
+
 /// 予定フォームで使う入力値の組み立てと正規化を担う純粋ロジック。
 ///
 /// Widgetは表示状態とユーザー操作に集中し、日時計算や保存値の正規化はこのクラスへ集約する。
@@ -115,5 +132,28 @@ class ScheduleFormLogic {
     required String location,
   }) {
     return title.trim().isNotEmpty && location.trim().isNotEmpty;
+  }
+
+  /// 予定フォーム全体の保存可否に必要な検証結果を返す。
+  static ScheduleFormValidationResult validateScheduleForm({
+    required String title,
+    required String location,
+    required DateTime startDate,
+    required TimeOfDay startTime,
+    required DateTime endDate,
+    required TimeOfDay endTime,
+  }) {
+    return ScheduleFormValidationResult(
+      hasRequiredFields: hasRequiredScheduleFields(
+        title: title,
+        location: location,
+      ),
+      hasInvalidTimeRange: hasInvalidTimeRange(
+        startDate: startDate,
+        startTime: startTime,
+        endDate: endDate,
+        endTime: endTime,
+      ),
+    );
   }
 }

--- a/lib/presentation/calendar/schedule_form_logic.dart
+++ b/lib/presentation/calendar/schedule_form_logic.dart
@@ -108,4 +108,12 @@ class ScheduleFormLogic {
     }
     return location;
   }
+
+  /// 保存に必要なテキスト項目が入力済みかどうかを返す。
+  static bool hasRequiredScheduleFields({
+    required String title,
+    required String location,
+  }) {
+    return title.trim().isNotEmpty && location.trim().isNotEmpty;
+  }
 }

--- a/lib/presentation/calendar/schedule_form_page.dart
+++ b/lib/presentation/calendar/schedule_form_page.dart
@@ -172,9 +172,13 @@ class ScheduleFormPage extends HookConsumerWidget {
       ScheduleFormLogic.timeOf(initialEndDate),
     );
 
-    final hasTitleError = useState<bool>(false);
-    final hasLocationError = useState<bool>(false);
     final hasTimeError = useState<bool>(false);
+    final hasRequiredFields = useState<bool>(
+      ScheduleFormLogic.hasRequiredScheduleFields(
+        title: titleController.text,
+        location: locationController.text,
+      ),
+    );
 
     final selectedLists = useState<List<UserList>>([]);
     final listsAsync = ref.watch(userListsStreamProvider);
@@ -222,16 +226,18 @@ class ScheduleFormPage extends HookConsumerWidget {
       selectedEndTime.value
     ]);
 
-    // バリデーション関数
-    void validateInputs() {
-      hasTitleError.value = titleController.text.trim().isEmpty;
-      hasLocationError.value = locationController.text.trim().isEmpty;
+    // 保存ボタンの有効状態だけを更新する。入力途中の必須エラー表示は行わない。
+    void updateRequiredFieldsState() {
+      hasRequiredFields.value = ScheduleFormLogic.hasRequiredScheduleFields(
+        title: titleController.text,
+        location: locationController.text,
+      );
     }
 
     // テキストフィールドの変更を監視
     useEffect(() {
       void listener() {
-        validateInputs();
+        updateRequiredFieldsState();
       }
 
       titleController.addListener(listener);
@@ -247,11 +253,11 @@ class ScheduleFormPage extends HookConsumerWidget {
     Future<void> handleSave() async {
       AppLogger.debug('ScheduleFormPage: Save button pressed');
 
-      if (titleController.text.isEmpty) {
-        AppLogger.warning('ScheduleFormPage: Title is empty');
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('タイトルを入力してください')),
-        );
+      if (!ScheduleFormLogic.hasRequiredScheduleFields(
+        title: titleController.text,
+        location: locationController.text,
+      )) {
+        AppLogger.warning('ScheduleFormPage: Required fields are empty');
         return;
       }
 
@@ -358,10 +364,10 @@ class ScheduleFormPage extends HookConsumerWidget {
           children: [
             TextField(
               controller: titleController,
-              decoration: InputDecoration(
+              decoration: const InputDecoration(
                 labelText: 'タイトル',
-                border: const OutlineInputBorder(),
-                errorText: hasTitleError.value ? 'タイトルを入力してください' : null,
+                border: OutlineInputBorder(),
+                helperText: '必須',
               ),
             ),
             const SizedBox(height: 16),
@@ -376,13 +382,10 @@ class ScheduleFormPage extends HookConsumerWidget {
             const SizedBox(height: 16),
             TextField(
               controller: locationController,
-              decoration: InputDecoration(
+              decoration: const InputDecoration(
                 labelText: '場所',
-                border: const OutlineInputBorder(),
-                errorText: hasLocationError.value
-                    ? '場所を入力してください。場所が未定の場合は「未定」と入力してください。'
-                    : null,
-                helperText: '場所が未定の場合は「未定」と入力してください。',
+                border: OutlineInputBorder(),
+                helperText: '必須。場所が未定の場合は「未定」と入力してください。',
               ),
             ),
             const SizedBox(height: 16),
@@ -569,9 +572,7 @@ class ScheduleFormPage extends HookConsumerWidget {
               ],
             ),
             const SizedBox(height: 16),
-            if (hasTimeError.value ||
-                hasTitleError.value ||
-                hasLocationError.value)
+            if (hasTimeError.value)
               Container(
                 margin: const EdgeInsets.symmetric(horizontal: 8),
                 padding: const EdgeInsets.all(8),
@@ -583,40 +584,6 @@ class ScheduleFormPage extends HookConsumerWidget {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    if (hasTitleError.value)
-                      const Padding(
-                        padding: EdgeInsets.only(bottom: 4),
-                        child: Row(
-                          children: [
-                            Icon(Icons.error_outline,
-                                color: Colors.red, size: 16),
-                            SizedBox(width: 8),
-                            Expanded(
-                              child: Text(
-                                'タイトルを入力してください',
-                                style: TextStyle(color: Colors.red),
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                    if (hasLocationError.value)
-                      const Padding(
-                        padding: EdgeInsets.only(bottom: 4),
-                        child: Row(
-                          children: [
-                            Icon(Icons.error_outline,
-                                color: Colors.red, size: 16),
-                            SizedBox(width: 8),
-                            Expanded(
-                              child: Text(
-                                '場所を入力してください。場所が未定の場合は「未定」と入力してください。',
-                                style: TextStyle(color: Colors.red),
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
                     if (hasTimeError.value)
                       const Row(
                         children: [
@@ -761,16 +728,12 @@ class ScheduleFormPage extends HookConsumerWidget {
         ),
       ),
       floatingActionButton: FloatingActionButton.extended(
-        onPressed: (hasTimeError.value ||
-                hasTitleError.value ||
-                hasLocationError.value)
+        onPressed: (hasTimeError.value || !hasRequiredFields.value)
             ? null
             : handleSave,
         icon: const Icon(Icons.save),
         label: const Text('保存'),
-        backgroundColor: (hasTimeError.value ||
-                hasTitleError.value ||
-                hasLocationError.value)
+        backgroundColor: (hasTimeError.value || !hasRequiredFields.value)
             ? Colors.grey
             : null,
       ),

--- a/lib/presentation/calendar/schedule_form_page.dart
+++ b/lib/presentation/calendar/schedule_form_page.dart
@@ -172,13 +172,24 @@ class ScheduleFormPage extends HookConsumerWidget {
       ScheduleFormLogic.timeOf(initialEndDate),
     );
 
-    final hasTimeError = useState<bool>(false);
-    final hasRequiredFields = useState<bool>(
-      ScheduleFormLogic.hasRequiredScheduleFields(
+    ScheduleFormValidationResult currentValidationResult() {
+      return ScheduleFormLogic.validateScheduleForm(
         title: titleController.text,
         location: locationController.text,
-      ),
+        startDate: selectedStartDate.value,
+        startTime: selectedStartTime.value,
+        endDate: selectedEndDate.value,
+        endTime: selectedEndTime.value,
+      );
+    }
+
+    final formValidationResult = useState<ScheduleFormValidationResult>(
+      currentValidationResult(),
     );
+
+    void updateValidationResult() {
+      formValidationResult.value = currentValidationResult();
+    }
 
     final selectedLists = useState<List<UserList>>([]);
     final listsAsync = ref.watch(userListsStreamProvider);
@@ -205,19 +216,9 @@ class ScheduleFormPage extends HookConsumerWidget {
       return null;
     }, [listsAsync]);
 
-    // 時間の整合性をチェックする関数
-    void validateTime() {
-      hasTimeError.value = ScheduleFormLogic.hasInvalidTimeRange(
-        startDate: selectedStartDate.value,
-        startTime: selectedStartTime.value,
-        endDate: selectedEndDate.value,
-        endTime: selectedEndTime.value,
-      );
-    }
-
-    // 初期表示時と時間変更時にバリデーションを実行
+    // 初期表示時と日時変更時にフォーム全体の検証結果を更新する。
     useEffect(() {
-      validateTime();
+      updateValidationResult();
       return null;
     }, [
       selectedStartDate.value,
@@ -226,18 +227,10 @@ class ScheduleFormPage extends HookConsumerWidget {
       selectedEndTime.value
     ]);
 
-    // 保存ボタンの有効状態だけを更新する。入力途中の必須エラー表示は行わない。
-    void updateRequiredFieldsState() {
-      hasRequiredFields.value = ScheduleFormLogic.hasRequiredScheduleFields(
-        title: titleController.text,
-        location: locationController.text,
-      );
-    }
-
     // テキストフィールドの変更を監視
     useEffect(() {
       void listener() {
-        updateRequiredFieldsState();
+        updateValidationResult();
       }
 
       titleController.addListener(listener);
@@ -253,10 +246,10 @@ class ScheduleFormPage extends HookConsumerWidget {
     Future<void> handleSave() async {
       AppLogger.debug('ScheduleFormPage: Save button pressed');
 
-      if (!ScheduleFormLogic.hasRequiredScheduleFields(
-        title: titleController.text,
-        location: locationController.text,
-      )) {
+      final validationResult = currentValidationResult();
+      formValidationResult.value = validationResult;
+
+      if (!validationResult.hasRequiredFields) {
         AppLogger.warning('ScheduleFormPage: Required fields are empty');
         return;
       }
@@ -271,7 +264,7 @@ class ScheduleFormPage extends HookConsumerWidget {
         selectedEndTime.value,
       );
 
-      if (endDateTime.isBefore(startDateTime)) {
+      if (validationResult.hasInvalidTimeRange) {
         AppLogger.warning('ScheduleFormPage: End date is before start date');
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('終了日時は開始日時より後に設定してください')),
@@ -454,7 +447,7 @@ class ScheduleFormPage extends HookConsumerWidget {
                           );
                           if (result != null) {
                             selectedStartTime.value = result;
-                            validateTime();
+                            updateValidationResult();
                           }
                         },
                         child: Container(
@@ -545,7 +538,7 @@ class ScheduleFormPage extends HookConsumerWidget {
                           );
                           if (result != null) {
                             selectedEndTime.value = result;
-                            validateTime();
+                            updateValidationResult();
                           }
                         },
                         child: Container(
@@ -572,7 +565,7 @@ class ScheduleFormPage extends HookConsumerWidget {
               ],
             ),
             const SizedBox(height: 16),
-            if (hasTimeError.value)
+            if (formValidationResult.value.hasInvalidTimeRange)
               Container(
                 margin: const EdgeInsets.symmetric(horizontal: 8),
                 padding: const EdgeInsets.all(8),
@@ -584,7 +577,7 @@ class ScheduleFormPage extends HookConsumerWidget {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    if (hasTimeError.value)
+                    if (formValidationResult.value.hasInvalidTimeRange)
                       const Row(
                         children: [
                           Icon(Icons.error_outline,
@@ -728,14 +721,11 @@ class ScheduleFormPage extends HookConsumerWidget {
         ),
       ),
       floatingActionButton: FloatingActionButton.extended(
-        onPressed: (hasTimeError.value || !hasRequiredFields.value)
-            ? null
-            : handleSave,
+        onPressed: formValidationResult.value.canSave ? handleSave : null,
         icon: const Icon(Icons.save),
         label: const Text('保存'),
-        backgroundColor: (hasTimeError.value || !hasRequiredFields.value)
-            ? Colors.grey
-            : null,
+        backgroundColor:
+            formValidationResult.value.canSave ? null : Colors.grey,
       ),
     );
   }

--- a/test/presentation/schedule/schedule_form_logic_test.dart
+++ b/test/presentation/schedule/schedule_form_logic_test.dart
@@ -108,6 +108,44 @@ void main() {
       expect(ScheduleFormLogic.optionalLocation('  '), '  ');
       expect(ScheduleFormLogic.optionalLocation('会議室'), '会議室');
     });
+
+    test('タイトルと場所が入力されている場合だけ必須項目入力済みになる', () {
+      expect(
+        ScheduleFormLogic.hasRequiredScheduleFields(
+          title: '予定',
+          location: '未定',
+        ),
+        isTrue,
+      );
+      expect(
+        ScheduleFormLogic.hasRequiredScheduleFields(
+          title: '',
+          location: '未定',
+        ),
+        isFalse,
+      );
+      expect(
+        ScheduleFormLogic.hasRequiredScheduleFields(
+          title: '   ',
+          location: '未定',
+        ),
+        isFalse,
+      );
+      expect(
+        ScheduleFormLogic.hasRequiredScheduleFields(
+          title: '予定',
+          location: '',
+        ),
+        isFalse,
+      );
+      expect(
+        ScheduleFormLogic.hasRequiredScheduleFields(
+          title: '予定',
+          location: '   ',
+        ),
+        isFalse,
+      );
+    });
   });
 }
 

--- a/test/presentation/schedule/schedule_form_logic_test.dart
+++ b/test/presentation/schedule/schedule_form_logic_test.dart
@@ -146,6 +146,44 @@ void main() {
         isFalse,
       );
     });
+
+    test('フォーム全体の保存可否を検証結果として返す', () {
+      final validResult = ScheduleFormLogic.validateScheduleForm(
+        title: '予定',
+        location: '未定',
+        startDate: DateTime(2026, 1, 1),
+        startTime: const TimeOfDay(hour: 10, minute: 0),
+        endDate: DateTime(2026, 1, 1),
+        endTime: const TimeOfDay(hour: 11, minute: 0),
+      );
+      expect(validResult.hasRequiredFields, isTrue);
+      expect(validResult.hasInvalidTimeRange, isFalse);
+      expect(validResult.canSave, isTrue);
+
+      final missingRequiredResult = ScheduleFormLogic.validateScheduleForm(
+        title: '予定',
+        location: '   ',
+        startDate: DateTime(2026, 1, 1),
+        startTime: const TimeOfDay(hour: 10, minute: 0),
+        endDate: DateTime(2026, 1, 1),
+        endTime: const TimeOfDay(hour: 11, minute: 0),
+      );
+      expect(missingRequiredResult.hasRequiredFields, isFalse);
+      expect(missingRequiredResult.hasInvalidTimeRange, isFalse);
+      expect(missingRequiredResult.canSave, isFalse);
+
+      final invalidTimeResult = ScheduleFormLogic.validateScheduleForm(
+        title: '予定',
+        location: '未定',
+        startDate: DateTime(2026, 1, 1),
+        startTime: const TimeOfDay(hour: 11, minute: 0),
+        endDate: DateTime(2026, 1, 1),
+        endTime: const TimeOfDay(hour: 10, minute: 0),
+      );
+      expect(invalidTimeResult.hasRequiredFields, isTrue);
+      expect(invalidTimeResult.hasInvalidTimeRange, isTrue);
+      expect(invalidTimeResult.canSave, isFalse);
+    });
   });
 }
 

--- a/test/presentation/schedule/schedule_widget_test.dart
+++ b/test/presentation/schedule/schedule_widget_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lakiite/presentation/calendar/schedule_form_page.dart';
 import '../../mock/providers/test_providers.dart';
 import '../../mock/base_mock.dart';
 import '../../utils/test_utils.dart';
@@ -166,6 +167,48 @@ void main() {
     });
 
     group('Schedule Form Widget Tests', () {
+      testWidgets('必須項目はフォーカスや入力途中でエラー表示せず保存ボタンを無効化する', (tester) async {
+        await tester.pumpWidget(
+          TestUtils.createTestApp(
+            overrides: TestProviders.forScheduleCreation,
+            child: const ScheduleFormPage(),
+          ),
+        );
+        await tester.pump(const Duration(milliseconds: 200));
+
+        expect(find.text('タイトルを入力してください'), findsNothing);
+        expect(find.textContaining('場所を入力してください'), findsNothing);
+
+        await tester.tap(find.widgetWithText(TextField, 'タイトル'));
+        await tester.pump();
+
+        expect(find.text('タイトルを入力してください'), findsNothing);
+        expect(find.textContaining('場所を入力してください'), findsNothing);
+
+        await tester.enterText(
+          find.widgetWithText(TextField, 'タイトル'),
+          'テスト予定',
+        );
+        await tester.pump();
+
+        expect(find.text('タイトルを入力してください'), findsNothing);
+        expect(find.textContaining('場所を入力してください'), findsNothing);
+
+        var saveButton = tester
+            .widget<FloatingActionButton>(find.byType(FloatingActionButton));
+        expect(saveButton.onPressed, isNull);
+
+        await tester.enterText(
+          find.widgetWithText(TextField, '場所'),
+          '未定',
+        );
+        await tester.pump();
+
+        saveButton = tester
+            .widget<FloatingActionButton>(find.byType(FloatingActionButton));
+        expect(saveButton.onPressed, isNotNull);
+      });
+
       testWidgets('スケジュール作成フォームが正しく表示される', (tester) async {
         await tester.pumpWidget(
           TestUtils.createTestApp(


### PR DESCRIPTION
## 概要
- タイトル・場所の必須チェックでフォーカス直後や入力途中にエラー文を出さないように修正
- 必須項目は helperText で常時明示し、未入力時は保存ボタンを無効化
- 必須項目と日時範囲をまとめた ScheduleFormValidationResult を追加し、保存可否判定を ScheduleFormLogic に集約
- Page 側は検証結果を表示・ボタン状態・保存ガードへ反映する責務に限定
- ユニットテストとWidgetテストを追加

## 確認
- dart format lib/presentation/calendar/schedule_form_logic.dart lib/presentation/calendar/schedule_form_page.dart test/presentation/schedule/schedule_form_logic_test.dart test/presentation/schedule/schedule_widget_test.dart
- git diff --check
- fvm flutter test test/presentation/schedule/schedule_form_logic_test.dart test/presentation/schedule/schedule_widget_test.dart --dart-define=FLUTTER_TEST=true
- fvm flutter analyze --no-fatal-infos