### PR TITLE
Fix stream provider lifecycles

### DIFF
--- a/lib/infrastructure/schedule_repository.dart
+++ b/lib/infrastructure/schedule_repository.dart
@@ -246,8 +246,8 @@ class ScheduleRepository implements IScheduleRepository {
       AppLogger.debug('SharedLists: ${schedule.sharedLists}');
       AppLogger.debug('VisibleTo: ${schedule.visibleTo}');
 
-      // スケジュールをそのままFirestoreに更新
-      final data = schedule.toJson();
+      // 作成時と同じFirestore保存形式に揃えて更新する
+      final data = ScheduleMapper.toFirestore(schedule);
       AppLogger.debug('Prepared update data:');
       AppLogger.debug(data.toString());
 

--- a/lib/presentation/calendar/schedule_detail_page.dart
+++ b/lib/presentation/calendar/schedule_detail_page.dart
@@ -12,6 +12,7 @@ import 'package:lakiite/application/schedule/schedule_interaction_state.dart';
 import 'package:lakiite/application/schedule/schedule_interaction_notifier.dart';
 import 'package:lakiite/application/schedule/schedule_notifier.dart';
 import 'package:lakiite/presentation/calendar/schedule_detail_logic.dart';
+import 'package:lakiite/presentation/calendar/schedule_providers.dart';
 import 'package:lakiite/presentation/calendar/widgets/comment_edit_dialog.dart';
 import 'package:lakiite/presentation/calendar/widgets/delete_confirmation_dialog.dart';
 import 'package:lakiite/presentation/calendar/widgets/reaction_users_sheet.dart';
@@ -69,15 +70,8 @@ class ScheduleDetailPage extends HookConsumerWidget {
     final targetCommentKey = useMemoized(GlobalKey.new);
     final didScrollToNotificationTarget = useRef(false);
 
-    // スケジュールのリアルタイム監視を行うStreamProviderを作成
-    final scheduleStreamProvider = StreamProvider<Schedule?>((ref) {
-      return ref
-          .read(scheduleNotifierProvider.notifier)
-          .watchSchedule(schedule.id);
-    });
-
     // 監視中のスケジュール情報
-    final watchedScheduleAsync = ref.watch(scheduleStreamProvider);
+    final watchedScheduleAsync = ref.watch(scheduleStreamProvider(schedule.id));
 
     // 現在表示すべきスケジュール情報を取得（最新のデータが取得できたらそれを使用、そうでなければ初期データ）
     final currentSchedule = watchedScheduleAsync.when(

--- a/lib/presentation/calendar/schedule_providers.dart
+++ b/lib/presentation/calendar/schedule_providers.dart
@@ -15,7 +15,7 @@ typedef CalendarMonthSchedulesQuery = ({
 /// This provider is presentation read state. Schedule mutations and monthly
 /// loading remain owned by the application schedule notifier.
 final userSchedulesStreamProvider =
-    StreamProvider.family<List<Schedule>, String>((ref, userId) {
+    StreamProvider.autoDispose.family<List<Schedule>, String>((ref, userId) {
   final authState = ref.watch(authNotifierProvider);
 
   return authState.when(
@@ -36,8 +36,8 @@ final userSchedulesStreamProvider =
 /// Calendar rendering reads schedules directly from the repository so it does
 /// not replace or cancel the timeline/global subscription owned by
 /// `scheduleNotifierProvider`.
-final calendarMonthSchedulesProvider =
-    StreamProvider.family<List<Schedule>, CalendarMonthSchedulesQuery>(
+final calendarMonthSchedulesProvider = StreamProvider.autoDispose
+    .family<List<Schedule>, CalendarMonthSchedulesQuery>(
   (ref, query) {
     final authState = ref.watch(authNotifierProvider);
     final displayMonth = DateTime(
@@ -62,3 +62,21 @@ final calendarMonthSchedulesProvider =
     );
   },
 );
+
+/// Single schedule read model for detail presentation UIs.
+final scheduleStreamProvider =
+    StreamProvider.autoDispose.family<Schedule?, String>((ref, scheduleId) {
+  final authState = ref.watch(authNotifierProvider);
+
+  return authState.when(
+    data: (state) {
+      if (state.status != AuthStatus.authenticated || state.user == null) {
+        return Stream.value(null);
+      }
+
+      return ref.watch(scheduleRepositoryProvider).watchSchedule(scheduleId);
+    },
+    loading: () => Stream.value(null),
+    error: (_, __) => Stream.value(null),
+  );
+});

--- a/lib/presentation/calendar/widgets/calendar_page_view.dart
+++ b/lib/presentation/calendar/widgets/calendar_page_view.dart
@@ -5,6 +5,7 @@ import 'package:lakiite/application/notification/notification_notifier.dart';
 import 'package:lakiite/domain/entity/schedule.dart';
 import 'package:lakiite/presentation/calendar/calendar_providers.dart';
 import 'package:lakiite/presentation/calendar/schedule_providers.dart';
+import 'package:lakiite/presentation/calendar/widgets/daily_schedule_list_page.dart';
 import 'package:lakiite/presentation/calendar/widgets/daily_schedule_view.dart';
 import 'package:lakiite/presentation/calendar/widgets/schedule_ownership_style.dart';
 import 'package:lakiite/presentation/schedule/schedule_display_order.dart';
@@ -1198,7 +1199,10 @@ class OptimizedDateCell extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     // 事前レンダリング最適化のためのフラグ
-    final hasSchedules = schedules.isNotEmpty;
+    final sortedSchedules = ScheduleDisplayOrder.sortedWithinDay(schedules);
+    final visibleSchedules = sortedSchedules.take(2).toList();
+    final remainingCount = sortedSchedules.length - visibleSchedules.length;
+    final hasSchedules = sortedSchedules.isNotEmpty;
     final cellColor = isToday
         ? Colors.blue.shade50
         : !isCurrentMonth
@@ -1264,7 +1268,7 @@ class OptimizedDateCell extends StatelessWidget {
                     ),
                     if (hasSchedules) ...[
                       const SizedBox(height: 1),
-                      ...schedules.take(3).map((schedule) {
+                      ...visibleSchedules.map((schedule) {
                         final isOwner =
                             ScheduleOwnershipStyle.isOwnedByCurrentUser(
                                 schedule, currentUserId);
@@ -1308,15 +1312,36 @@ class OptimizedDateCell extends StatelessWidget {
                           ),
                         );
                       }),
-                      if (schedules.length > 3)
-                        Padding(
-                          padding: const EdgeInsets.only(top: 0.5),
-                          child: Text(
-                            '+${schedules.length - 3}',
-                            style: TextStyle(
-                              fontSize: 8,
-                              color: Colors.grey.shade600,
-                              fontWeight: FontWeight.w500,
+                      if (remainingCount > 0)
+                        Align(
+                          alignment: Alignment.centerRight,
+                          child: Semantics(
+                            label: '予定をすべて表示 +$remainingCount',
+                            button: true,
+                            child: InkWell(
+                              borderRadius: BorderRadius.circular(4),
+                              onTap: () {
+                                Navigator.of(context).push(
+                                  MaterialPageRoute(
+                                    builder: (context) => DailyScheduleListPage(
+                                      date: date,
+                                      schedules: sortedSchedules,
+                                      currentUserId: currentUserId,
+                                    ),
+                                  ),
+                                );
+                              },
+                              child: Padding(
+                                padding: const EdgeInsets.only(top: 0.5),
+                                child: Text(
+                                  '+$remainingCount',
+                                  style: TextStyle(
+                                    fontSize: 11.2,
+                                    color: Colors.grey.shade600,
+                                    fontWeight: FontWeight.w500,
+                                  ),
+                                ),
+                              ),
                             ),
                           ),
                         ),

--- a/lib/presentation/friend/friend_profile_page.dart
+++ b/lib/presentation/friend/friend_profile_page.dart
@@ -6,6 +6,7 @@ import '../../application/auth/auth_notifier.dart';
 import '../../domain/entity/schedule.dart';
 import '../../domain/entity/user.dart';
 import '../calendar/schedule_providers.dart';
+import '../schedule/schedule_display_order.dart';
 import '../widgets/schedule_tile.dart';
 import '../../utils/logger.dart';
 
@@ -233,16 +234,17 @@ class FriendProfilePage extends ConsumerWidget {
                         );
                       }
 
-                      // 日付でソート
-                      userSchedules.sort(
-                          (a, b) => a.startDateTime.compareTo(b.startDateTime));
+                      final sortedSchedules =
+                          ScheduleDisplayOrder.sortedTimeline(
+                        userSchedules,
+                      );
 
                       return ListView.builder(
                         shrinkWrap: true,
                         physics: const NeverScrollableScrollPhysics(),
-                        itemCount: userSchedules.length,
+                        itemCount: sortedSchedules.length,
                         itemBuilder: (context, index) {
-                          final schedule = userSchedules[index];
+                          final schedule = sortedSchedules[index];
                           return ScheduleTile(
                             schedule: schedule,
                             currentUserId: currentUserId ?? '',

--- a/lib/presentation/list/list_edit_page.dart
+++ b/lib/presentation/list/list_edit_page.dart
@@ -6,6 +6,7 @@ import '../../app/di/providers.dart';
 import '../../application/list/list_notifier.dart';
 import '../../domain/entity/list.dart';
 import '../../domain/entity/user.dart';
+import 'list_providers.dart';
 
 class ListEditPage extends ConsumerStatefulWidget {
   const ListEditPage({super.key, required this.list});
@@ -44,7 +45,7 @@ class _ListEditPageState extends ConsumerState<ListEditPage> {
     }
   }
 
-  Future<void> _saveChanges() async {
+  Future<void> _saveChanges(UserList currentList) async {
     if (_nameController.text.trim().isEmpty) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('リスト名を入力してください')),
@@ -55,26 +56,26 @@ class _ListEditPageState extends ConsumerState<ListEditPage> {
     setState(() => _isLoading = true);
 
     try {
-      final String? newIconUrl = widget.list.iconUrl;
+      final String? newIconUrl = currentList.iconUrl;
       if (_selectedImage != null) {
         // 画像のアップロード処理を実装
         // newIconUrl = await uploadImage(_selectedImage!);
       }
 
       // メンバーリストの更新
-      final updatedMemberIds = widget.list.memberIds
+      final updatedMemberIds = currentList.memberIds
           .where((id) => !_excludedMemberIds.contains(id))
           .toList();
 
       // 更新されたリストオブジェクトを作成
       final updatedList = UserList(
-        id: widget.list.id,
+        id: currentList.id,
         listName: _nameController.text.trim(),
-        ownerId: widget.list.ownerId,
+        ownerId: currentList.ownerId,
         memberIds: updatedMemberIds,
-        createdAt: widget.list.createdAt,
+        createdAt: currentList.createdAt,
         iconUrl: newIconUrl,
-        description: widget.list.description,
+        description: currentList.description,
       );
 
       // リストの更新
@@ -99,6 +100,8 @@ class _ListEditPageState extends ConsumerState<ListEditPage> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final listAsync = ref.watch(listStreamProvider(widget.list.id));
+    final currentList = listAsync.valueOrNull ?? widget.list;
 
     return Scaffold(
       appBar: AppBar(
@@ -116,7 +119,7 @@ class _ListEditPageState extends ConsumerState<ListEditPage> {
               padding:
                   const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
               child: FilledButton(
-                onPressed: _saveChanges,
+                onPressed: () => _saveChanges(currentList),
                 child: const Text('保存'),
               ),
             ),
@@ -136,11 +139,11 @@ class _ListEditPageState extends ConsumerState<ListEditPage> {
                       radius: 50,
                       backgroundImage: _selectedImage != null
                           ? FileImage(_selectedImage!)
-                          : (widget.list.iconUrl != null
-                              ? NetworkImage(widget.list.iconUrl!)
+                          : (currentList.iconUrl != null
+                              ? NetworkImage(currentList.iconUrl!)
                               : null) as ImageProvider?,
                       child:
-                          _selectedImage == null && widget.list.iconUrl == null
+                          _selectedImage == null && currentList.iconUrl == null
                               ? const Icon(Icons.list, size: 50)
                               : null,
                     ),
@@ -185,9 +188,9 @@ class _ListEditPageState extends ConsumerState<ListEditPage> {
                   ListView.builder(
                     shrinkWrap: true,
                     physics: const NeverScrollableScrollPhysics(),
-                    itemCount: widget.list.memberIds.length,
+                    itemCount: currentList.memberIds.length,
                     itemBuilder: (context, index) {
-                      final memberId = widget.list.memberIds[index];
+                      final memberId = currentList.memberIds[index];
                       return FutureBuilder<PublicUserModel?>(
                         future: ref
                             .read(userRepositoryProvider)

--- a/lib/presentation/list/list_member_invite_page.dart
+++ b/lib/presentation/list/list_member_invite_page.dart
@@ -5,6 +5,7 @@ import '../../application/auth/auth_state.dart';
 import '../../application/list/list_notifier.dart';
 import '../../domain/entity/list.dart';
 import '../friend/friend_providers.dart';
+import 'list_providers.dart';
 
 /// リストメンバー追加ページ
 class ListMemberInvitePage extends ConsumerStatefulWidget {
@@ -35,10 +36,15 @@ class _ListMemberInvitePageState extends ConsumerState<ListMemberInvitePage> {
         }
 
         final friendsAsync = ref.watch(userFriendsStreamProvider);
+        final listAsync = ref.watch(listStreamProvider(widget.list.id));
+        final currentList = listAsync.valueOrNull ?? widget.list;
+        final selectedFriendsToAdd = selectedFriends
+            .where((friendId) => !currentList.memberIds.contains(friendId))
+            .toSet();
 
         return Scaffold(
           appBar: AppBar(
-            title: Text('${widget.list.listName}にメンバーを追加'),
+            title: Text('${currentList.listName}にメンバーを追加'),
           ),
           body: friendsAsync.when(
             data: (friends) {
@@ -47,8 +53,9 @@ class _ListMemberInvitePageState extends ConsumerState<ListMemberInvitePage> {
                 itemBuilder: (context, index) {
                   final friend = friends[index];
                   final friendId = friend.id;
-                  final isSelected = selectedFriends.contains(friendId);
-                  final isInList = widget.list.memberIds.contains(friendId);
+                  final isInList = currentList.memberIds.contains(friendId);
+                  final isSelected =
+                      !isInList && selectedFriendsToAdd.contains(friendId);
 
                   return ListTile(
                     enabled: !isInList,
@@ -113,19 +120,19 @@ class _ListMemberInvitePageState extends ConsumerState<ListMemberInvitePage> {
             child: Padding(
               padding: const EdgeInsets.all(16.0),
               child: ElevatedButton(
-                onPressed: selectedFriends.isEmpty
+                onPressed: selectedFriendsToAdd.isEmpty
                     ? null
                     : () async {
                         final scaffoldMessenger = ScaffoldMessenger.of(context);
                         final navigator = Navigator.of(context);
                         try {
                           // 選択された友達をリストに追加
-                          for (final friendId in selectedFriends) {
+                          for (final friendId in selectedFriendsToAdd) {
                             // リストにメンバーを追加
                             await ref
                                 .read(listNotifierProvider.notifier)
                                 .addMember(
-                                  widget.list.id,
+                                  currentList.id,
                                   friendId,
                                 );
                           }
@@ -140,7 +147,7 @@ class _ListMemberInvitePageState extends ConsumerState<ListMemberInvitePage> {
                           }
                         }
                       },
-                child: Text('選択したメンバー(${selectedFriends.length}名)を追加'),
+                child: Text('選択したメンバー(${selectedFriendsToAdd.length}名)を追加'),
               ),
             ),
           ),

--- a/lib/presentation/list/list_providers.dart
+++ b/lib/presentation/list/list_providers.dart
@@ -6,7 +6,7 @@ import 'package:lakiite/domain/entity/list.dart';
 
 /// Single list read model for list detail UIs.
 final listStreamProvider =
-    StreamProvider.family<UserList?, String>((ref, listId) {
+    StreamProvider.autoDispose.family<UserList?, String>((ref, listId) {
   final authState = ref.watch(authNotifierProvider);
 
   return authState.when(

--- a/lib/presentation/my_page/widgets/schedule_list.dart
+++ b/lib/presentation/my_page/widgets/schedule_list.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lakiite/presentation/widgets/schedule_tile.dart';
 import 'package:lakiite/presentation/calendar/edit_schedule_page.dart';
+import 'package:lakiite/presentation/schedule/schedule_display_order.dart';
 import '../../calendar/schedule_providers.dart';
 
 /// ユーザーの予定一覧を表示するウィジェット
@@ -56,15 +57,16 @@ class ScheduleList extends ConsumerWidget {
           );
         }
 
-        // 日付でソート
-        mySchedules.sort((a, b) => a.startDateTime.compareTo(b.startDateTime));
+        final sortedSchedules = ScheduleDisplayOrder.sortedTimeline(
+          mySchedules,
+        );
 
         return ListView.builder(
           shrinkWrap: true,
           physics: const NeverScrollableScrollPhysics(),
-          itemCount: mySchedules.length,
+          itemCount: sortedSchedules.length,
           itemBuilder: (context, index) {
-            final schedule = mySchedules[index];
+            final schedule = sortedSchedules[index];
             return ScheduleTile(
               schedule: schedule,
               currentUserId: userId,

--- a/lib/presentation/presentation_provider.dart
+++ b/lib/presentation/presentation_provider.dart
@@ -10,7 +10,10 @@ export 'package:lakiite/application/schedule/schedule_notifier.dart'
 export 'package:lakiite/presentation/calendar/calendar_providers.dart'
     show selectedDateProvider;
 export 'package:lakiite/presentation/calendar/schedule_providers.dart'
-    show calendarMonthSchedulesProvider, userSchedulesStreamProvider;
+    show
+        calendarMonthSchedulesProvider,
+        scheduleStreamProvider,
+        userSchedulesStreamProvider;
 export 'package:lakiite/presentation/friend/friend_providers.dart'
     show userFriendsProvider, userFriendsStreamProvider;
 export 'package:lakiite/presentation/list/list_providers.dart'

--- a/lib/presentation/user/user_providers.dart
+++ b/lib/presentation/user/user_providers.dart
@@ -9,7 +9,7 @@ import 'package:lakiite/domain/entity/user.dart';
 /// This provider stays in the user presentation feature so generic user reads
 /// are not mixed into broad app-level presentation exports.
 final userStreamProvider =
-    StreamProvider.family<UserModel?, String>((ref, userId) {
+    StreamProvider.autoDispose.family<UserModel?, String>((ref, userId) {
   final authState = ref.watch(authNotifierProvider);
 
   return authState.when(

--- a/test/presentation/calendar/calendar_schedule_providers_test.dart
+++ b/test/presentation/calendar/calendar_schedule_providers_test.dart
@@ -64,11 +64,28 @@ class _FakeAuthRepository implements IAuthRepository {
 }
 
 class _TrackingScheduleRepository implements IScheduleRepository {
+  _TrackingScheduleRepository() {
+    _allController.onCancel = () {
+      watchUserSchedulesCancelCount++;
+    };
+    _monthController.onCancel = () {
+      watchUserSchedulesForMonthCancelCount++;
+    };
+    _scheduleController.onCancel = () {
+      watchScheduleCancelCount++;
+    };
+  }
+
   final _monthController = StreamController<List<Schedule>>.broadcast();
   final _allController = StreamController<List<Schedule>>.broadcast();
+  final _scheduleController = StreamController<Schedule?>.broadcast();
 
   int watchUserSchedulesCallCount = 0;
   int watchUserSchedulesForMonthCallCount = 0;
+  int watchScheduleCallCount = 0;
+  int watchUserSchedulesCancelCount = 0;
+  int watchUserSchedulesForMonthCancelCount = 0;
+  int watchScheduleCancelCount = 0;
   DateTime? lastDisplayMonth;
 
   @override
@@ -92,7 +109,10 @@ class _TrackingScheduleRepository implements IScheduleRepository {
       const Stream.empty();
 
   @override
-  Stream<Schedule?> watchSchedule(String scheduleId) => const Stream.empty();
+  Stream<Schedule?> watchSchedule(String scheduleId) {
+    watchScheduleCallCount++;
+    return _scheduleController.stream;
+  }
 
   @override
   Future<Schedule> createSchedule(Schedule schedule) =>
@@ -117,6 +137,7 @@ class _TrackingScheduleRepository implements IScheduleRepository {
   void dispose() {
     _monthController.close();
     _allController.close();
+    _scheduleController.close();
   }
 }
 
@@ -209,6 +230,87 @@ void main() {
       expect(scheduleRepository.watchUserSchedulesCallCount, 0);
 
       subscription.close();
+      authSubscription.close();
+    });
+
+    test('userSchedulesStreamProvider は購読終了時にrepository購読を破棄する', () async {
+      final authSubscription = _listenAuthenticatedAuthState(
+        container,
+        mockAuthRepository,
+        testUser,
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      final provider = userSchedulesStreamProvider(testUser.id);
+      final subscription = container.listen(
+        provider,
+        (_, __) {},
+        fireImmediately: true,
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(scheduleRepository.watchUserSchedulesCallCount, 1);
+
+      subscription.close();
+      await container.pump();
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(container.exists(provider), isFalse);
+      authSubscription.close();
+    });
+
+    test('calendarMonthSchedulesProvider は購読終了時にrepository購読を破棄する', () async {
+      final authSubscription = _listenAuthenticatedAuthState(
+        container,
+        mockAuthRepository,
+        testUser,
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      final provider = calendarMonthSchedulesProvider((
+        userId: testUser.id,
+        displayMonth: DateTime(2026, 3, 20),
+      ));
+      final subscription = container.listen(
+        provider,
+        (_, __) {},
+        fireImmediately: true,
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(scheduleRepository.watchUserSchedulesForMonthCallCount, 1);
+
+      subscription.close();
+      await container.pump();
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(container.exists(provider), isFalse);
+      authSubscription.close();
+    });
+
+    test('scheduleStreamProvider は予定詳細の単体購読をautoDisposeする', () async {
+      final authSubscription = _listenAuthenticatedAuthState(
+        container,
+        mockAuthRepository,
+        testUser,
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      final provider = scheduleStreamProvider('schedule-1');
+      final subscription = container.listen(
+        provider,
+        (_, __) {},
+        fireImmediately: true,
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(scheduleRepository.watchScheduleCallCount, 1);
+
+      subscription.close();
+      await container.pump();
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(container.exists(provider), isFalse);
       authSubscription.close();
     });
   });

--- a/test/presentation/calendar/month_calendar_schedule_cell_test.dart
+++ b/test/presentation/calendar/month_calendar_schedule_cell_test.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lakiite/domain/entity/schedule.dart';
+import 'package:lakiite/presentation/calendar/widgets/calendar_page_view.dart';
+
+void main() {
+  testWidgets('月次セルは2件まで表示し残数からその日の予定一覧へ遷移する', (tester) async {
+    final date = DateTime(2026, 5, 28);
+    final schedules = [
+      _schedule(
+        id: 'all-day-old',
+        title: '古い終日',
+        date: date,
+        isAllDay: true,
+        createdAt: DateTime(2026, 5, 28, 8),
+      ),
+      _schedule(
+        id: 'all-day-new',
+        title: '新しい終日',
+        date: date,
+        isAllDay: true,
+        createdAt: DateTime(2026, 5, 28, 9),
+      ),
+      _schedule(
+        id: 'timed',
+        title: '時間予定',
+        date: date,
+        startDateTime: DateTime(2026, 5, 28, 10),
+        endDateTime: DateTime(2026, 5, 28, 11),
+        createdAt: DateTime(2026, 5, 28, 7),
+      ),
+    ];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 180,
+            height: 160,
+            child: OptimizedDateCell(
+              date: date,
+              schedules: schedules,
+              isToday: false,
+              isWeekend: false,
+              isSaturday: false,
+              isCurrentMonth: true,
+              isHoliday: false,
+              holidayName: '',
+              currentUserId: 'owner',
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('古い終日'), findsOneWidget);
+    expect(find.text('新しい終日'), findsOneWidget);
+    expect(find.text('時間予定'), findsNothing);
+    expect(find.text('+1'), findsOneWidget);
+
+    final plusText = tester.widget<Text>(find.text('+1'));
+    expect(plusText.style?.fontSize, 11.2);
+
+    final cellRight = tester.getTopRight(find.byType(OptimizedDateCell)).dx;
+    final plusRight = tester.getTopRight(find.text('+1')).dx;
+    expect(cellRight - plusRight, lessThan(8));
+
+    await tester.tap(find.text('+1'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('予定一覧'), findsOneWidget);
+    expect(find.text('古い終日'), findsOneWidget);
+    expect(find.text('新しい終日'), findsOneWidget);
+    expect(find.text('時間予定'), findsOneWidget);
+    expect(find.text('10:00〜11:00'), findsOneWidget);
+  });
+}
+
+Schedule _schedule({
+  required String id,
+  required String title,
+  required DateTime date,
+  required DateTime createdAt,
+  bool isAllDay = false,
+  DateTime? startDateTime,
+  DateTime? endDateTime,
+}) {
+  return Schedule(
+    id: id,
+    title: title,
+    description: '',
+    startDateTime: startDateTime ?? date,
+    endDateTime: endDateTime ?? date,
+    isAllDay: isAllDay,
+    ownerId: 'owner',
+    ownerDisplayName: 'Owner',
+    sharedLists: const [],
+    visibleTo: const ['owner'],
+    createdAt: createdAt,
+    updatedAt: createdAt,
+  );
+}

--- a/test/presentation/list/list_edit_page_test.dart
+++ b/test/presentation/list/list_edit_page_test.dart
@@ -1,0 +1,109 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lakiite/app/di/providers.dart';
+import 'package:lakiite/domain/entity/list.dart';
+import 'package:lakiite/domain/entity/user.dart';
+import 'package:lakiite/domain/interfaces/i_list_repository.dart';
+import 'package:lakiite/presentation/list/list_edit_page.dart';
+import 'package:lakiite/presentation/list/list_providers.dart';
+
+import '../../mock/repository/mock_user_repository.dart';
+
+void main() {
+  testWidgets('リスト編集は保存時に最新のmemberIdsを保持する', (tester) async {
+    final listController = StreamController<UserList?>();
+    final listRepository = _CapturingListRepository();
+    final userRepository = MockUserRepository()
+      ..addTestUser(
+        UserModel.create(id: 'member-1', name: 'メンバー1', displayName: 'メンバー一郎'),
+      )
+      ..addTestUser(
+        UserModel.create(id: 'member-2', name: 'メンバー2', displayName: 'メンバー二郎'),
+      );
+    final initialList = _list(memberIds: const ['member-1']);
+    final latestList = _list(memberIds: const ['member-1', 'member-2']);
+
+    addTearDown(listController.close);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          listRepositoryProvider.overrideWithValue(listRepository),
+          userRepositoryProvider.overrideWithValue(userRepository),
+          listStreamProvider.overrideWith(
+            (ref, listId) => listController.stream,
+          ),
+        ],
+        child: MaterialApp(home: ListEditPage(list: initialList)),
+      ),
+    );
+
+    listController.add(latestList);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 250));
+
+    await tester.tap(find.text('保存'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 250));
+
+    expect(listRepository.updatedList, isNotNull);
+    expect(listRepository.updatedList!.memberIds, ['member-1', 'member-2']);
+  });
+}
+
+class _CapturingListRepository implements IListRepository {
+  UserList? updatedList;
+
+  @override
+  Future<void> updateList(UserList list) async {
+    updatedList = list;
+  }
+
+  @override
+  Future<void> addMember(String listId, String userId) =>
+      Future.error(UnimplementedError());
+
+  @override
+  Future<UserList> createList({
+    required String listName,
+    required List<String> memberIds,
+    required String ownerId,
+    String? iconUrl,
+    String? description,
+  }) =>
+      Future.error(UnimplementedError());
+
+  @override
+  Future<void> deleteList(String listId) => Future.error(UnimplementedError());
+
+  @override
+  Future<UserList?> getList(String listId) =>
+      Future.error(UnimplementedError());
+
+  @override
+  Future<List<UserList>> getLists(String ownerId) =>
+      Future.error(UnimplementedError());
+
+  @override
+  Future<void> removeMember(String listId, String userId) =>
+      Future.error(UnimplementedError());
+
+  @override
+  Stream<UserList?> watchList(String listId) => const Stream.empty();
+
+  @override
+  Stream<List<UserList>> watchUserLists(String ownerId) => const Stream.empty();
+}
+
+UserList _list({required List<String> memberIds}) {
+  return UserList(
+    id: 'list-1',
+    listName: 'テストリスト',
+    ownerId: 'owner',
+    memberIds: memberIds,
+    createdAt: DateTime(2026, 5, 30),
+  );
+}

--- a/test/presentation/list/list_member_invite_page_test.dart
+++ b/test/presentation/list/list_member_invite_page_test.dart
@@ -1,0 +1,80 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lakiite/application/auth/auth_notifier.dart';
+import 'package:lakiite/domain/entity/list.dart';
+import 'package:lakiite/domain/entity/user.dart';
+import 'package:lakiite/presentation/friend/friend_providers.dart';
+import 'package:lakiite/presentation/list/list_member_invite_page.dart';
+import 'package:lakiite/presentation/list/list_providers.dart';
+
+import '../../mock/repository/mock_auth_repository.dart';
+
+void main() {
+  testWidgets('メンバー追加は最新のmemberIdsで既存メンバーを選択不可にする', (tester) async {
+    final authRepository = MockAuthRepository();
+    final listController = StreamController<UserList?>();
+    final currentUser = UserModel.create(
+      id: 'owner',
+      name: 'オーナー',
+      displayName: 'オーナー',
+    );
+    final initialList = _list(memberIds: const ['member-1']);
+    final latestList = _list(memberIds: const ['member-1', 'member-2']);
+    final friends = [
+      UserModel.create(
+        id: 'member-2',
+        name: 'メンバー2',
+        displayName: 'メンバー二郎',
+      ).publicProfile,
+      UserModel.create(
+        id: 'member-3',
+        name: 'メンバー3',
+        displayName: 'メンバー三郎',
+      ).publicProfile,
+    ];
+
+    addTearDown(listController.close);
+    addTearDown(authRepository.dispose);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authRepositoryProvider.overrideWithValue(authRepository),
+          userFriendsStreamProvider.overrideWith(
+            (ref) => Stream.value(friends),
+          ),
+          listStreamProvider.overrideWith(
+            (ref, listId) => listController.stream,
+          ),
+        ],
+        child: MaterialApp(home: ListMemberInvitePage(list: initialList)),
+      ),
+    );
+
+    authRepository.setCurrentUser(currentUser);
+    listController.add(latestList);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 250));
+
+    await tester.tap(find.text('メンバー二郎'));
+    await tester.pump();
+
+    final addButton = tester.widget<ElevatedButton>(
+      find.widgetWithText(ElevatedButton, '選択したメンバー(0名)を追加'),
+    );
+    expect(addButton.onPressed, isNull);
+  });
+}
+
+UserList _list({required List<String> memberIds}) {
+  return UserList(
+    id: 'list-1',
+    listName: 'テストリスト',
+    ownerId: 'owner',
+    memberIds: memberIds,
+    createdAt: DateTime(2026, 5, 30),
+  );
+}

--- a/test/presentation/presentation_provider_test.dart
+++ b/test/presentation/presentation_provider_test.dart
@@ -27,8 +27,8 @@ import 'package:lakiite/presentation/presentation_provider.dart'
     as presentation;
 import 'package:lakiite/presentation/presentation_provider.dart';
 
-import '../../mock/repositories/mock_auth_repository.dart';
-import '../../mock/repositories/mock_user_repository.dart';
+import '../mock/repository/mock_auth_repository.dart';
+import '../mock/repository/mock_user_repository.dart';
 
 class _TrackingScheduleRepository implements IScheduleRepository {
   _TrackingScheduleRepository() {
@@ -176,7 +176,7 @@ void main() {
         displayName: 'テストユーザー',
       );
 
-      mockAuthRepository.setUser(testUser);
+      mockAuthRepository.setCurrentUser(testUser);
       mockUserRepository.addTestUser(testUser);
 
       container = ProviderContainer(
@@ -214,7 +214,9 @@ void main() {
     });
 
     test('userSchedulesStreamProvider はログアウト時に空配列へ切り替わる', () async {
-      await container.read(authNotifierProvider.future);
+      final authFuture = container.read(authNotifierProvider.future);
+      mockAuthRepository.setCurrentUser(testUser);
+      await authFuture;
 
       final subscription = container.listen(
         userSchedulesStreamProvider(testUser.id),
@@ -262,6 +264,16 @@ void main() {
       );
     });
 
+    test('presentation_provider は scheduleStreamProvider を再定義しない', () {
+      expect(
+        identical(
+          calendar_schedule.scheduleStreamProvider,
+          presentation.scheduleStreamProvider,
+        ),
+        isTrue,
+      );
+    });
+
     test('my_page は userSchedulesStreamProvider を再定義しない', () {
       expect(
         identical(
@@ -283,7 +295,9 @@ void main() {
     });
 
     test('timelineSchedulesProvider はログアウト時に空配列へ切り替わる', () async {
-      await container.read(authNotifierProvider.future);
+      final authFuture = container.read(authNotifierProvider.future);
+      mockAuthRepository.setCurrentUser(testUser);
+      await authFuture;
 
       final subscription = container.listen(
         timelineSchedulesProvider,
@@ -349,7 +363,9 @@ void main() {
     });
 
     test('userListsStreamProvider はログアウト時に空配列へ切り替わる', () async {
-      await container.read(authNotifierProvider.future);
+      final authFuture = container.read(authNotifierProvider.future);
+      mockAuthRepository.setCurrentUser(testUser);
+      await authFuture;
 
       final subscription = container.listen(
         userListsStreamProvider,
@@ -372,7 +388,9 @@ void main() {
     });
 
     test('listStreamProvider はログアウト時に null へ切り替わる', () async {
-      await container.read(authNotifierProvider.future);
+      final authFuture = container.read(authNotifierProvider.future);
+      mockAuthRepository.setCurrentUser(testUser);
+      await authFuture;
 
       final subscription = container.listen(
         listStreamProvider('test-list-id'),


### PR DESCRIPTION
## Summary
- make presentation stream providers auto-dispose and add a shared schedule detail stream provider
- make list edit and member invite pages read the latest list stream before saving/adding
- add regression tests for latest memberIds, existing-member invite guards, provider exports, and autoDispose behavior
- cap month calendar schedule chips at 2 items and route overflow +n taps to the shared daily schedule list
- centralize schedule display ordering so all-day items use createdAt ordering and timed items use time ordering across month, timeline, and schedule lists
- serialize schedule updates through the Firestore mapper so all-day flags use the same persisted shape as creates

## Verification
- fvm flutter test test/presentation/calendar/month_calendar_schedule_cell_test.dart test/presentation/calendar/daily_all_day_schedule_list_test.dart test/presentation/schedule/schedule_display_order_test.dart test/presentation/list/list_edit_page_test.dart test/presentation/list/list_member_invite_page_test.dart test/presentation/calendar/calendar_schedule_providers_test.dart test/presentation/presentation_provider_test.dart test/presentation/list/list_detail_page_test.dart
- fvm flutter analyze
- git diff --check
- Galaxy SCG19 (RFCW31S5JLJ) dev flavor E2E via adb: created all-day schedules, confirmed month +1 overflow, navigated to 予定一覧, confirmed timeline ordering, and verified list detail/member display

## Notes
- firebase-commons already allows optional boolean isAllDay in Firestore rules, so no additional rules change was needed
- firebase-commons rules test was not rerun locally because firebase-tools requires JDK 21 or newer in this environment