### PR TITLE
feat: crop profile images before upload

### DIFF
--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,0 +1,3 @@
+# image_cropper / UCrop の難読化対策
+-keep class com.yalantis.ucrop.** { *; }
+-dontwarn com.yalantis.ucrop.**

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -61,5 +61,14 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+
+        <!-- image_cropper: https://pub.dev/packages/image_cropper -->
+        <activity
+            android:name="com.yalantis.ucrop.UCropActivity"
+            android:screenOrientation="portrait"
+            android:theme="@style/UCropTheme"
+            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
+            android:windowSoftInputMode="adjustResize"
+            android:exported="false" />
     </application>
 </manifest>

--- a/android/app/src/main/res/values-night/styles.xml
+++ b/android/app/src/main/res/values-night/styles.xml
@@ -19,4 +19,14 @@
     <style name="NormalTheme" parent="@android:style/Theme.Black.NoTitleBar">
         <item name="android:windowBackground">?android:colorBackground</item>
     </style>
+
+    <!-- ImageCropper用のテーマ：システムUIとの重なりを防ぐ（ダークモード） -->
+    <style name="UCropTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
+        <item name="android:statusBarColor">@android:color/black</item>
+        <item name="android:navigationBarColor">@android:color/black</item>
+        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
+        <item name="android:windowTranslucentStatus">false</item>
+        <item name="android:windowTranslucentNavigation">false</item>
+        <item name="android:fitsSystemWindows">true</item>
+    </style>
 </resources>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -19,4 +19,14 @@
     <style name="NormalTheme" parent="@android:style/Theme.Light.NoTitleBar">
         <item name="android:windowBackground">?android:colorBackground</item>
     </style>
+
+    <!-- ImageCropper用のテーマ：システムUIとの重なりを防ぐ -->
+    <style name="UCropTheme" parent="Theme.AppCompat.Light.NoActionBar">
+        <item name="android:statusBarColor">@android:color/black</item>
+        <item name="android:navigationBarColor">@android:color/black</item>
+        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
+        <item name="android:windowTranslucentStatus">false</item>
+        <item name="android:windowTranslucentNavigation">false</item>
+        <item name="android:fitsSystemWindows">true</item>
+    </style>
 </resources>

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1426,6 +1426,9 @@ PODS:
   - gRPC-Core/Interface (1.69.0)
   - gRPC-Core/Privacy (1.69.0)
   - GTMSessionFetcher/Core (5.0.0)
+  - image_cropper (0.0.4):
+    - Flutter
+    - TOCropViewController (~> 2.7.4)
   - image_picker_ios (0.0.1):
     - Flutter
   - integration_test (0.0.1):
@@ -1463,6 +1466,7 @@ PODS:
   - SDWebImageWebPCoder (0.15.0):
     - libwebp (~> 1.0)
     - SDWebImage/Core (~> 5.17)
+  - TOCropViewController (2.7.4)
   - url_launcher_ios (0.0.1):
     - Flutter
   - webview_flutter_wkwebview (0.0.1):
@@ -1480,6 +1484,7 @@ DEPENDENCIES:
   - flutter_local_notifications (from `.symlinks/plugins/flutter_local_notifications/ios`)
   - flutter_native_splash (from `.symlinks/plugins/flutter_native_splash/ios`)
   - google_mobile_ads (from `.symlinks/plugins/google_mobile_ads/ios`)
+  - image_cropper (from `.symlinks/plugins/image_cropper/ios`)
   - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
   - integration_test (from `.symlinks/plugins/integration_test/ios`)
   - patrol (from `.symlinks/plugins/patrol/darwin`)
@@ -1519,6 +1524,7 @@ SPEC REPOS:
     - RecaptchaInterop
     - SDWebImage
     - SDWebImageWebPCoder
+    - TOCropViewController
 
 EXTERNAL SOURCES:
   cloud_firestore:
@@ -1541,6 +1547,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_native_splash/ios"
   google_mobile_ads:
     :path: ".symlinks/plugins/google_mobile_ads/ios"
+  image_cropper:
+    :path: ".symlinks/plugins/image_cropper/ios"
   image_picker_ios:
     :path: ".symlinks/plugins/image_picker_ios/ios"
   integration_test:
@@ -1586,6 +1594,7 @@ SPEC CHECKSUMS:
   "gRPC-C++": cc207623316fb041a7a3e774c252cf68a058b9e8
   gRPC-Core: 860978b7db482de8b4f5e10677216309b5ff6330
   GTMSessionFetcher: 02d6e866e90bc236f48a703a041dfe43e6221a29
