### PR TITLE
Fix list detail refresh after member update

### DIFF
--- a/lib/presentation/list/list_detail_page.dart
+++ b/lib/presentation/list/list_detail_page.dart
@@ -31,9 +31,7 @@ class _ListDetailPageState extends ConsumerState<ListDetailPage> {
     return listAsync.when(
       data: (list) {
         if (list == null) {
-          return const Scaffold(
-            body: Center(child: Text('リストが見つかりません')),
-          );
+          return const Scaffold(body: Center(child: Text('リストが見つかりません')));
         }
 
         return Scaffold(
@@ -75,7 +73,8 @@ class _ListDetailPageState extends ConsumerState<ListDetailPage> {
                         if (mounted) {
                           scaffoldMessenger.showSnackBar(
                             SnackBar(
-                                content: Text('削除に失敗しました: ${e.toString()}')),
+                              content: Text('削除に失敗しました: ${e.toString()}'),
+                            ),
                           );
                         }
                       }
@@ -83,10 +82,7 @@ class _ListDetailPageState extends ConsumerState<ListDetailPage> {
                   }
                 },
                 itemBuilder: (context) => [
-                  const PopupMenuItem(
-                    value: 'delete',
-                    child: Text('リストを削除'),
-                  ),
+                  const PopupMenuItem(value: 'delete', child: Text('リストを削除')),
                 ],
               ),
             ],
