### PR TITLE
[codex] Fix friend request acceptance regression

### DIFF
--- a/integration_test/social_schedule_emulator_flow_test.dart
+++ b/integration_test/social_schedule_emulator_flow_test.dart
@@ -69,20 +69,11 @@ void main() {
     final requestId = requestSnapshot.docs.single.id;
     await AcceptFriendRequestUseCase(
       notificationRepository: notificationRepository,
-      userRepository: userRepository,
     ).execute(requestId);
 
     final accepted = await notificationRepository.getNotification(requestId);
     expect(accepted?.status, domain.NotificationStatus.accepted);
     expect(accepted?.isRead, isTrue);
-
-    final receiverPrivate = await FirebaseFirestore.instance
-        .collection('users')
-        .doc(receiver.id)
-        .collection('private')
-        .doc('profile')
-        .get();
-    expect(receiverPrivate.data()?['lists'], contains(sender.id));
 
     final start = DateTime.now().add(const Duration(days: 1));
     final schedule = await scheduleRepository.createSchedule(

--- a/lib/application/notification/accept_friend_request_use_case.dart
+++ b/lib/application/notification/accept_friend_request_use_case.dart
@@ -1,21 +1,16 @@
-import '../../domain/entity/notification.dart';
 import '../../domain/interfaces/i_notification_repository.dart';
-import '../../domain/interfaces/i_user_repository.dart';
 
 /// 友達申請通知の承認に伴う業務処理を担うUseCase。
 class AcceptFriendRequestUseCase {
   const AcceptFriendRequestUseCase({
     required INotificationRepository notificationRepository,
-    required IUserRepository userRepository,
-  })  : _notificationRepository = notificationRepository,
-        _userRepository = userRepository;
+  }) : _notificationRepository = notificationRepository;
 
   final INotificationRepository _notificationRepository;
-  final IUserRepository _userRepository;
 
   /// 友達申請通知を承認する。
   ///
-  /// 申請元または受信者が存在しない場合は友達関係を作らず、通知を期限切れにする。
+  /// フレンド関係の更新は Cloud Functions の通知ステータス更新トリガーに任せる。
   Future<void> execute(String notificationId) async {
     final notification =
         await _notificationRepository.getNotification(notificationId);
@@ -23,38 +18,6 @@ class AcceptFriendRequestUseCase {
       throw Exception('Notification not found');
     }
 
-    if (notification.type != NotificationType.friend) {
-      await _notificationRepository.acceptNotification(notificationId);
-      return;
-    }
-
-    final receiver = await _userRepository.getUser(notification.receiveUserId);
-    final sender = await _userRepository.getUser(notification.sendUserId);
-    if (receiver == null || sender == null) {
-      await _notificationRepository.expireNotification(notificationId);
-      return;
-    }
-
-    await _addFriendIfNeeded(
-      userId: receiver.id,
-      friendId: sender.id,
-    );
-    await _addFriendIfNeeded(
-      userId: sender.id,
-      friendId: receiver.id,
-    );
     await _notificationRepository.acceptNotification(notificationId);
-  }
-
-  Future<void> _addFriendIfNeeded({
-    required String userId,
-    required String friendId,
-  }) async {
-    final user = await _userRepository.getUser(userId);
-    if (user == null || user.friends.contains(friendId)) {
-      return;
-    }
-
-    await _userRepository.addToList(userId, friendId);
   }
 }

--- a/lib/application/notification/notification_notifier.dart
+++ b/lib/application/notification/notification_notifier.dart
@@ -29,7 +29,6 @@ final acceptFriendRequestUseCaseProvider =
     Provider<AcceptFriendRequestUseCase>((ref) {
   return AcceptFriendRequestUseCase(
     notificationRepository: ref.watch(notificationRepositoryProvider),
-    userRepository: ref.watch(userRepositoryProvider),
   );
 });
 
@@ -254,10 +253,6 @@ class NotificationNotifier extends StateNotifier<AsyncValue<void>> {
             userRepo.clearCache();
             AppLogger.debug('フレンド申請承認時にUserRepositoryキャッシュをクリアしました');
           }
