### PR TITLE
フレンド画面に、送信済みかつ pending の友達申請を表示する

### DIFF
--- a/lib/presentation/friend/friend_list_page.dart
+++ b/lib/presentation/friend/friend_list_page.dart
@@ -2,6 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../application/auth/auth_notifier.dart';
 import '../../application/auth/auth_state.dart';
+import '../../application/notification/notification_notifier.dart'
+    show sentNotificationsByTypeProvider;
+import '../../domain/entity/notification.dart' as domain;
 import '../list/create_list_page.dart';
 import '../list/list_detail_page.dart';
 import '../list/list_providers.dart';
@@ -85,50 +88,29 @@ class _FriendListPageState extends ConsumerState<FriendListPage>
   Widget _buildFriendTabContent() {
     // StreamProviderに変更してリアルタイム更新を実現
     final friendsAsync = ref.watch(userFriendsStreamProvider);
+    final sentFriendRequestsAsync = ref.watch(
+      sentNotificationsByTypeProvider(domain.NotificationType.friend),
+    );
 
     return friendsAsync.when(
       data: (friends) {
-        if (friends.isEmpty) {
-          return RefreshIndicator(
-            onRefresh: () async {
-              // StreamProviderは自動更新されるため、最小限の更新のみ
-              ref.invalidate(userFriendsStreamProvider);
-            },
-            child: ListView(
-              physics: const AlwaysScrollableScrollPhysics(),
-              children: const [
-                Center(
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      SizedBox(height: 120),
-                      Icon(
-                        Icons.people_outline,
-                        size: 64,
-                        color: Colors.grey,
-                      ),
-                      SizedBox(height: 16),
-                      Text(
-                        'フレンドがいません',
-                        style: TextStyle(
-                          color: Colors.grey,
-                          fontSize: 16,
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ],
-            ),
-          );
-        }
+        final pendingRequests = sentFriendRequestsAsync.valueOrNull
+                ?.where(
+                  (request) =>
+                      request.status == domain.NotificationStatus.pending,
+                )
+                .toList() ??
+            const <domain.Notification>[];
 
         return RefreshIndicator(
           onRefresh: () async {
             // StreamProviderは自動更新されるため、最小限の更新のみ
             ref.invalidate(userFriendsStreamProvider);
+            ref.invalidate(
+              sentNotificationsByTypeProvider(domain.NotificationType.friend),
+            );
           },
-          child: ListView.builder(
+          child: ListView(
             key: const PageStorageKey('friend_list'), // キーを追加してスクロール位置を保持
             physics: const AlwaysScrollableScrollPhysics(),
             padding: const EdgeInsets.only(
@@ -137,59 +119,109 @@ class _FriendListPageState extends ConsumerState<FriendListPage>
               top: 8,
               bottom: 58,
             ),
-            itemCount: friends.length,
-            itemBuilder: (context, index) {
-              final friend = friends[index];
-              return Card(
-                margin: const EdgeInsets.only(bottom: 4),
-                child: ListTile(
-                  contentPadding: const EdgeInsets.symmetric(
-                    horizontal: 16,
-                    vertical: 4,
+            children: [
+              if (friends.isEmpty)
+                const Padding(
+                  padding: EdgeInsets.only(top: 112, bottom: 32),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Icon(Icons.people_outline, size: 64, color: Colors.grey),
+                      SizedBox(height: 16),
+                      Text(
+                        'フレンドがいません',
+                        style: TextStyle(color: Colors.grey, fontSize: 16),
+                      ),
+                    ],
                   ),
-                  leading: friend.iconUrl != null
-                      ? CircleAvatar(
-                          radius: 24,
-                          backgroundImage: NetworkImage(friend.iconUrl!),
-                        )
-                      : const DefaultUserIcon(size: 48),
-                  title: Text(
-                    friend.displayName,
-                    style: const TextStyle(
-                      fontWeight: FontWeight.bold,
-                      fontSize: 16,
-                    ),
-                  ),
-                  subtitle: Text(
-                    friend.shortBio ?? '',
-                    style: TextStyle(
-                      color: Colors.grey[600],
-                      fontSize: 14,
-                    ),
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                  onTap: () {
-                    Navigator.of(context).push(
-                      MaterialPageRoute(
-                        builder: (context) => FriendProfilePage(
-                          userId: friend.id,
+                )
+              else
+                ...friends.map(
+                  (friend) => Card(
+                    margin: const EdgeInsets.only(bottom: 4),
+                    child: ListTile(
+                      contentPadding: const EdgeInsets.symmetric(
+                        horizontal: 16,
+                        vertical: 4,
+                      ),
+                      leading: friend.iconUrl != null
+                          ? CircleAvatar(
+                              radius: 24,
+                              backgroundImage: NetworkImage(friend.iconUrl!),
+                            )
+                          : const DefaultUserIcon(size: 48),
+                      title: Text(
+                        friend.displayName,
+                        style: const TextStyle(
+                          fontWeight: FontWeight.bold,
+                          fontSize: 16,
                         ),
                       ),
-                    );
-                  },
+                      subtitle: Text(
+                        friend.shortBio ?? '',
+                        style: TextStyle(color: Colors.grey[600], fontSize: 14),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                      onTap: () {
+                        Navigator.of(context).push(
+                          MaterialPageRoute(
+                            builder: (context) =>
+                                FriendProfilePage(userId: friend.id),
+                          ),
+                        );
+                      },
+                    ),
+                  ),
                 ),
-              );
-            },
+              if (sentFriendRequestsAsync.isLoading)
+                const Padding(
+                  padding: EdgeInsets.symmetric(vertical: 16),
+                  child: Center(child: CircularProgressIndicator()),
+                )
+              else if (pendingRequests.isNotEmpty) ...[
+                const Padding(
+                  padding: EdgeInsets.only(top: 20, bottom: 8),
+                  child: Text(
+                    '申請中',
+                    style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+                  ),
+                ),
+                ...pendingRequests.map((request) {
+                  final displayName =
+                      request.receiveUserDisplayName ?? request.receiveUserId;
+                  return Card(
+                    margin: const EdgeInsets.only(bottom: 4),
+                    child: ListTile(
+                      contentPadding: const EdgeInsets.symmetric(
+                        horizontal: 16,
+                        vertical: 4,
+                      ),
+                      leading: const CircleAvatar(
+                        radius: 24,
+                        child: Icon(Icons.hourglass_empty),
+                      ),
+                      title: Text(
+                        displayName,
+                        style: const TextStyle(
+                          fontWeight: FontWeight.bold,
+                          fontSize: 16,
+                        ),
+                      ),
+                      subtitle: Text(
+                        '承認待ち',
+                        style: TextStyle(color: Colors.grey[600], fontSize: 14),
+                      ),
+                    ),
+                  );
+                }),
+              ],
+            ],
           ),
         );
       },
-      loading: () => const Center(
-        child: CircularProgressIndicator(),
-      ),
-      error: (error, stack) => Center(
-        child: Text('エラーが発生しました: $error'),
-      ),
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (error, stack) => Center(child: Text('エラーが発生しました: $error')),
     );
   }
 

--- a/test/presentation/friend/friend_list_page_test.dart
+++ b/test/presentation/friend/friend_list_page_test.dart
@@ -1,0 +1,129 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lakiite/application/auth/auth_notifier.dart' as auth;
+import 'package:lakiite/application/auth/auth_state.dart';
+import 'package:lakiite/application/notification/notification_notifier.dart'
+    as notification;
+import 'package:lakiite/domain/entity/notification.dart' as domain;
+import 'package:lakiite/domain/entity/user.dart';
+import 'package:lakiite/presentation/friend/friend_list_page.dart';
+import 'package:lakiite/presentation/friend/friend_providers.dart';
+
+class _StubAuthNotifier extends auth.AuthNotifier {
+  _StubAuthNotifier(this._state);
+
+  final AuthState _state;
+
+  @override
+  FutureOr<AuthState> build() => _state;
+}
+
+void main() {
+  group('FriendListPage', () {
+    testWidgets('送信済みの保留中友達申請をフレンド一覧下の申請中セクションに表示する', (tester) async {
+      final currentUser = UserModel.create(
+        id: 'current-user-id',
+        name: '現在ユーザー',
+        displayName: '現在ユーザー',
+      );
+      final friend = UserModel.create(
+        id: 'friend-id',
+        name: '友達一郎',
+        displayName: '友達一郎',
+      );
+      final pendingRequest = domain.Notification.createFriendRequest(
+        fromUserId: currentUser.id,
+        toUserId: 'pending-friend-id',
+        fromUserDisplayName: currentUser.displayName,
+        toUserDisplayName: '申請先ユーザー',
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            auth.authNotifierProvider.overrideWith(
+              () => _StubAuthNotifier(AuthState.authenticated(currentUser)),
+            ),
+            userFriendsStreamProvider.overrideWith(
+              (ref) => Stream.value([friend.publicProfile]),
+            ),
+            notification.sentNotificationsByTypeProvider.overrideWith(
+              (ref, type) => Stream.value([pendingRequest]),
+            ),
+            notification.unreadNotificationCountProvider.overrideWith(
+              (ref) => Stream.value(0),
+            ),
+            notification.unreadNotificationCountByTypeProvider.overrideWith(
+              (ref, type) => Stream.value(0),
+            ),
+          ],
+          child: const MaterialApp(home: FriendListPage()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('友達一郎'), findsOneWidget);
+      expect(find.text('申請中'), findsOneWidget);
+      expect(find.text('申請先ユーザー'), findsOneWidget);
+      expect(find.text('承認待ち'), findsOneWidget);
+    });
+
+    testWidgets('拒否済みの送信済み友達申請は申請中セクションに表示しない', (tester) async {
+      final currentUser = UserModel.create(
+        id: 'current-user-id',
+        name: '現在ユーザー',
+        displayName: '現在ユーザー',
+      );
+      final friend = UserModel.create(
+        id: 'friend-id',
+        name: '友達一郎',
+        displayName: '友達一郎',
+      );
+      final rejectedRequest = domain.Notification(
+        id: 'rejected-request-id',
+        type: domain.NotificationType.friend,
+        sendUserId: currentUser.id,
+        receiveUserId: 'rejected-friend-id',
+        sendUserDisplayName: currentUser.displayName,
+        receiveUserDisplayName: '拒否済みユーザー',
+        status: domain.NotificationStatus.rejected,
+        createdAt: DateTime(2026, 5, 27),
+        updatedAt: DateTime(2026, 5, 27),
+        rejectionCount: 1,
+        isRead: true,
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            auth.authNotifierProvider.overrideWith(
+              () => _StubAuthNotifier(AuthState.authenticated(currentUser)),
+            ),
+            userFriendsStreamProvider.overrideWith(
+              (ref) => Stream.value([friend.publicProfile]),
+            ),
+            notification.sentNotificationsByTypeProvider.overrideWith(
+              (ref, type) => Stream.value([rejectedRequest]),
+            ),
+            notification.unreadNotificationCountProvider.overrideWith(
+              (ref) => Stream.value(0),
+            ),
+            notification.unreadNotificationCountByTypeProvider.overrideWith(
+              (ref, type) => Stream.value(0),
+            ),
+          ],
+          child: const MaterialApp(home: FriendListPage()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('友達一郎'), findsOneWidget);
+      expect(find.text('申請中'), findsNothing);
+      expect(find.text('拒否済みユーザー'), findsNothing);
+      expect(find.text('承認待ち'), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- フレンド画面に、送信済みかつ pending の友達申請を表示する「申請中」セクションを追加
- rejected の送信済み友達申請は「申請中」に表示しない Widget テストを追加

## Test Plan
- `fvm flutter test test/presentation/friend/friend_list_page_test.dart`
- `fvm flutter analyze lib/presentation/friend/friend_list_page.dart test/presentation/friend/friend_list_page_test.dart`
- Galaxy SCG19 実機で dev flavor を起動し、Firestore dev に一時通知 `notifications/codex-debug-pending-friend-request` を作成して「申請中」「Codex確認用ユーザー / 承認待ち」の表示を確認。削除後に非表示も確認済み

## Notes
- `lib/firebase_options.dart` は元ディレクトリからローカルにコピーして実機検証に使用。gitignore対象のためPRには含めていません

Refs #179