+  image_cropper: c4326ea50132b1e1564499e5d32a84f01fb03537
   image_picker_ios: 7fe1ff8e34c1790d6fff70a32484959f563a928a
   integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
   leveldb-library: cc8b8f8e013647a295ad3f8cd2ddf49a6f19be19
@@ -1597,6 +1606,7 @@ SPEC CHECKSUMS:
   RecaptchaInterop: 11e0b637842dfb48308d242afc3f448062325aba
   SDWebImage: 16309af6d214ba3f77a7c6f6fdda888cb313a50a
   SDWebImageWebPCoder: 0e06e365080397465cc73a7a9b472d8a3bd0f377
+  TOCropViewController: 80b8985ad794298fb69d3341de183f33d1853654
   url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
   webview_flutter_wkwebview: 8ebf4fded22593026f7dbff1fbff31ea98573c8d
 

--- a/lib/domain/interfaces/i_image_cropper_service.dart
+++ b/lib/domain/interfaces/i_image_cropper_service.dart
@@ -1,0 +1,12 @@
+import 'dart:io';
+
+abstract class IImageCropperService {
+  /// 画像を切り取り、切り取り後の画像ファイルを返す。
+  ///
+  /// ユーザーが切り取りをキャンセルした場合はnullを返す。
+  Future<File?> cropImage({
+    required File sourceFile,
+    double? aspectRatioX,
+    double? aspectRatioY,
+  });
+}

--- a/lib/infrastructure/image/flutter_image_cropper_service.dart
+++ b/lib/infrastructure/image/flutter_image_cropper_service.dart
@@ -1,0 +1,52 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:image_cropper/image_cropper.dart';
+
+import '../../domain/interfaces/i_image_cropper_service.dart';
+import '../../utils/logger.dart';
+
+class FlutterImageCropperService implements IImageCropperService {
+  static const Color _toolbarColor = Color(0xFFffa600);
+
+  @override
+  Future<File?> cropImage({
+    required File sourceFile,
+    double? aspectRatioX,
+    double? aspectRatioY,
+  }) async {
+    try {
+      final aspectRatio = (aspectRatioX != null && aspectRatioY != null)
+          ? CropAspectRatio(ratioX: aspectRatioX, ratioY: aspectRatioY)
+          : null;
+
+      final croppedFile = await ImageCropper().cropImage(
+        sourcePath: sourceFile.path,
+        aspectRatio: aspectRatio,
+        uiSettings: [
+          AndroidUiSettings(
+            toolbarTitle: '画像を切り取り',
+            toolbarColor: _toolbarColor,
+            toolbarWidgetColor: Colors.white,
+            initAspectRatio: CropAspectRatioPreset.original,
+            lockAspectRatio: aspectRatio != null,
+          ),
+          IOSUiSettings(
+            title: '画像を切り取り',
+            doneButtonTitle: '完了',
+            cancelButtonTitle: 'キャンセル',
+            aspectRatioLockEnabled: aspectRatio != null,
+          ),
+        ],
+      );
+
+      if (croppedFile == null) {
+        return null;
+      }
+      return File(croppedFile.path);
+    } catch (e) {
+      AppLogger.error('画像切り取りエラー', e);
+      throw Exception('画像の切り取りに失敗しました');
+    }
+  }
+}

--- a/lib/infrastructure/providers.dart
+++ b/lib/infrastructure/providers.dart
@@ -1,7 +1,10 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import '../domain/interfaces/i_storage_service.dart';
+
+import '../domain/interfaces/i_image_cropper_service.dart';
 import '../domain/interfaces/i_image_processor_service.dart';
+import '../domain/interfaces/i_storage_service.dart';
 import 'firebase/firebase_storage_service.dart';
