### PR TITLE
カレンダー予定取得とキャッシュ責務を再設計

### DIFF
--- a/lib/domain/value/schedule_month_range.dart
+++ b/lib/domain/value/schedule_month_range.dart
@@ -1,0 +1,37 @@
+/// Firestore schedule queries for a displayed calendar month.
+///
+/// The calendar renders leading and trailing days around the visible month, so
+/// the query intentionally covers the previous month through the next month.
+class ScheduleMonthRange {
+  const ScheduleMonthRange({
+    required this.startInclusive,
+    required this.endExclusive,
+  });
+
+  /// Builds the calendar query window for [displayMonth].
+  factory ScheduleMonthRange.forDisplayMonth(DateTime displayMonth) {
+    return ScheduleMonthRange(
+      startInclusive: DateTime(displayMonth.year, displayMonth.month - 1, 1),
+      endExclusive: DateTime(displayMonth.year, displayMonth.month + 2, 1),
+    );
+  }
+
+  /// First day of the previous month at midnight.
+  final DateTime startInclusive;
+
+  /// First day of the month after next at midnight.
+  final DateTime endExclusive;
+
+  /// Firestore-compatible lower bound ISO string.
+  String get startInclusiveIso => _toFirestoreIso(startInclusive);
+
+  /// Firestore-compatible upper bound ISO string.
+  String get endExclusiveIso => _toFirestoreIso(endExclusive);
+
+  static String _toFirestoreIso(DateTime dateTime) {
+    final year = dateTime.year.toString().padLeft(4, '0');
+    final month = dateTime.month.toString().padLeft(2, '0');
+    final day = dateTime.day.toString().padLeft(2, '0');
+    return '$year-$month-${day}T00:00:00.000';
+  }
+}

--- a/lib/infrastructure/schedule_repository.dart
+++ b/lib/infrastructure/schedule_repository.dart
@@ -2,6 +2,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import '../domain/entity/schedule.dart';
 import '../domain/interfaces/i_schedule_repository.dart';
+import '../domain/value/schedule_month_range.dart';
 import '../utils/logger.dart';
 import 'mapper/schedule_mapper.dart';
 