@@ -104,10 +100,10 @@ class _ListDetailPageState extends ConsumerState<ListDetailPage> {
                       // リストアイコン
                       CircleAvatar(
                         radius: 40,
-                        backgroundImage: widget.list.iconUrl != null
-                            ? NetworkImage(widget.list.iconUrl!)
+                        backgroundImage: list.iconUrl != null
+                            ? NetworkImage(list.iconUrl!)
                             : null,
-                        child: widget.list.iconUrl == null
+                        child: list.iconUrl == null
                             ? const Icon(Icons.list, size: 40)
                             : null,
                       ),
@@ -117,7 +113,7 @@ class _ListDetailPageState extends ConsumerState<ListDetailPage> {
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
                             Text(
-                              widget.list.listName,
+                              list.listName,
                               style: theme.textTheme.headlineSmall,
                               overflow: TextOverflow.ellipsis,
                             ),
@@ -127,7 +123,7 @@ class _ListDetailPageState extends ConsumerState<ListDetailPage> {
                                 Navigator.of(context).push(
                                   MaterialPageRoute(
                                     builder: (context) =>
-                                        ListEditPage(list: widget.list),
+                                        ListEditPage(list: list),
                                   ),
                                 );
                               },
@@ -141,11 +137,11 @@ class _ListDetailPageState extends ConsumerState<ListDetailPage> {
                   ),
                 ),
                 // リストの説明
-                if (widget.list.description != null)
+                if (list.description != null)
                   Padding(
                     padding: const EdgeInsets.symmetric(horizontal: 16.0),
                     child: Text(
-                      widget.list.description!,
+                      list.description!,
                       style: theme.textTheme.bodyLarge,
                     ),
                   ),
@@ -155,19 +151,16 @@ class _ListDetailPageState extends ConsumerState<ListDetailPage> {
                   padding: const EdgeInsets.symmetric(horizontal: 16.0),
                   child: Row(
                     children: [
-                      Text(
-                        'メンバー',
-                        style: theme.textTheme.titleLarge,
-                      ),
+                      Text('メンバー', style: theme.textTheme.titleLarge),
                       const SizedBox(width: 8),
-                      Text('${widget.list.memberIds.length}人'),
+                      Text('${list.memberIds.length}人'),
                       const Spacer(),
                       OutlinedButton.icon(
                         onPressed: () {
                           Navigator.of(context).push(
                             MaterialPageRoute(
                               builder: (context) =>
-                                  ListMemberInvitePage(list: widget.list),
+                                  ListMemberInvitePage(list: list),
                             ),
                           );
                         },
@@ -183,9 +176,9 @@ class _ListDetailPageState extends ConsumerState<ListDetailPage> {
                   shrinkWrap: true,
                   physics: const NeverScrollableScrollPhysics(),
                   padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                  itemCount: widget.list.memberIds.length,
+                  itemCount: list.memberIds.length,
                   itemBuilder: (context, index) {
-                    final memberId = widget.list.memberIds[index];
+                    final memberId = list.memberIds[index];
                     return FutureBuilder<PublicUserModel?>(
                       future: ref
                           .read(userRepositoryProvider)
@@ -253,12 +246,10 @@ class _ListDetailPageState extends ConsumerState<ListDetailPage> {
           ),
         );
       },
-      loading: () => const Scaffold(
-        body: Center(child: CircularProgressIndicator()),
-      ),
-      error: (error, _) => Scaffold(
-        body: Center(child: Text('エラーが発生しました: $error')),
-      ),
+      loading: () =>
+          const Scaffold(body: Center(child: CircularProgressIndicator())),
+      error: (error, _) =>
+          Scaffold(body: Center(child: Text('エラーが発生しました: $error'))),
     );
   }
 }

--- a/test/presentation/list/list_detail_page_test.dart
+++ b/test/presentation/list/list_detail_page_test.dart
@@ -1,0 +1,67 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lakiite/app/di/providers.dart';
+import 'package:lakiite/domain/entity/list.dart';
+import 'package:lakiite/domain/entity/user.dart';
+import 'package:lakiite/presentation/list/list_detail_page.dart';
+import 'package:lakiite/presentation/list/list_providers.dart';
+
+import '../../mock/repository/mock_user_repository.dart';
+
+void main() {
+  testWidgets('リスト詳細はlistStreamProviderの最新メンバーを表示する', (tester) async {
+    final listController = StreamController<UserList?>();
+    final userRepository = MockUserRepository()
+      ..addTestUser(
+        UserModel.create(id: 'member-1', name: 'メンバー1', displayName: 'メンバー一郎'),
+      )
+      ..addTestUser(
+        UserModel.create(id: 'member-2', name: 'メンバー2', displayName: 'メンバー二郎'),
+      );
+    final initialList = _list(memberIds: const ['member-1']);
+    final updatedList = _list(memberIds: const ['member-1', 'member-2']);
+
+    addTearDown(listController.close);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          userRepositoryProvider.overrideWithValue(userRepository),
+          listStreamProvider.overrideWith(
+            (ref, listId) => listController.stream,
+          ),
+        ],
+        child: MaterialApp(home: ListDetailPage(list: initialList)),
+      ),
+    );
+
+    listController.add(initialList);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 250));
+
+    expect(find.text('1人'), findsOneWidget);
+    expect(find.text('メンバー一郎'), findsOneWidget);
+    expect(find.text('メンバー二郎'), findsNothing);
+
+    listController.add(updatedList);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 250));
+
+    expect(find.text('2人'), findsOneWidget);
+    expect(find.text('メンバー一郎'), findsOneWidget);
+    expect(find.text('メンバー二郎'), findsOneWidget);
+  });
+}
+
+UserList _list({required List<String> memberIds}) {
+  return UserList(
+    id: 'list-1',
+    listName: 'テストリスト',
+    ownerId: 'owner',
+    memberIds: memberIds,
+    createdAt: DateTime(2026, 5, 30),
+  );
+}


### PR DESCRIPTION
## Summary
- Use the latest list value from listStreamProvider when rendering ListDetailPage
- Pass the refreshed list to edit and member invite flows
- Add a widget test covering member list refresh from stream updates

## Test Plan
- git diff --check
- fvm dart format lib/presentation/list/list_detail_page.dart test/presentation/list/list_detail_page_test.dart

## Not Run
- fvm flutter test test/presentation/list/list_detail_page_test.dart: blocked locally because this fresh worktree does not contain ignored lib/firebase_options.dart
- fvm flutter analyze: blocked locally for the same missing ignored Firebase options file