+import 'image/flutter_image_cropper_service.dart';
 import 'image/flutter_image_processor_service.dart';
 
 final storageServiceProvider = Provider<IStorageService>((ref) {
@@ -10,4 +13,8 @@ final storageServiceProvider = Provider<IStorageService>((ref) {
 
 final imageProcessorServiceProvider = Provider<IImageProcessorService>((ref) {
   return FlutterImageProcessorService();
+});
+
+final imageCropperServiceProvider = Provider<IImageCropperService>((ref) {
+  return FlutterImageCropperService();
 });

--- a/lib/presentation/my_page/my_page_view_model.dart
+++ b/lib/presentation/my_page/my_page_view_model.dart
@@ -1,20 +1,23 @@
 import 'dart:io';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter/services.dart';
+
 import 'package:firebase_storage/firebase_storage.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lakiite/application/auth/auth_state.dart';
+import 'package:lakiite/utils/logger.dart';
+
 import '../../app/di/providers.dart';
 import '../../application/auth/auth_notifier.dart';
-import '../../infrastructure/image_picker_service.dart' as picker;
-import '../../domain/entity/user.dart';
 import '../../domain/entity/schedule.dart';
-import '../../domain/value/user_id.dart';
-import '../../domain/interfaces/i_user_repository.dart';
+import '../../domain/entity/user.dart';
+import '../../domain/interfaces/i_image_cropper_service.dart';
+import '../../domain/interfaces/i_image_processor_service.dart';
 import '../../domain/interfaces/i_schedule_repository.dart';
 import '../../domain/interfaces/i_storage_service.dart';
-import '../../domain/interfaces/i_image_processor_service.dart';
+import '../../domain/interfaces/i_user_repository.dart';
+import '../../domain/value/user_id.dart';
+import '../../infrastructure/image_picker_service.dart' as picker;
 import '../../infrastructure/providers.dart';
-import 'package:lakiite/utils/logger.dart';
 
 export '../calendar/schedule_providers.dart' show userSchedulesStreamProvider;
 
@@ -49,11 +52,13 @@ final myPageViewModelProvider =
   final scheduleRepository = ref.watch(scheduleRepositoryProvider);
   final storageService = ref.watch(storageServiceProvider);
   final imageProcessorService = ref.watch(imageProcessorServiceProvider);
+  final imageCropperService = ref.watch(imageCropperServiceProvider);
   return MyPageViewModel(
     userRepository,
     scheduleRepository,
     storageService,
     imageProcessorService,
+    imageCropperService,
     ref,
   );
 });
@@ -64,12 +69,14 @@ class MyPageViewModel extends StateNotifier<AsyncValue<UserModel?>> {
     this._scheduleRepository,
     this._storageService,
     this._imageProcessorService,
+    this._imageCropperService,
     this._ref,
   ) : super(const AsyncValue.loading());
   final IUserRepository _userRepository;
   final IScheduleRepository _scheduleRepository;
   final IStorageService _storageService;
   final IImageProcessorService _imageProcessorService;
+  final IImageCropperService _imageCropperService;
   final Ref _ref;
 
   Future<void> pickImage() async {
@@ -91,9 +98,24 @@ class MyPageViewModel extends StateNotifier<AsyncValue<UserModel?>> {
           throw Exception('画像ファイルが見つかりません');
         }
 
+        AppLogger.debug('画像切り取りを開始します');
+        final croppedImageFile = await _imageCropperService.cropImage(
+          sourceFile: imageFile,
+          aspectRatioX: 1,
+          aspectRatioY: 1,
+        );
+        if (croppedImageFile == null) {
+          AppLogger.debug('画像の切り取りがキャンセルされました');
+          return;
+        }
+        if (!croppedImageFile.existsSync()) {
+          throw Exception('切り取り後の画像ファイルが見つかりません');
+        }
+        AppLogger.debug('切り取り後の画像パス: ${croppedImageFile.path}');
+
         AppLogger.debug('画像圧縮を開始します');
         final compressedImageFile = await _imageProcessorService.compressImage(
-          imageFile,
+          croppedImageFile,
           minWidth: 300,
           minHeight: 300,
           quality: 85,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -754,6 +754,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.5.4"
+  image_cropper:
+    dependency: "direct main"
+    description:
+      name: image_cropper
+      sha256: "4e9c96c029eb5a23798da1b6af39787f964da6ffc78fd8447c140542a9f7c6fc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.1.0"
+  image_cropper_for_web:
+    dependency: transitive
+    description:
+      name: image_cropper_for_web
+      sha256: fd81ebe36f636576094377aab32673c4e5d1609b32dec16fad98d2b71f1250a9
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.0"
+  image_cropper_platform_interface:
+    dependency: transitive
+    description:
+      name: image_cropper_platform_interface
+      sha256: "2d8db8f4b638e448fa89a1e77cd8f053b4547472bd3ae073169e86626d03afef"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.2.0"
   image_picker:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,7 @@ dependencies:
 
   # Media & Assets
   image_picker: ^1.0.7
+  image_cropper: ^9.1.0
   flutter_image_compress: ^2.1.0
   path: ^1.8.3
   image: ^4.1.7

--- a/test/application/flows/primary_user_flows_test.dart
+++ b/test/application/flows/primary_user_flows_test.dart
@@ -13,9 +13,11 @@ import 'package:lakiite/domain/entity/notification.dart';
 import 'package:lakiite/domain/entity/schedule_comment.dart';
 import 'package:lakiite/domain/entity/schedule_reaction.dart';
 import 'package:lakiite/domain/interfaces/i_friend_list_repository.dart';
+import 'package:lakiite/domain/interfaces/i_image_cropper_service.dart';
 import 'package:lakiite/domain/interfaces/i_image_processor_service.dart';
 import 'package:lakiite/domain/interfaces/i_schedule_interaction_repository.dart';
 import 'package:lakiite/domain/interfaces/i_storage_service.dart';
+import 'package:lakiite/infrastructure/image_picker_service.dart';
 import 'package:lakiite/infrastructure/firebase/push_notification_sender.dart';
 import 'package:lakiite/infrastructure/providers.dart';
 import 'package:lakiite/presentation/my_page/my_page_view_model.dart';
@@ -36,6 +38,8 @@ void main() {
     late _FakeScheduleInteractionRepository scheduleInteractionRepository;
     late _FakeStorageService storageService;
     late _FakeImageProcessorService imageProcessorService;
+    late _FakeImageCropperService imageCropperService;
+    late _FakeImagePickerService imagePickerService;
     late ProviderContainer container;
 
     setUp(() {
@@ -47,6 +51,8 @@ void main() {
       scheduleInteractionRepository = _FakeScheduleInteractionRepository();
       storageService = _FakeStorageService();
       imageProcessorService = _FakeImageProcessorService();
+      imageCropperService = _FakeImageCropperService();
+      imagePickerService = _FakeImagePickerService();
 
       container = ProviderContainer(
         overrides: [
@@ -76,6 +82,8 @@ void main() {
           storageServiceProvider.overrideWithValue(storageService),
           imageProcessorServiceProvider
               .overrideWithValue(imageProcessorService),
+          imageCropperServiceProvider.overrideWithValue(imageCropperService),
+          imagePickerServiceProvider.overrideWithValue(imagePickerService),
         ],
       );
     });
@@ -264,6 +272,67 @@ void main() {
       expect(updatedUser?.iconUrl, storageService.uploadedUrl);
       expect(storageService.uploadedPath, 'v1/users/icon/${user.id}');
     });
+
+    test('プロフィール画像を選択すると切り取り後の画像を選択状態に保存する', () async {
+      final user = BaseMock.createTestUser();
+      userRepository.addTestUser(user);
+      final pickedImageFile = File(
+        '${Directory.systemTemp.path}/lakiite-picked-profile-test.jpg',
+      );
+      final croppedImageFile = File(
+        '${Directory.systemTemp.path}/lakiite-cropped-profile-test.jpg',
+      );
+      await pickedImageFile.writeAsBytes([1, 2, 3]);
+      await croppedImageFile.writeAsBytes([4, 5, 6]);
+      imagePickerService.pickedPath = pickedImageFile.path;
+      imageCropperService.croppedFile = croppedImageFile;
+
+      final viewModel = container.read(myPageViewModelProvider.notifier);
+      await viewModel.loadUser(user.id);
+
+      await viewModel.pickImage();
+
+      expect(imageCropperService.sourceFile?.path, pickedImageFile.path);
+      expect(imageCropperService.aspectRatioX, 1);
+      expect(imageCropperService.aspectRatioY, 1);
+      expect(
+        imageProcessorService.compressedSourceFile?.path,
+        croppedImageFile.path,
+      );
+      expect(
+        container.read(selectedImageProvider)?.path,
+        croppedImageFile.path,
+      );
+    });
+
+    test('プロフィール画像の切り取りをキャンセルすると選択状態を変更しない', () async {
+      final user = BaseMock.createTestUser();
+      userRepository.addTestUser(user);
+      final pickedImageFile = File(
+        '${Directory.systemTemp.path}/lakiite-picked-profile-cancel-test.jpg',
+      );
+      final currentSelectedImageFile = File(
+        '${Directory.systemTemp.path}/lakiite-current-profile-test.jpg',
+      );
+      await pickedImageFile.writeAsBytes([1, 2, 3]);
+      await currentSelectedImageFile.writeAsBytes([7, 8, 9]);
+      imagePickerService.pickedPath = pickedImageFile.path;
+      imageCropperService.croppedFile = null;
+      container.read(selectedImageProvider.notifier).state =
+          currentSelectedImageFile;
+
+      final viewModel = container.read(myPageViewModelProvider.notifier);
+      await viewModel.loadUser(user.id);
+
+      await viewModel.pickImage();
+
+      expect(imageCropperService.sourceFile?.path, pickedImageFile.path);
+      expect(imageProcessorService.compressedSourceFile, isNull);
+      expect(
+        container.read(selectedImageProvider)?.path,
+        currentSelectedImageFile.path,
+      );
+    });
   });
 }
 
@@ -357,6 +426,8 @@ class _FakeStorageService implements IStorageService {
 }
 
 class _FakeImageProcessorService implements IImageProcessorService {
+  File? compressedSourceFile;
+
   @override
   Future<File> compressImage(
     File imageFile, {
@@ -364,6 +435,7 @@ class _FakeImageProcessorService implements IImageProcessorService {
     int minHeight = 300,
     int quality = 85,
   }) async {
+    compressedSourceFile = imageFile;
     return imageFile;
   }
 
@@ -377,5 +449,33 @@ class _FakeImageProcessorService implements IImageProcessorService {
     final directory = await createTempDirectory();
     final file = File('${directory.path}/image.$extension');
     return file.writeAsBytes(data);
+  }
+}
+
+class _FakeImageCropperService implements IImageCropperService {
+  File? croppedFile;
+  File? sourceFile;
+  double? aspectRatioX;
+  double? aspectRatioY;
+
+  @override
+  Future<File?> cropImage({
+    required File sourceFile,
+    double? aspectRatioX,
+    double? aspectRatioY,
+  }) async {
+    this.sourceFile = sourceFile;
+    this.aspectRatioX = aspectRatioX;
+    this.aspectRatioY = aspectRatioY;
+    return croppedFile;
+  }
+}
+
+class _FakeImagePickerService extends ImagePickerService {
+  String? pickedPath;
+
+  @override
+  Future<String?> pickImage(ImageSource imageSource) async {
+    return pickedPath;
   }
 }


### PR DESCRIPTION
## Summary
- プロフィール画像選択後に 1:1 固定の切り取り画面を挟むようにしました
- image_cropper 用のサービス、DI、Android UCrop 設定、iOS Pod依存ロックを追加しました
- crop成功時とcropキャンセル時のプロフィール画像選択フローをテストで固定しました

## Review Notes
- テストレビュー: 成功系だけだとキャンセル時の回帰を拾えなかったため、cropキャンセル時に既存の選択状態を保持し、圧縮へ進まないテストを追加しました
- アーキテクチャ: 既存の IImageProcessorService と同様に、cropも domain/interfaces に抽象を置き、実装は infrastructure/image、DIは infrastructure/providers.dart に寄せています
- Android設定: ZEN の実装を参考に UCropActivity、UCropTheme、UCropのProGuard設定を追加しています
- iOS設定: image_cropper のiOSプラグイン依存として Podfile.lock に TOCropViewController が追加されることを確認しました

## Test Plan
- fvm flutter test test/application/flows/primary_user_flows_test.dart
- fvm flutter test test/architecture/layer_dependency_test.dart
- fvm flutter analyze lib/domain/interfaces/i_image_cropper_service.dart lib/infrastructure/image/flutter_image_cropper_service.dart lib/infrastructure/providers.dart lib/presentation/my_page/my_page_view_model.dart test/application/flows/primary_user_flows_test.dart
- fvm flutter build apk --debug --flavor dev --dart-define-from-file=dart_define/dev_dart_define.json
- fvm flutter build ios --debug --flavor dev --no-codesign --dart-define-from-file=dart_define/dev_dart_define.json
- git diff --check
- Galaxy SCG19 / Android 16 実機で dev flavor を起動し、プロフィール編集 → Photo Picker → UCrop切り取り → 保存 → プロフィール画像反映まで確認しました

## Notes
- lib/firebase_options.dart はローカル検証用に元ディレクトリからコピーしましたが、gitignore対象のためPRには含めていません
- iOS実機確認は未実施です。no-codesignビルドでPod依存解決とXcodeビルドは確認済みです