@@ -335,22 +336,18 @@ class ScheduleRepository implements IScheduleRepository {
     try {
       await _ensureAuthenticated();
 
-      // 表示月の6ヶ月前の1日を計算
-      final sixMonthsAgo =
-          DateTime(displayMonth.year, displayMonth.month - 6, 1);
-
-      // 日付形式を正確に整形（必ず2桁になるようにフォーマット）
-      final year = sixMonthsAgo.year.toString();
-      final month = sixMonthsAgo.month.toString().padLeft(2, '0');
-      final day = sixMonthsAgo.day.toString().padLeft(2, '0');
-      final sixMonthsAgoIso = '$year-$month-${day}T00:00:00.000';
+      final range = ScheduleMonthRange.forDisplayMonth(displayMonth);
 
       // 最初に素早くキャッシュからデータを取得（データがあれば即時返却）
       try {
         final cachedSnapshot = await _firestore
             .collection('schedules')
             .where('visibleTo', arrayContains: userId)
-            .where('startDateTime', isGreaterThanOrEqualTo: sixMonthsAgoIso)
+            .where(
+              'startDateTime',
+              isGreaterThanOrEqualTo: range.startInclusiveIso,
+            )
+            .where('startDateTime', isLessThan: range.endExclusiveIso)
             .orderBy('startDateTime', descending: false)
             .get(const GetOptions(source: Source.cache));
 
@@ -379,7 +376,11 @@ class ScheduleRepository implements IScheduleRepository {
       final stream = _firestore
           .collection('schedules')
           .where('visibleTo', arrayContains: userId)
-          .where('startDateTime', isGreaterThanOrEqualTo: sixMonthsAgoIso)
+          .where(
+            'startDateTime',
+            isGreaterThanOrEqualTo: range.startInclusiveIso,
+          )
+          .where('startDateTime', isLessThan: range.endExclusiveIso)
           .orderBy('startDateTime', descending: false)
           .snapshots();
 

--- a/lib/presentation/calendar/schedule_providers.dart
+++ b/lib/presentation/calendar/schedule_providers.dart
@@ -4,6 +4,12 @@ import 'package:lakiite/application/auth/auth_notifier.dart';
 import 'package:lakiite/application/auth/auth_state.dart';
 import 'package:lakiite/domain/entity/schedule.dart';
 
+/// Request parameters for calendar month schedule streams.
+typedef CalendarMonthSchedulesQuery = ({
+  String userId,
+  DateTime displayMonth,
+});
+
 /// User schedule list read model for calendar and profile presentation UIs.
 ///
 /// This provider is presentation read state. Schedule mutations and monthly
@@ -24,3 +30,35 @@ final userSchedulesStreamProvider =
     error: (_, __) => Stream.value([]),
   );
 });
+
+/// Calendar-specific schedule read model for a displayed month.
+///
+/// Calendar rendering reads schedules directly from the repository so it does
+/// not replace or cancel the timeline/global subscription owned by
+/// `scheduleNotifierProvider`.
+final calendarMonthSchedulesProvider =
+    StreamProvider.family<List<Schedule>, CalendarMonthSchedulesQuery>(
+  (ref, query) {
+    final authState = ref.watch(authNotifierProvider);
+    final displayMonth = DateTime(
+      query.displayMonth.year,
+      query.displayMonth.month,
+      1,
+    );
+
+    return authState.when(
+      data: (state) {
+        if (state.status != AuthStatus.authenticated ||
+            state.user?.id != query.userId) {
+          return Stream.value([]);
+        }
+
+        return ref
+            .watch(scheduleRepositoryProvider)
+            .watchUserSchedulesForMonth(query.userId, displayMonth);
+      },
+      loading: () => Stream.value([]),
+      error: (_, __) => Stream.value([]),
+    );
+  },
+);

--- a/lib/presentation/calendar/widgets/calendar_page_view.dart
+++ b/lib/presentation/calendar/widgets/calendar_page_view.dart
@@ -1,11 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
-import 'package:lakiite/application/auth/auth_notifier.dart';
 import 'package:lakiite/application/notification/notification_notifier.dart';
-import 'package:lakiite/application/schedule/schedule_notifier.dart';
 import 'package:lakiite/domain/entity/schedule.dart';
 import 'package:lakiite/presentation/calendar/calendar_providers.dart';
+import 'package:lakiite/presentation/calendar/schedule_providers.dart';
 import 'package:lakiite/presentation/calendar/widgets/daily_schedule_view.dart';
 import 'package:lakiite/presentation/theme/app_theme.dart';
 import 'package:lakiite/presentation/calendar/create_schedule_page.dart';
@@ -14,7 +13,6 @@ import 'dart:async'; // Timerのインポートを追加
 import 'package:flutter/gestures.dart' show DragStartBehavior;
 import 'package:flutter/services.dart' show rootBundle;
 import 'package:lakiite/utils/logger.dart'; // AppLoggerのインポートを追加
-import 'package:lakiite/application/auth/auth_state.dart';
 
 // 現在表示中のカレンダーページインデックスを保持するプロバイダー
 final calendarCurrentIndexProvider =
@@ -40,6 +38,7 @@ bool _isCalendarFirstBuild = true;
 // スライド中かどうかを管理するフラグ
 bool _isSliding = false;
 Timer? _slidingTimer;
+Timer? _cleanupTimer;
 const Duration _calendarSettledFetchDelay = Duration(milliseconds: 500);
 
 // PageControllerをキャッシュするプロバイダー
@@ -61,12 +60,6 @@ final calendarPageControllerProvider = Provider<PageController>((ref) {
 
   return controller;
 });
-
-// 直前に読み込みリクエストが行われた時間を記録するプロバイダー
-final lastDataFetchTimeProvider = StateProvider<DateTime?>((ref) => null);
-
-// 読み込みスロットリングの最小間隔（ミリ秒）
-const int _minFetchIntervalMillis = 500;
 
 // 画面幅に対してこの割合だけ横に動いたら、低速ドラッグでも月送りとして扱う
 const double _calendarPageTurnThreshold = 0.07;
@@ -133,10 +126,6 @@ final holidaysProvider = FutureProvider<Map<String, String>>((ref) async {
 // 事前にキャッシュする祝日データを管理するプロバイダー
 final cachedHolidaysProvider = StateProvider<Map<String, String>>((ref) => {});
 
-// 表示月ごとにスケジュールデータの読み込み状態を管理
-final monthDataLoadingProvider =
-    StateProvider.family<bool, String>((ref, monthKey) => false);
-
 // カレンダー表示用の月キーを生成
 String getMonthKey(DateTime date) {
   return '${date.year}-${date.month.toString().padLeft(2, '0')}';
@@ -157,10 +146,6 @@ final calendarOptimizationProvider = StateProvider<bool>((ref) => true);
 // 既に作成済みの月ページを管理するプロバイダー
 final renderedMonthsProvider = StateProvider<Set<int>>((ref) => {});
 
-// スケジュールデータのキャッシュプロバイダー
-final cachedSchedulesProvider =
-    StateProvider<Map<String, List<Schedule>>>((ref) => {});
-
 // 最後にクリーンアップを実行した時間
 final lastCleanupTimeProvider = StateProvider<DateTime?>((ref) => null);
 
@@ -180,8 +165,17 @@ class CalendarPageView extends HookConsumerWidget {
     final visibleDateTime = _getVisibleDateTime(currentIndexValue);
     final visibleMonth = _getMonthName(visibleDateTime.month);
     final visibleYear = visibleDateTime.year.toString();
-    ref.watch(authNotifierProvider);
     final currentUserId = ref.watch(currentUserIdProvider);
+    final visibleMonthSchedules = currentUserId == null
+        ? const AsyncValue<List<Schedule>>.data([])
+        : ref.watch(
+            calendarMonthSchedulesProvider(
+              (
+                userId: currentUserId,
+                displayMonth: visibleDateTime,
+              ),
+            ),
+          );
 
     // 最適化モードの取得
     ref.watch(calendarOptimizationProvider);
@@ -214,12 +208,12 @@ class CalendarPageView extends HookConsumerWidget {
       return () {
         _slidingTimer?.cancel();
         _slidingTimer = null;
+        _cleanupTimer?.cancel();
+        _cleanupTimer = null;
       };
     }, []);
 
     void updateMonthCacheWindow(int index) {
-      final visibleDate = _getVisibleDateTime(index);
-
       if (ref.exists(holidaysProvider) && ref.exists(cachedHolidaysProvider)) {
         final cachedHolidays = ref.read(cachedHolidaysProvider);
         if (cachedHolidays.isEmpty) {
@@ -264,16 +258,7 @@ class CalendarPageView extends HookConsumerWidget {
         }
       }
 
-      if (currentUserId != null) {
-        _fetchDataWithThrottle(
-          ref,
-          currentUserId,
-          visibleDate,
-          true,
-          isMounted,
-        );
-        _scheduleCleanup(ref, index, isMounted);
-      }
+      _scheduleCleanup(ref, index, isMounted);
     }
 
     void commitPageChange(
@@ -382,108 +367,42 @@ class CalendarPageView extends HookConsumerWidget {
       return null;
     }, []);
 
-    // 初期表示時にデータを取得
+    // 初期表示時に祝日と描画対象月を準備
     useEffect(() {
-      if (currentUserId != null) {
-        final visibleDate = _getVisibleDateTime(currentIndexValue);
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!isMounted()) {
+          return;
+        }
+        try {
+          final holidaysAsync = ref.read(holidaysProvider);
+          holidaysAsync.whenData((holidays) {
+            try {
+              if (ref.exists(cachedHolidaysProvider)) {
+                ref.read(cachedHolidaysProvider.notifier).state = holidays;
+                AppLogger.debug('カレンダー初期表示: 祝日データキャッシュ完了');
+              }
+            } catch (e) {
+              AppLogger.error('祝日データ反映エラー: $e');
+            }
+          });
 
-        // ビルド完了後に実行（ウィジェットツリーの構築中に状態を変更しないため）
-        WidgetsBinding.instance.addPostFrameCallback((_) {
-          if (!isMounted()) {
-            return;
+          final newIndices = <int>{currentIndexValue};
+          for (int i = 1; i <= _prefetchMonthsRange; i++) {
+            newIndices.add(currentIndexValue - i);
+            newIndices.add(currentIndexValue + i);
           }
-          try {
-            AppLogger.debug('カレンダー初期表示: データ取得開始 - userId: $currentUserId');
 
-            // 祝日データとスケジュールデータを並列で取得（祝日データ待ちを解消）
-            // 祝日データの読み込み
-            final holidaysAsync = ref.read(holidaysProvider);
-            holidaysAsync.whenData((holidays) {
-              try {
-                if (ref.exists(cachedHolidaysProvider)) {
-                  ref.read(cachedHolidaysProvider.notifier).state = holidays;
-                  AppLogger.debug('カレンダー初期表示: 祝日データキャッシュ完了');
-                }
-              } catch (e) {
-                AppLogger.error('祝日データ反映エラー: $e');
-              }
-            });
-
-            // スケジュールデータの取得（祝日データと並列実行）
-            AppLogger.debug('カレンダー初期表示: スケジュールデータ取得開始');
-            _fetchDataWithThrottle(
-                ref, currentUserId, visibleDate, true, isMounted);
-
-            // 前後の月のデータも事前に取得
-            for (int i = 1; i <= _prefetchMonthsRange; i++) {
-              // 前の月
-              final prevDate =
-                  DateTime(visibleDate.year, visibleDate.month - i, 1);
-              _fetchDataWithThrottle(
-                  ref, currentUserId, prevDate, false, isMounted);
-
-              // 次の月
-              final nextDate =
-                  DateTime(visibleDate.year, visibleDate.month + i, 1);
-              _fetchDataWithThrottle(
-                  ref, currentUserId, nextDate, false, isMounted);
-            }
-
-            // 前後の月のインデックス集合を初期化
-            final newIndices = <int>{currentIndexValue};
-            for (int i = 1; i <= _prefetchMonthsRange; i++) {
-              newIndices.add(currentIndexValue - i);
-              newIndices.add(currentIndexValue + i);
-            }
-
-            if (ref.exists(activeMonthIndicesProvider)) {
-              ref.read(activeMonthIndicesProvider.notifier).state = newIndices;
-            }
-
-            // ★重要: ログイン時にスライド完了処理と同等の処理を実行
-            // 少し遅延させてからデータ表示を確実にする
-            Future.delayed(const Duration(milliseconds: 500), () {
-              if (!isMounted()) {
-                return;
-              }
-              try {
-                final latestAuthState = ref.read(authNotifierProvider);
-                final stillAuthenticated = latestAuthState.maybeWhen(
-                  data: (state) =>
-                      state.status == AuthStatus.authenticated &&
-                      state.user?.id == currentUserId,
-                  orElse: () => false,
-                );
-                if (!stillAuthenticated) {
-                  AppLogger.debug('カレンダー初期表示: 認証状態が変化したため強制再取得を中止');
-                  return;
-                }
-
-                // 最適化モードを無効化（スライド完了時と同じ処理）
-                if (ref.exists(calendarOptimizationProvider)) {
-                  ref.read(calendarOptimizationProvider.notifier).state = false;
-                }
-
-                // データを強制再取得（スライド完了時と同じ処理）
-                if (ref.exists(scheduleNotifierProvider)) {
-                  AppLogger.debug('カレンダー初期表示: データ強制再取得実行');
-                  _fetchDataWithThrottle(
-                      ref, currentUserId, visibleDate, true, isMounted);
-                }
-              } catch (e) {
-                AppLogger.error('カレンダー初期表示: 最適化モード制御エラー: $e');
-              }
-            });
-
-            // 定期的なクリーンアップを開始
-            _scheduleCleanup(ref, currentIndexValue, isMounted);
-          } catch (e) {
-            AppLogger.error('初期データ読み込みエラー: $e');
+          if (ref.exists(activeMonthIndicesProvider)) {
+            ref.read(activeMonthIndicesProvider.notifier).state = newIndices;
           }
-        });
-      }
+
+          _scheduleCleanup(ref, currentIndexValue, isMounted);
+        } catch (e) {
+          AppLogger.error('初期データ準備エラー: $e');
+        }
+      });
       return null;
-    }, [currentUserId]);
+    }, [currentIndexValue]);
 
     // 可能な限りキャッシュを再利用するページビュー
     return Padding(
@@ -531,9 +450,8 @@ class CalendarPageView extends HookConsumerWidget {
           // ローディングインジケーター（現在表示中の月のデータ読み込み状態を表示）
           Consumer(
             builder: (context, ref, child) {
-              final currentMonthKey = getMonthKey(visibleDateTime);
               final isLoading =
-                  ref.watch(monthDataLoadingProvider(currentMonthKey));
+                  currentUserId != null && visibleMonthSchedules.isLoading;
               return isLoading
                   ? const LinearProgressIndicator(
                       backgroundColor: Colors.transparent,
@@ -716,7 +634,8 @@ class CalendarPageView extends HookConsumerWidget {
     // 前回のクリーンアップから一定時間経過している場合のみ実行
     if (lastCleanup == null ||
         now.difference(lastCleanup).inMilliseconds > _cleanupIntervalMillis) {
-      Future.delayed(const Duration(seconds: 3), () {
+      _cleanupTimer?.cancel();
+      _cleanupTimer = Timer(const Duration(seconds: 3), () {
         if (!isMounted()) {
           return;
         }
@@ -762,112 +681,6 @@ class CalendarPageView extends HookConsumerWidget {
       });
     }
   }
-
-  // スロットリングを適用してデータ取得
-  void _fetchDataWithThrottle(
-    WidgetRef ref,
-    String userId,
-    DateTime date, [
-    bool force = false,
-    bool Function()? isMounted,
-  ]) {
-    try {
-      if (isMounted != null && !isMounted()) {
-        return;
-      }
-
-      final monthKey = getMonthKey(date);
-      final authState = ref.read(authNotifierProvider);
-      final stillAuthenticated = authState.maybeWhen(
-        data: (state) =>
-            state.status == AuthStatus.authenticated &&
-            state.user?.id == userId,
-        orElse: () => false,
-      );
-      if (!stillAuthenticated) {
-        return;
-      }
-
-      // Providerの存在確認
-      if (!ref.exists(lastDataFetchTimeProvider) ||
-          !ref.exists(cachedSchedulesProvider) ||
-          !ref.exists(monthDataLoadingProvider(monthKey))) {
-        return;
-      }
-
-      final lastFetchTime = ref.read(lastDataFetchTimeProvider);
-      final now = DateTime.now();
-
-      // キャッシュチェック
-      final cachedSchedules = ref.read(cachedSchedulesProvider);
-      final hasCachedData = cachedSchedules.containsKey(monthKey);
-
-      // 読み込み状態を取得
-      final isLoading = ref.read(monthDataLoadingProvider(monthKey));
-      final isFirstLoad = lastFetchTime == null;
-
-      // スライド中は不要なデータ取得をスキップ
-      if (_isSliding && !force) {
-        return;
-      }
-
-      // 強制フラグがある、または前回の読み込みから一定時間経過している場合に読み込み
-      if (force ||
-          isFirstLoad ||
-          !isLoading &&
-              (!hasCachedData ||
-                  now.difference(lastFetchTime).inMilliseconds >
-                      _minFetchIntervalMillis)) {
-        // 読み込み状態を更新
-        ref.read(monthDataLoadingProvider(monthKey).notifier).state = true;
-        ref.read(lastDataFetchTimeProvider.notifier).state = now;
-
-        try {
-          // APIリクエスト
-          if (ref.exists(scheduleNotifierProvider)) {
-            ref
-                .read(scheduleNotifierProvider.notifier)
-                .watchUserSchedulesForMonth(userId, date);
-
-            // 一定時間後にローディング状態を解除
-            Future.delayed(const Duration(milliseconds: 1000), () {
-              if (isMounted != null && !isMounted()) {
-                return;
-              }
-              try {
-                if (ref.exists(monthDataLoadingProvider(monthKey))) {
-                  ref.read(monthDataLoadingProvider(monthKey).notifier).state =
-                      false;
-                }
-              } catch (e) {
-                AppLogger.error('ローディング状態解除エラー: $e');
-              }
-            });
-          }
-        } catch (e) {
-          AppLogger.error('スケジュールデータ取得エラー: $e');
-          // エラー時も読み込み状態を解除
-          Future.delayed(const Duration(milliseconds: 300), () {
-            if (isMounted != null && !isMounted()) {
-              return;
-            }
-            try {
-              if (ref.exists(monthDataLoadingProvider(monthKey))) {
-                ref.read(monthDataLoadingProvider(monthKey).notifier).state =
-                    false;
-              }
-            } catch (_) {
-              // 無視
-            }
-          });
-        }
-      }
-    } catch (e) {
-      AppLogger.error('データ取得処理エラー: $e');
-    }
-  }
-
-  // 指定した範囲の月の祝日データを先読み
 
   String _getMonthName(int month) {
     final monthNames = [
@@ -1087,92 +900,22 @@ class CalendarPageContent extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     // 最適化モードの取得
     final isOptimized = ref.watch(calendarOptimizationProvider);
+    final currentUserId = ref.watch(currentUserIdProvider);
+    final schedulesAsync = currentUserId == null
+        ? const AsyncValue<List<Schedule>>.data([])
+        : ref.watch(
+            calendarMonthSchedulesProvider(
+              (
+                userId: currentUserId,
+                displayMonth: visiblePageDate,
+              ),
+            ),
+          );
 
     // メモ化して再計算を防止
     final currentDates =
         useMemoized(() => _getCurrentDates(visiblePageDate), [visiblePageDate]);
-
-    // キャッシュされたスケジュールデータを取得
-    final cachedSchedules = ref.watch(cachedSchedulesProvider);
-
-    // スケジュールデータを取得（ローディング中はプレースホルダーを表示）
-    final scheduleState = ref.watch(scheduleNotifierProvider);
-
-    // スケジュールデータを取得（改善版：初期表示時の問題を解決）
-    final schedules = useMemoized(() {
-      // 初期表示時やキャッシュが空の場合は、scheduleStateを直接使用
-      if (cachedSchedules.isEmpty || !isOptimized) {
-        return scheduleState.when(
-          data: (state) => state.maybeMap(
-            loaded: (loaded) {
-              // スライド中でなければキャッシュを更新
-              if (!_isSliding) {
-                Future.microtask(() {
-                  try {
-                    ref.read(cachedSchedulesProvider.notifier).state = {
-                      ...cachedSchedules,
-                      ...loaded.schedules.fold<Map<String, List<Schedule>>>(
-                        {},
-                        (map, schedule) {
-                          final key =
-                              '${schedule.startDateTime.year}-${schedule.startDateTime.month}';
-                          map[key] = [...(map[key] ?? []), schedule];
-                          return map;
-                        },
-                      ),
-                    };
-                  } catch (e) {
-                    AppLogger.error('キャッシュ更新エラー: $e');
-                  }
-                });
-              }
-              return loaded.schedules;
-            },
-            orElse: () {
-              return <Schedule>[];
-            },
-          ),
-          loading: () {
-            return <Schedule>[];
-          },
-          error: (_, __) {
-            return <Schedule>[];
-          },
-        );
-      }
-
-      // 最適化モード時でキャッシュがある場合
-      return scheduleState.maybeWhen(
-        data: (state) => state.maybeMap(
-          loaded: (loaded) {
-            // スライド中でなければキャッシュを更新
-            if (!_isSliding) {
-              Future.microtask(() {
-                try {
-                  ref.read(cachedSchedulesProvider.notifier).state = {
-                    ...cachedSchedules,
-                    ...loaded.schedules.fold<Map<String, List<Schedule>>>(
-                      {},
-                      (map, schedule) {
-                        final key =
-                            '${schedule.startDateTime.year}-${schedule.startDateTime.month}';
-                        map[key] = [...(map[key] ?? []), schedule];
-                        return map;
-                      },
-                    ),
-                  };
-                } catch (e) {
-                  AppLogger.error('キャッシュ更新エラー: $e');
-                }
-              });
-            }
-            return loaded.schedules;
-          },
-          orElse: () => <Schedule>[],
-        ),
-        orElse: () => <Schedule>[],
-      );
-    }, [scheduleState, isOptimized, cachedSchedules, _isSliding]);
+    final schedules = schedulesAsync.valueOrNull ?? const <Schedule>[];
 
     // 日付ごとにスケジュールをフィルタリング（最適化）- 高速アルゴリズムを使用
     final dateSchedulesMap = useMemoized(() {

--- a/lib/presentation/calendar/widgets/calendar_page_view.dart
+++ b/lib/presentation/calendar/widgets/calendar_page_view.dart
@@ -134,6 +134,9 @@ String getMonthKey(DateTime date) {
 // 何ヶ月先のデータまで先読みするか
 const int _prefetchMonthsRange = 2;
 
+// スケジュールデータとして先読みする前後月の範囲
+const int _schedulePrefetchMonthsRange = 1;
+
 // 事前にレンダリングする月の数（前後_preRenderMonthsRange月）
 const int _preRenderMonthsRange = 2;
 
@@ -176,6 +179,28 @@ class CalendarPageView extends HookConsumerWidget {
               ),
             ),
           );
+    if (currentUserId != null) {
+      for (int offset = -_schedulePrefetchMonthsRange;
+          offset <= _schedulePrefetchMonthsRange;
+          offset++) {
+        if (offset == 0) {
+          continue;
+        }
+
+        ref.watch(
+          calendarMonthSchedulesProvider(
+            (
+              userId: currentUserId,
+              displayMonth: DateTime(
+                visibleDateTime.year,
+                visibleDateTime.month + offset,
+                1,
+              ),
+            ),
+          ),
+        );
+      }
+    }
 
     // 最適化モードの取得
     ref.watch(calendarOptimizationProvider);

--- a/lib/presentation/presentation_provider.dart
+++ b/lib/presentation/presentation_provider.dart
@@ -10,7 +10,7 @@ export 'package:lakiite/application/schedule/schedule_notifier.dart'
 export 'package:lakiite/presentation/calendar/calendar_providers.dart'
     show selectedDateProvider;
 export 'package:lakiite/presentation/calendar/schedule_providers.dart'
-    show userSchedulesStreamProvider;
+    show calendarMonthSchedulesProvider, userSchedulesStreamProvider;
 export 'package:lakiite/presentation/friend/friend_providers.dart'
     show userFriendsProvider, userFriendsStreamProvider;
 export 'package:lakiite/presentation/list/list_providers.dart'

--- a/test/domain/value/schedule_month_range_test.dart
+++ b/test/domain/value/schedule_month_range_test.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lakiite/domain/value/schedule_month_range.dart';
+
+void main() {
+  group('ScheduleMonthRange', () {
+    test('表示月の前月月初から翌々月月初直前までを取得範囲にする', () {
+      final range = ScheduleMonthRange.forDisplayMonth(DateTime(2026, 3, 20));
+
+      expect(range.startInclusive, DateTime(2026, 2, 1));
+      expect(range.endExclusive, DateTime(2026, 5, 1));
+    });
+
+    test('Firestore のISO文字列として月範囲境界を表現する', () {
+      final range = ScheduleMonthRange.forDisplayMonth(DateTime(2026, 1, 31));
+
+      expect(range.startInclusiveIso, '2025-12-01T00:00:00.000');
+      expect(range.endExclusiveIso, '2026-03-01T00:00:00.000');
+    });
+  });
+}

--- a/test/presentation/calendar/calendar_schedule_providers_test.dart
+++ b/test/presentation/calendar/calendar_schedule_providers_test.dart
@@ -1,0 +1,229 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:lakiite/app/di/providers.dart';
+import 'package:lakiite/application/auth/auth_notifier.dart';
+import 'package:lakiite/application/auth/auth_state.dart';
+import 'package:lakiite/domain/entity/schedule.dart';
+import 'package:lakiite/domain/entity/user.dart';
+import 'package:lakiite/domain/interfaces/i_auth_repository.dart';
+import 'package:lakiite/domain/interfaces/i_schedule_repository.dart';
+import 'package:lakiite/presentation/calendar/schedule_providers.dart';
+
+import '../../mock/repository/mock_user_repository.dart';
+
+class _FakeAuthRepository implements IAuthRepository {
+  final _controller = StreamController<UserModel?>.broadcast();
+  UserModel? _currentUser;
+
+  void setCurrentUser(UserModel? user) {
+    _currentUser = user;
+    _controller.add(user);
+  }
+
+  @override
+  Stream<UserModel?> authStateChanges() async* {
+    yield _currentUser;
+    yield* _controller.stream;
+  }
+
+  @override
+  Future<void> signOut() async {
+    setCurrentUser(null);
+  }
+
+  @override
+  Future<UserModel?> signIn(String email, String password) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<UserModel?> signUp(String email, String password, String name) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<bool> deleteAccount() {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<bool> deleteAccountWithReauth(String password) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<bool> reauthenticateWithPassword(String password) {
+    throw UnimplementedError();
+  }
+
+  void dispose() {
+    _controller.close();
+  }
+}
+
+class _TrackingScheduleRepository implements IScheduleRepository {
+  final _monthController = StreamController<List<Schedule>>.broadcast();
+  final _allController = StreamController<List<Schedule>>.broadcast();
+
+  int watchUserSchedulesCallCount = 0;
+  int watchUserSchedulesForMonthCallCount = 0;
+  DateTime? lastDisplayMonth;
+
+  @override
+  Stream<List<Schedule>> watchUserSchedules(String userId) {
+    watchUserSchedulesCallCount++;
+    return _allController.stream;
+  }
+
+  @override
+  Stream<List<Schedule>> watchUserSchedulesForMonth(
+    String userId,
+    DateTime displayMonth,
+  ) {
+    watchUserSchedulesForMonthCallCount++;
+    lastDisplayMonth = displayMonth;
+    return _monthController.stream;
+  }
+
+  @override
+  Stream<List<Schedule>> watchListSchedules(String listId) =>
+      const Stream.empty();
+
+  @override
+  Stream<Schedule?> watchSchedule(String scheduleId) => const Stream.empty();
+
+  @override
+  Future<Schedule> createSchedule(Schedule schedule) =>
+      Future.error(UnimplementedError());
+
+  @override
+  Future<void> deleteSchedule(String scheduleId) =>
+      Future.error(UnimplementedError());
+
+  @override
+  Future<List<Schedule>> getListSchedules(String listId) =>
+      Future.error(UnimplementedError());
+
+  @override
+  Future<List<Schedule>> getUserSchedules(String userId) =>
+      Future.error(UnimplementedError());
+
+  @override
+  Future<void> updateSchedule(Schedule schedule) =>
+      Future.error(UnimplementedError());
+
+  void dispose() {
+    _monthController.close();
+    _allController.close();
+  }
+}
+
+void main() {
+  group('calendarMonthSchedulesProvider', () {
+    late ProviderContainer container;
+    late _FakeAuthRepository mockAuthRepository;
+    late MockUserRepository mockUserRepository;
+    late _TrackingScheduleRepository scheduleRepository;
+    late UserModel testUser;
+
+    setUp(() {
+      mockAuthRepository = _FakeAuthRepository();
+      mockUserRepository = MockUserRepository();
+      scheduleRepository = _TrackingScheduleRepository();
+      testUser = UserModel.create(
+        id: 'test-user-id',
+        name: 'テストユーザー',
+        displayName: 'テストユーザー',
+      );
+
+      mockUserRepository.addTestUser(testUser);
+
+      container = ProviderContainer(
+        overrides: [
+          authRepositoryProvider.overrideWithValue(mockAuthRepository),
+          userRepositoryProvider.overrideWithValue(mockUserRepository),
+          scheduleRepositoryProvider.overrideWithValue(scheduleRepository),
+        ],
+      );
+    });
+
+    tearDown(() {
+      scheduleRepository.dispose();
+      mockAuthRepository.dispose();
+      container.dispose();
+    });
+
+    test('カレンダー専用の月別購読だけを開始し、全体購読を使わない', () async {
+      final authSubscription = _listenAuthenticatedAuthState(
+        container,
+        mockAuthRepository,
+        testUser,
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      final subscription = container.listen(
+        calendarMonthSchedulesProvider((
+          userId: testUser.id,
+          displayMonth: DateTime(2026, 3, 20),
+        )),
+        (_, __) {},
+        fireImmediately: true,
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(scheduleRepository.watchUserSchedulesForMonthCallCount, 1);
+      expect(scheduleRepository.watchUserSchedulesCallCount, 0);
+      expect(scheduleRepository.lastDisplayMonth, DateTime(2026, 3, 1));
+
+      subscription.close();
+      authSubscription.close();
+    });
+
+    test('ログアウト時はrepositoryを購読せず空配列を返す', () async {
+      final authSubscription = _listenAuthenticatedAuthState(
+        container,
+        mockAuthRepository,
+        testUser,
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      await mockAuthRepository.signOut();
+
+      final provider = calendarMonthSchedulesProvider((
+        userId: testUser.id,
+        displayMonth: DateTime(2026, 3, 20),
+      ));
+      final subscription = container.listen(
+        provider,
+        (_, __) {},
+        fireImmediately: true,
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      final state = container.read(provider);
+
+      expect(state.hasValue, isTrue);
+      expect(state.value, isEmpty);
+      expect(scheduleRepository.watchUserSchedulesForMonthCallCount, 0);
+      expect(scheduleRepository.watchUserSchedulesCallCount, 0);
+
+      subscription.close();
+      authSubscription.close();
+    });
+  });
+}
+
+ProviderSubscription<AsyncValue<AuthState>> _listenAuthenticatedAuthState(
+  ProviderContainer container,
+  _FakeAuthRepository authRepository,
+  UserModel user,
+) {
+  final subscription = container.listen(
+    authNotifierProvider,
+    (_, __) {},
+    fireImmediately: true,
+  );
+  authRepository.setCurrentUser(user);
+  return subscription;
+}

--- a/test/presentation/presentation_provider_test.dart
+++ b/test/presentation/presentation_provider_test.dart
@@ -252,6 +252,16 @@ void main() {
       );
     });
 
+    test('presentation_provider は calendarMonthSchedulesProvider を再定義しない', () {
+      expect(
+        identical(
+          calendar_schedule.calendarMonthSchedulesProvider,
+          presentation.calendarMonthSchedulesProvider,
+        ),
+        isTrue,
+      );
+    });
+
     test('my_page は userSchedulesStreamProvider を再定義しない', () {
       expect(
         identical(


### PR DESCRIPTION
## 概要
- カレンダー専用の月別予定Providerを追加し、タイムライン/全体購読と分離
- Firestoreの月別取得範囲を表示月の前月月初以上、翌々月月初未満に限定
- カレンダーUIから手動キャッシュ更新とScheduleNotifier経由の取得制御を削除し、Provider購読に集約
- 表示月の前後月をProviderとして先読み

## テスト
- fvm flutter analyze --no-fatal-infos
- fvm flutter test test/domain/value/schedule_month_range_test.dart test/presentation/calendar/calendar_schedule_providers_test.dart test/presentation/calendar/calendar_scroll_behavior_test.dart test/presentation/presentation_provider_test.dart --dart-define=FLUTTER_TEST=true

Closes #175