-
-          // プロバイダー自体も無効化してより確実にキャッシュをクリア
-          _ref.invalidate(userRepositoryProvider);
-          AppLogger.debug('フレンド申請承認時にuserRepositoryProviderを無効化しました');
         } catch (e) {
           // キャッシュクリアに失敗しても処理は続行
           AppLogger.error('フレンド申請承認時のキャッシュクリアに失敗: $e');

--- a/lib/infrastructure/user_repository.dart
+++ b/lib/infrastructure/user_repository.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:typed_data';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_storage/firebase_storage.dart';
@@ -317,26 +318,38 @@ class UserRepository implements IUserRepository {
       yield _userCache[id];
     }
 
-    yield* _firestore
-        .collection('users')
-        .doc(id)
-        .snapshots()
-        .asyncMap((publicDoc) async {
-      if (!publicDoc.exists) return null;
+    final publicRef = _firestore.collection('users').doc(id);
+    final privateRef = publicRef.collection('private').doc('profile');
 
-      final privateDoc = await _firestore
-          .collection('users')
-          .doc(id)
-          .collection('private')
-          .doc('profile')
-          .get();
+    late final StreamController<UserModel?> controller;
+    StreamSubscription<DocumentSnapshot<Map<String, dynamic>>>? publicSub;
+    StreamSubscription<DocumentSnapshot<Map<String, dynamic>>>? privateSub;
+    DocumentSnapshot<Map<String, dynamic>>? publicDoc;
+    DocumentSnapshot<Map<String, dynamic>>? privateDoc;
+    var hasPublicSnapshot = false;
+    var hasPrivateSnapshot = false;
 
-      if (!privateDoc.exists) return null;
+    void emitIfReady() {
+      if (controller.isClosed || !hasPublicSnapshot || !hasPrivateSnapshot) {
+        return;
+      }
 
-      final publicData = publicDoc.data()!;
-      publicData['id'] = publicDoc.id;
+      final currentPublicDoc = publicDoc;
+      final currentPrivateDoc = privateDoc;
+      if (currentPublicDoc == null ||
+          currentPrivateDoc == null ||
+          !currentPublicDoc.exists ||
+          !currentPrivateDoc.exists) {
+        controller.add(null);
+        return;
+      }
 
-      final privateData = privateDoc.data()!;
+      final publicData =
+          Map<String, dynamic>.from(currentPublicDoc.data() ?? {});
+      publicData['id'] = currentPublicDoc.id;
+
+      final privateData =
+          Map<String, dynamic>.from(currentPrivateDoc.data() ?? {});
       privateData['lists'] = privateData['lists'] ?? [];
 
       final userModel = UserModel(
@@ -344,11 +357,39 @@ class UserRepository implements IUserRepository {
         privateProfile: PrivateUserModel.fromJson(privateData),
       );
 
-      // キャッシュを更新
       _userCache[id] = userModel;
+      controller.add(userModel);
+    }
 
-      return userModel;
-    });
+    controller = StreamController<UserModel?>(
+      onListen: () {
+        publicSub = publicRef.snapshots().listen(
+          (snapshot) {
+            publicDoc = snapshot;
+            hasPublicSnapshot = true;
+            emitIfReady();
+          },
+          onError: controller.addError,
+        );
+        privateSub = privateRef.snapshots().listen(
+          (snapshot) {
+            privateDoc = snapshot;
+            hasPrivateSnapshot = true;
+            emitIfReady();
+          },
+          onError: controller.addError,
+        );
+      },
+      onCancel: () async {
+        await publicSub?.cancel();
+        await privateSub?.cancel();
+        if (!controller.isClosed) {
+          await controller.close();
+        }
+      },
+    );
+
+    yield* controller.stream;
   }
 
   @override

--- a/lib/presentation/notification/notification_list_page.dart
+++ b/lib/presentation/notification/notification_list_page.dart
@@ -397,6 +397,9 @@ class _NotificationItem extends ConsumerWidget {
       );
     }
 
+    final canOpenDetail =
+        !state.isLoading && notification.type != domain.NotificationType.friend;
+
     return buildLoadingOverlay(
       Card(
         margin: const EdgeInsets.only(bottom: 12),
@@ -507,7 +510,7 @@ class _NotificationItem extends ConsumerWidget {
                       ),
                     ),
                   ),
-            onTap: state.isLoading ? null : handleNotificationTap,
+            onTap: canOpenDetail ? handleNotificationTap : null,
           ),
         ),
       ),

--- a/test/application/flows/primary_user_flows_test.dart
+++ b/test/application/flows/primary_user_flows_test.dart
@@ -140,28 +140,15 @@ void main() {
       expect(sent.single.status, NotificationStatus.pending);
     });
 
