### PR TITLE
fix: Dev iOS配信ワークフローを安定化

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,6 +1,12 @@
 name: Setup CI
 description: Setup CI environment for LaKiite Flutter app
 
+inputs:
+  flutter-cache:
+    description: Enable subosito/flutter-action cache
+    required: false
+    default: "false"
+
 runs:
   using: "composite"
   steps:
@@ -20,7 +26,7 @@ runs:
       with:
         flutter-version: ${{ steps.flutter_sdk_version.outputs.version }}
         channel: stable
-        cache: false
+        cache: ${{ inputs.flutter-cache }}
 
     - name: Get dependencies
       run: flutter pub get

--- a/.github/workflows/deploy_dev_ios.yml
+++ b/.github/workflows/deploy_dev_ios.yml
@@ -2,6 +2,12 @@ name: "[Release] Dev iOS"
 
 on:
   workflow_dispatch:
+    inputs:
+      clean_ios_cache:
+        description: "Clean Pods, Podfile.lock, and Xcode DerivedData before building"
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build:
@@ -22,6 +28,19 @@ jobs:
 
       - name: Setup CI
         uses: ./.github/actions/setup
+        with:
+          flutter-cache: "true"
+
+      - name: Restore CocoaPods cache
+        if: ${{ !inputs.clean_ios_cache }}
+        uses: actions/cache@v4
+        with:
+          path: |
+            ios/Pods
+            ~/Library/Caches/CocoaPods
+          key: ${{ runner.os }}-pods-${{ hashFiles('ios/Podfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-
 
       - name: Restore Firebase config files
         run: |
@@ -36,17 +55,19 @@ jobs:
         run: |
           mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles/
 
-      - name: Clean iOS build cache and update dependencies
+      - name: Prepare iOS build cache
         run: |
           cd ios
-          # Clean all caches for fresh dependency resolution
-          rm -rf Pods
-          rm -rf Podfile.lock
-          rm -rf build
-          rm -rf ~/Library/Developer/Xcode/DerivedData/*
-          # Clean CocoaPods cache for latest Firebase/gRPC (commented out to speed up build)
-          # pod cache clean --all
-          echo "Cleaned all caches for iOS 15.0 and Firebase SDK 12.4.0 compatibility"
+          if [ "${{ inputs.clean_ios_cache }}" = "true" ]; then
+            rm -rf Pods
+            rm -rf Podfile.lock
+            rm -rf build
+            rm -rf ~/Library/Developer/Xcode/DerivedData/*
+            echo "Cleaned iOS dependency and build caches for fresh dependency resolution"
+          else
+            rm -rf build
+            echo "Keeping Pods and Podfile.lock so dependency caches can be reused"
+          fi
 
       - name: Debug certificates and provisioning profiles
         env:

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -88,7 +88,8 @@ platform :ios do
   end
 
   private_lane :flutter_marketing_version do
-    version_line = File.readlines("../pubspec.yaml").find { |line| line.start_with?("version:") }
+    pubspec_path = File.expand_path("../../pubspec.yaml", __dir__)
+    version_line = File.readlines(pubspec_path).find { |line| line.start_with?("version:") }
     UI.user_error!("❌ pubspec.yaml version is missing") if version_line.nil?
 
     version_line.split[1].split("+").first

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -25,8 +25,7 @@ platform :ios do
     # Skip prepare_build due to Flutter SDK permission issues
     # prepare_build
 
-    # Calculate build number from git commits
-    build_number = (10000 + sh("cd .. && git rev-list --count HEAD", log: false).strip.to_i).to_s
+    build_number = resolve_dev_build_number
     ENV["BUILD_NUMBER"] = build_number
     UI.message "🔢 Build number: #{build_number}"
 
@@ -57,6 +56,83 @@ platform :ios do
     ENV["BUILD_NUMBER"] = build_number
 
     UI.message "🔢 Build number: #{build_number}"
+  end
+
+  private_lane :resolve_dev_build_number do
+    override_build_number = ENV["BUILD_NUMBER"].to_s.strip
+    if !override_build_number.empty?
+      UI.message "🔢 Using BUILD_NUMBER override: #{override_build_number}"
+      override_build_number
+    else
+      ensure_dev_app_store_connect_env
+
+      begin
+        app_version = flutter_marketing_version
+        latest_build_number = latest_testflight_build_number(
+          api_key: dev_app_store_connect_api_key,
+          app_identifier: ENV["APP_IDENTIFIER"],
+          version: app_version,
+          initial_build_number: 10000
+        )
+
+        build_number = (latest_build_number.to_i + 1).to_s
+        UI.message "🔢 Latest TestFlight build for #{app_version}: #{latest_build_number}"
+        build_number
+      rescue => e
+        fallback_build_number = Time.now.to_i.to_s
+        UI.important "⚠️  Failed to fetch latest TestFlight build number: #{e.message}"
+        UI.message "🔢 Using timestamp fallback build number: #{fallback_build_number}"
+        fallback_build_number
+      end
+    end
+  end
+
+  private_lane :flutter_marketing_version do
+    version_line = File.readlines("../pubspec.yaml").find { |line| line.start_with?("version:") }
+    UI.user_error!("❌ pubspec.yaml version is missing") if version_line.nil?
+
+    version_line.split[1].split("+").first
+  end
+
+  private_lane :dev_app_store_connect_api_key do
+    ensure_dev_app_store_connect_env
+
+    asc_key_id = ENV["ASC_KEY_ID"] || ""
+    asc_issuer_id = ENV["ASC_ISSUER_ID"] || ""
+    asc_api_key_path = ENV["ASC_API_KEY_PATH"] || ""
+    asc_api_key_base64 = ENV["ASC_API_KEY_BASE64"] || ""
+
+    if !asc_api_key_base64.empty?
+      UI.message "📄 Using Base64 encoded API Key for CI/CD"
+      asc_api_key_path = "./AuthKey.p8"
+
+      require 'base64'
+      File.open(asc_api_key_path, 'wb') do |file|
+        file.write(Base64.decode64(asc_api_key_base64))
+      end
+    end
+
+    app_store_connect_api_key(
+      key_id: asc_key_id,
+      issuer_id: asc_issuer_id,
+      key_filepath: File.expand_path(asc_api_key_path),
+      in_house: false
+    )
+  end
+
+  private_lane :ensure_dev_app_store_connect_env do
+    asc_key_id = ENV["ASC_KEY_ID"] || ""
+    asc_issuer_id = ENV["ASC_ISSUER_ID"] || ""
+    asc_api_key_path = ENV["ASC_API_KEY_PATH"] || ""
+    asc_api_key_base64 = ENV["ASC_API_KEY_BASE64"] || ""
+
+    if asc_key_id.empty? || asc_issuer_id.empty?
+      UI.user_error!("❌ ASC_KEY_ID and ASC_ISSUER_ID environment variables are required")
+    end
+
+    if asc_api_key_base64.empty? && asc_api_key_path.empty?
+      UI.user_error!("❌ Either ASC_API_KEY_PATH or ASC_API_KEY_BASE64 environment variable is required")
+    end
   end
 
   private_lane :build_and_upload_dev do
@@ -211,39 +287,8 @@ platform :ios do
     existing_ipa = "./build/#{ipa_output_name}.ipa"
     UI.success "✅ Generated IPA: #{existing_ipa}"
 
-    # Environment variables for App Store Connect API (no fallback - must be set explicitly)
-    asc_key_id = ENV["ASC_KEY_ID"] || ""
-    asc_issuer_id = ENV["ASC_ISSUER_ID"] || ""
-    asc_api_key_path = ENV["ASC_API_KEY_PATH"] || ""
-    asc_api_key_base64 = ENV["ASC_API_KEY_BASE64"] || ""
-
-    if asc_key_id.empty? || asc_issuer_id.empty?
-      UI.user_error!("❌ ASC_KEY_ID and ASC_ISSUER_ID environment variables are required")
-    end
-
-    if asc_api_key_base64.empty? && asc_api_key_path.empty?
-      UI.user_error!("❌ Either ASC_API_KEY_PATH or ASC_API_KEY_BASE64 environment variable is required")
-    end
-
-    # CI/CD環境ではBase64エンコードされたAPI Keyを使用
-    if !asc_api_key_base64.empty?
-      UI.message "📄 Using Base64 encoded API Key for CI/CD"
-      asc_api_key_path = "./AuthKey.p8"
-
-      # Base64デコードして一時ファイルに保存
-      require 'base64'
-      File.open(asc_api_key_path, 'wb') do |file|
-        file.write(Base64.decode64(asc_api_key_base64))
-      end
-    end
-
     # Upload to TestFlight using App Store Connect API Key
-    api_key = app_store_connect_api_key(
-      key_id: asc_key_id,
-      issuer_id: asc_issuer_id,
-      key_filepath: File.expand_path(asc_api_key_path),
-      in_house: false
-    )
+    api_key = dev_app_store_connect_api_key
 
     # Skip app existence check for now
     # ensure_app_exists_on_asc(api_key: api_key)


### PR DESCRIPTION
## 概要
- Dev iOS配信のbuild numberをTestFlight上の最新値+1で決定するように変更
- 最新build number取得に失敗した場合はtimestampへfallbackし、同一コミット再実行での重複を避ける
- Dev iOS workflowでFlutter cacheとCocoaPods cacheを有効化
- 通常実行ではPods/Podfile.lockを削除せず、必要な場合だけ手動入力 `clean_ios_cache` で完全cleanできるように変更

## 背景
- 既存の `git rev-list --count HEAD` 由来のbuild numberは、同じcommitで再実行すると同じ値になり、TestFlight uploadで重複エラーになる
- iOS workflowが毎回Pods/Podfile.lock/DerivedDataを削除しており、FirebaseFirestore/gRPC系の依存解決・ビルドが重くなっていた

## 検証
- `ruby -c ios/fastlane/Fastfile`
- `ruby -e 'require "yaml"; YAML.load_file(".github/actions/setup/action.yml"); YAML.load_file(".github/workflows/deploy_dev_ios.yml"); puts "YAML OK"'`\n- `git diff --check`\n- `cd ios && fastlane lanes`\n\n## 補足\n- 実際のTestFlight uploadはGitHub Actions上のsecretとApp Store Connect接続が必要なため、PR作成後にworkflow_dispatchで確認する想定です。