### PR TITLE
[codex] AndroidリリースのJavaセットアップを安定化

### DIFF
--- a/.github/workflows/deploy_dev_android.yml
+++ b/.github/workflows/deploy_dev_android.yml
@@ -23,8 +23,8 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v5.2.0
         with:
-          distribution: 'zulu'
-          java-version: '17.x'
+          distribution: 'temurin'
+          java-version: '17'
 
       - name: Accept Android SDK licenses and install NDK
         run: |

--- a/.github/workflows/deploy_prod_android.yml
+++ b/.github/workflows/deploy_prod_android.yml
@@ -20,8 +20,8 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v5.2.0
         with:
-          distribution: 'zulu'
-          java-version: '17.x'
+          distribution: 'temurin'
+          java-version: '17'
 
       - name: Accept Android SDK licenses and install NDK
         run: |


### PR DESCRIPTION
## Summary
- Android dev/prod release workflows の Java distribution を `zulu` から `temurin` に変更
- `java-version` を `17.x` から `17` に変更し、Zulu latest解決時のHTTP 520失敗を回避

## Validation
- `[Release] Dev Android` を `release/verify-dev-android-actions` で実行
- Run: https://github.com/keishimizu26629/LaKiite-flutter-app/actions/runs/26605514047
- 結果: success
- `Setup Java`, `flutter build appbundle`, `flutter build apk`, `Deploy to Play Store (Internal)`, `Deploy to Firebase App Distribution` まで成功

## Notes
- 失敗していた run では `actions/setup-java` が `zulu` + `17.x` の latest解決中に `error code: 520` で停止していました。