-    test('友達申請を承認すると通知と双方の友達リストが更新される', () async {
-      final sender = BaseMock.createTestUser(
-        id: 'sender-id',
-        name: '申請者',
-        displayName: '申請者',
-      );
-      final receiver = BaseMock.createTestUser(
-        id: 'receiver-id',
-        name: '受信者',
-        displayName: '受信者',
-      );
-      userRepository
-        ..addTestUser(sender)
-        ..addTestUser(receiver);
+    test('友達申請を承認すると通知を承認済みにする', () async {
       notificationRepository.addTestNotification(
         Notification(
           id: 'friend-request-id',
           type: NotificationType.friend,
-          sendUserId: sender.id,
-          receiveUserId: receiver.id,
-          sendUserDisplayName: sender.displayName,
-          receiveUserDisplayName: receiver.displayName,
+          sendUserId: 'sender-id',
+          receiveUserId: 'receiver-id',
+          sendUserDisplayName: '申請者',
+          receiveUserDisplayName: '受信者',
           status: NotificationStatus.pending,
           createdAt: DateTime(2026, 5, 22),
           updatedAt: DateTime(2026, 5, 22),
@@ -174,30 +161,20 @@ void main() {
 
       final accepted =
           await notificationRepository.getNotification('friend-request-id');
-      final updatedSender = await userRepository.getUser(sender.id);
-      final updatedReceiver = await userRepository.getUser(receiver.id);
 
       expect(accepted?.status, NotificationStatus.accepted);
       expect(accepted?.isRead, isTrue);
-      expect(updatedSender?.friends, contains(receiver.id));
-      expect(updatedReceiver?.friends, contains(sender.id));
     });
 
-    test('申請元ユーザーが削除済みの友達申請を承認すると通知を期限切れとして既読にする', () async {
-      final receiver = BaseMock.createTestUser(
-        id: 'receiver-id',
-        name: '受信者',
-        displayName: '受信者',
-      );
-      userRepository.addTestUser(receiver);
+    test('友達申請承認は削除済みユーザー判定をクライアントで行わない', () async {
       notificationRepository.addTestNotification(
         Notification(
           id: 'deleted-sender-request-id',
           type: NotificationType.friend,
           sendUserId: 'deleted-sender-id',
-          receiveUserId: receiver.id,
+          receiveUserId: 'receiver-id',
           sendUserDisplayName: '削除済み申請者',
-          receiveUserDisplayName: receiver.displayName,
+          receiveUserDisplayName: '受信者',
           status: NotificationStatus.pending,
           createdAt: DateTime(2026, 5, 22),
           updatedAt: DateTime(2026, 5, 22),
@@ -208,13 +185,11 @@ void main() {
           .read(notification_app.notificationNotifierProvider.notifier)
           .acceptNotification('deleted-sender-request-id');
 
-      final expired = await notificationRepository
+      final accepted = await notificationRepository
           .getNotification('deleted-sender-request-id');
-      final updatedReceiver = await userRepository.getUser(receiver.id);
 
-      expect(expired?.status, NotificationStatus.expired);
-      expect(expired?.isRead, isTrue);
-      expect(updatedReceiver?.friends, isNot(contains('deleted-sender-id')));
+      expect(accepted?.status, NotificationStatus.accepted);
+      expect(accepted?.isRead, isTrue);
     });
 
     test('予定を追加すると保存済み予定として取得できる', () async {

--- a/test/application/notification/accept_friend_request_use_case_test.dart
+++ b/test/application/notification/accept_friend_request_use_case_test.dart
@@ -2,44 +2,26 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:lakiite/application/notification/accept_friend_request_use_case.dart';
 import 'package:lakiite/domain/entity/notification.dart';
 
-import '../../mock/base_mock.dart';
 import '../../mock/repository/mock_notification_repository.dart';
-import '../../mock/repository/mock_user_repository.dart';
 
 void main() {
   group('AcceptFriendRequestUseCase', () {
-    late MockUserRepository userRepository;
     late MockNotificationRepository notificationRepository;
     late AcceptFriendRequestUseCase useCase;
 
     setUp(() {
-      userRepository = MockUserRepository();
       notificationRepository = MockNotificationRepository();
       useCase = AcceptFriendRequestUseCase(
         notificationRepository: notificationRepository,
-        userRepository: userRepository,
       );
     });
 
-    test('申請元と受信者が存在する場合は双方を友達にして通知を承認済みにする', () async {
-      final sender = BaseMock.createTestUser(
-        id: 'sender-id',
-        name: '申請者',
-        displayName: '申請者',
-      );
-      final receiver = BaseMock.createTestUser(
-        id: 'receiver-id',
-        name: '受信者',
-        displayName: '受信者',
-      );
-      userRepository
-        ..addTestUser(sender)
-        ..addTestUser(receiver);
+    test('友達申請承認は相手の非公開プロフィールを読まず通知を承認済みにする', () async {
       notificationRepository.addTestNotification(
         _friendRequest(
           id: 'friend-request-id',
-          sendUserId: sender.id,
-          receiveUserId: receiver.id,
+          sendUserId: 'sender-id',
+          receiveUserId: 'receiver-id',
         ),
       );
 
@@ -47,65 +29,9 @@ void main() {
 
       final notification =
           await notificationRepository.getNotification('friend-request-id');
-      final updatedSender = await userRepository.getUser(sender.id);
-      final updatedReceiver = await userRepository.getUser(receiver.id);
 
       expect(notification?.status, NotificationStatus.accepted);
       expect(notification?.isRead, isTrue);
-      expect(updatedSender?.friends, contains(receiver.id));
-      expect(updatedReceiver?.friends, contains(sender.id));
-    });
-
-    test('申請元が削除済みの場合は友達追加せず通知を期限切れとして既読にする', () async {
-      final receiver = BaseMock.createTestUser(
-        id: 'receiver-id',
-        name: '受信者',
-        displayName: '受信者',
-      );
-      userRepository.addTestUser(receiver);
-      notificationRepository.addTestNotification(
-        _friendRequest(
-          id: 'deleted-sender-request-id',
-          sendUserId: 'deleted-sender-id',
-          receiveUserId: receiver.id,
-        ),
-      );
-
-      await useCase.execute('deleted-sender-request-id');
-
-      final notification = await notificationRepository
-          .getNotification('deleted-sender-request-id');
-      final updatedReceiver = await userRepository.getUser(receiver.id);
-
-      expect(notification?.status, NotificationStatus.expired);
-      expect(notification?.isRead, isTrue);
-      expect(updatedReceiver?.friends, isNot(contains('deleted-sender-id')));
-    });
-
-    test('受信者が削除済みの場合は友達追加せず通知を期限切れとして既読にする', () async {
-      final sender = BaseMock.createTestUser(
-        id: 'sender-id',
-        name: '申請者',
-        displayName: '申請者',
-      );
-      userRepository.addTestUser(sender);
-      notificationRepository.addTestNotification(
-        _friendRequest(
-          id: 'deleted-receiver-request-id',
-          sendUserId: sender.id,
-          receiveUserId: 'deleted-receiver-id',
-        ),
-      );
-
-      await useCase.execute('deleted-receiver-request-id');
-
-      final notification = await notificationRepository
-          .getNotification('deleted-receiver-request-id');
-      final updatedSender = await userRepository.getUser(sender.id);
-
-      expect(notification?.status, NotificationStatus.expired);
-      expect(notification?.isRead, isTrue);
-      expect(updatedSender?.friends, isNot(contains('deleted-receiver-id')));
     });
   });
 }

--- a/test/mock/repository/mock_notification_repository.dart
+++ b/test/mock/repository/mock_notification_repository.dart
@@ -29,6 +29,14 @@ class MockNotificationRepository extends BaseMock
     _notifications.clear();
   }
 
+  Notification? findTestNotification(String notificationId) {
+    try {
+      return _notifications.firstWhere((n) => n.id == notificationId);
+    } catch (e) {
+      return null;
+    }
+  }
+
   @override
   Future<void> createNotification(Notification notification) async {
     await Future.delayed(const Duration(milliseconds: 200));

--- a/test/presentation/notification/notification_list_page_test.dart
+++ b/test/presentation/notification/notification_list_page_test.dart
@@ -1,0 +1,139 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lakiite/app/di/providers.dart';
+import 'package:lakiite/application/auth/auth_notifier.dart';
+import 'package:lakiite/application/auth/auth_state.dart';
+import 'package:lakiite/application/notification/notification_notifier.dart'
+    as notification_app;
+import 'package:lakiite/domain/entity/notification.dart' as domain;
+import 'package:lakiite/domain/entity/user.dart';
+import 'package:lakiite/infrastructure/firebase/push_notification_sender.dart';
+import 'package:lakiite/presentation/notification/notification_list_page.dart';
+
+import '../../mock/repository/mock_notification_repository.dart';
+import '../../mock/repository/mock_user_repository.dart';
+
+void main() {
+  group('NotificationListPage', () {
+    late MockNotificationRepository notificationRepository;
+    late MockUserRepository userRepository;
+    late UserModel currentUser;
+    late domain.Notification friendRequest;
+
+    setUp(() {
+      notificationRepository = MockNotificationRepository();
+      userRepository = MockUserRepository();
+      currentUser = UserModel.create(
+        id: 'receiver-id',
+        name: '受信者',
+        displayName: '受信者',
+      );
+      friendRequest = domain.Notification(
+        id: 'friend-request-id',
+        type: domain.NotificationType.friend,
+        sendUserId: 'sender-id',
+        receiveUserId: currentUser.id,
+        sendUserDisplayName: '申請者',
+        receiveUserDisplayName: currentUser.displayName,
+        status: domain.NotificationStatus.pending,
+        createdAt: DateTime(2026, 5, 27),
+        updatedAt: DateTime(2026, 5, 27),
+      );
+
+      userRepository.addTestUser(currentUser);
+      userRepository.addTestUser(
+        UserModel.create(
+          id: 'sender-id',
+          name: '申請者',
+          displayName: '申請者',
+        ),
+      );
+      notificationRepository.addTestNotification(friendRequest);
+    });
+
+    testWidgets('フレンド申請通知の行タップではプロフィールへ遷移しない', (tester) async {
+      final navigatorObserver = _RecordingNavigatorObserver();
+
+      await tester.pumpWidget(
+        _buildTestApp(
+          currentUser: currentUser,
+          notificationRepository: notificationRepository,
+          userRepository: userRepository,
+          navigatorObserver: navigatorObserver,
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 150));
+
+      await tester.tap(find.text('フレンド申請'));
+      await tester.pump();
+
+      expect(navigatorObserver.pushedRoutes, isEmpty);
+    });
+
+    testWidgets('フレンド申請通知の承認ボタンは承認処理だけを実行する', (tester) async {
+      final navigatorObserver = _RecordingNavigatorObserver();
+
+      await tester.pumpWidget(
+        _buildTestApp(
+          currentUser: currentUser,
+          notificationRepository: notificationRepository,
+          userRepository: userRepository,
+          navigatorObserver: navigatorObserver,
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 150));
+
+      await tester.tap(find.widgetWithText(ElevatedButton, '承認'));
+      await tester.pump(const Duration(milliseconds: 400));
+
+      final acceptedNotification =
+          notificationRepository.findTestNotification(friendRequest.id);
+
+      expect(acceptedNotification?.status, domain.NotificationStatus.accepted);
+      expect(navigatorObserver.pushedRoutes, isEmpty);
+    });
+  });
+}
+
+Widget _buildTestApp({
+  required UserModel currentUser,
+  required MockNotificationRepository notificationRepository,
+  required MockUserRepository userRepository,
+  required NavigatorObserver navigatorObserver,
+}) {
+  return ProviderScope(
+    overrides: [
+      authStateStreamProvider.overrideWith(
+        (ref) => Stream.value(AuthState.authenticated(currentUser)),
+      ),
+      notification_app.currentUserIdProvider.overrideWithValue(currentUser.id),
+      notification_app.notificationRepositoryProvider.overrideWithValue(
+        notificationRepository,
+      ),
+      notification_app.pushNotificationSenderProvider.overrideWithValue(
+        PushNotificationSender(
+          cloudFunctionUrl: 'https://example.test/push',
+          tokenResolver: (_) async => const [],
+        ),
+      ),
+      userRepositoryProvider.overrideWithValue(userRepository),
+    ],
+    child: MaterialApp(
+      navigatorObservers: [navigatorObserver],
+      home: const NotificationListPage(),
+    ),
+  );
+}
+
+class _RecordingNavigatorObserver extends NavigatorObserver {
+  final pushedRoutes = <Route<dynamic>>[];
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    if (previousRoute != null) {
+      pushedRoutes.add(route);
+    }
+    super.didPush(route, previousRoute);
+  }
+}

--- a/test/presentation/repository_session_scope_test.dart
+++ b/test/presentation/repository_session_scope_test.dart
@@ -4,9 +4,15 @@ import 'package:firebase_auth/firebase_auth.dart' as firebase_auth;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:lakiite/app/di/providers.dart';
+import 'package:lakiite/application/notification/notification_notifier.dart'
+    as notification_app;
+import 'package:lakiite/domain/entity/notification.dart';
 import 'package:lakiite/domain/entity/schedule.dart';
 import 'package:lakiite/domain/interfaces/i_schedule_repository.dart';
 import 'package:lakiite/domain/interfaces/i_user_repository.dart';
+import 'package:lakiite/infrastructure/firebase/push_notification_sender.dart';
+
+import '../mock/repository/mock_notification_repository.dart';
 
 class _FakeFirebaseUser implements firebase_auth.User {
   _FakeFirebaseUser(this._uid);
@@ -103,6 +109,7 @@ void main() {
   group('repository session scope', () {
     late ProviderContainer container;
     late _FakeFirebaseAuth firebaseAuth;
+    late MockNotificationRepository notificationRepository;
     late ProviderSubscription<IUserRepository> userRepositorySubscription;
     late ProviderSubscription<IScheduleRepository>
         scheduleRepositorySubscription;
@@ -111,6 +118,7 @@ void main() {
 
     setUp(() {
       firebaseAuth = _FakeFirebaseAuth();
+      notificationRepository = MockNotificationRepository();
 
       container = ProviderContainer(
         overrides: [
@@ -121,6 +129,14 @@ void main() {
           scheduleRepositoryFactoryProvider.overrideWithValue(
             () =>
                 _TrackingScheduleRepository(++scheduleRepositoryInstanceCount),
+          ),
+          notification_app.notificationRepositoryProvider
+              .overrideWithValue(notificationRepository),
+          notification_app.pushNotificationSenderProvider.overrideWithValue(
+            PushNotificationSender(
+              cloudFunctionUrl: 'https://example.test/push',
+              tokenResolver: (_) async => const [],
+            ),
           ),
         ],
       );
@@ -193,6 +209,37 @@ void main() {
         scheduleUserBRepository.instanceId,
         isNot(scheduleUserARepository.instanceId),
       );
+    });
+
+    test('フレンド申請承認では user repository を作り直さない', () async {
+      firebaseAuth.setCurrentUser(_FakeFirebaseUser('receiver-id'));
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      notificationRepository.addTestNotification(
+        Notification(
+          id: 'friend-request-id',
+          type: NotificationType.friend,
+          sendUserId: 'sender-id',
+          receiveUserId: 'receiver-id',
+          sendUserDisplayName: '申請者',
+          receiveUserDisplayName: '受信者',
+          createdAt: DateTime(2026),
+          updatedAt: DateTime(2026),
+          status: NotificationStatus.pending,
+        ),
+      );
+
+      final before =
+          container.read(userRepositoryProvider) as _TrackingUserRepository;
+
+      await container
+          .read(notification_app.notificationNotifierProvider.notifier)
+          .acceptNotification('friend-request-id');
+
+      final after =
+          container.read(userRepositoryProvider) as _TrackingUserRepository;
+
+      expect(after.instanceId, before.instanceId);
     });
   });
 }


### PR DESCRIPTION
## Summary
- Stop reading the sender private profile when accepting friend requests; the client now only marks the notification as accepted.
- Keep friend-list updates owned by the Cloud Functions notification status trigger.
- Watch the current user's private profile so server-side friends updates are reflected in the friend tab.
- Prevent friend request notification rows from navigating to a profile when the user is trying to accept/reject.
- Add regression coverage for the acceptance flow, repository session scope, and notification-list friend request interactions.

## Root Cause
The previous acceptance flow read users/{senderId}/private/profile before the users were friends. Firestore rules correctly denied that read, so Android dev acceptance failed with PERMISSION_DENIED.

## Validation
- fvm dart format targeted changed Dart files
- fvm flutter test test/presentation/notification/notification_list_page_test.dart
- fvm flutter test test/application/notification/accept_friend_request_use_case_test.dart test/application/flows/primary_user_flows_test.dart test/presentation/repository_session_scope_test.dart test/presentation/friend/friend_request_card_test.dart test/presentation/notification/notification_list_page_test.dart
- fvm flutter analyze
- Verified on Galaxy SCG19 dev build connected to project lakiite-flutter-app-dev
- Confirmed Cloud Functions onNotificationStatusUpdate successfully updated friends for testtest and 二郎
