### PR TITLE
Firebase Emulator E2Eの自動実行を停止

### DIFF
--- a/.github/workflows/firebase_emulator_integration_tests.yml
+++ b/.github/workflows/firebase_emulator_integration_tests.yml
@@ -1,23 +1,9 @@
 name: Firebase Emulator E2E Smoke Tests
 run-name: Firebase Emulator E2E Smoke (${{ github.event_name }} - ${{ github.ref_name }})
 
-# Heavy native-device smoke tests. Keep this workflow off pull_request; it is
-# intended for manual runs and post-merge main branch smoke verification.
+# Heavy native-device smoke tests are intentionally manual-only. PR coverage
+# is provided by unit/widget tests with mocked repositories and providers.
 on:
-  push:
-    branches: [main]
-    paths:
-      - "lib/**"
-      - "integration_test/**"
-      - "patrol_test/**"
-      - "android/**"
-      - "ios/**"
-      - "assets/**"
-      - "pubspec.yaml"
-      - "pubspec.lock"
-      - "firebase.json"
-      - ".firebaserc"
-      - ".github/workflows/firebase_emulator_integration_tests.yml"
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## 概要
- Firebase Emulator E2E Smoke Tests の main push トリガーを削除
- 重いAndroid/iOS Patrol E2Eは workflow_dispatch の手動実行専用に変更
- PR時の担保は既存のUnit/Widget/軽量Integration CIに集約

## 背景
main merge後にFirebase Emulator E2E Smokeが自動実行され、Android/iOSの重いネイティブE2Eが失敗していたため。

## 確認
- git diff --check
- workflow定義が workflow_dispatch のみになっていることを確認