### PR TITLE
chore: promote support page to production

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -1,12 +1,13 @@
 # LaKiite Web Assets
 
-このフォルダには、GitHub Pagesで公開するWeb用ファイルが含まれています。
+このフォルダには、Firebase HostingやGitHub Pagesで公開するWeb用ファイルが含まれています。
 
 ## 📄 ファイル一覧
 
 - `index.html` - メインランディングページ
 - `privacy-policy.html` - プライバシーポリシー
 - `terms-of-service.html` - 利用規約
+- `support.html` - サポートページ
 - `account-deletion.html` - アカウント削除ページ（一般向け）
 - `account-deletion-webview.html` - アカウント削除ページ（WebView用）
 
@@ -30,7 +31,17 @@
 - メインページ: `https://keishimizu26629.github.io/LaKiite-flutter-app/`
 - プライバシーポリシー: `https://keishimizu26629.github.io/LaKiite-flutter-app/privacy-policy.html`
 - 利用規約: `https://keishimizu26629.github.io/LaKiite-flutter-app/terms-of-service.html`
+- サポート: `https://keishimizu26629.github.io/LaKiite-flutter-app/support.html`
 - アカウント削除: `https://keishimizu26629.github.io/LaKiite-flutter-app/account-deletion.html`
+
+## 🌐 Firebase Hosting
+
+`firebase.json` では `web/` をHostingの公開ディレクトリに設定しています。
+
+想定URL：
+
+- Dev: `https://lakiite-flutter-app-dev.web.app/support.html`
+- Prod: `https://lakiite-flutter-app-prod.web.app/support.html`
 
 ### 🔧 設定変更が必要
 GitHub Repository Settings → Pages → Source を以下に変更してください：

--- a/web/index.html
+++ b/web/index.html
@@ -26,6 +26,7 @@
         .links {
             display: flex;
             justify-content: center;
+            flex-wrap: wrap;
             gap: 30px;
             margin-top: 30px;
         }
@@ -78,6 +79,11 @@
         <a href="terms-of-service.html" class="link-card">
             <h3>📋 利用規約</h3>
             <p>サービス利用に関する規約</p>
+        </a>
+
+        <a href="support.html" class="link-card">
+            <h3>LaKiite サポート</h3>
+            <p>お問い合わせとサポート窓口</p>
         </a>
 
         <a href="child-safety-standards.html" class="link-card">

--- a/web/support.html
+++ b/web/support.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>LaKiite サポート</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+            max-width: 900px;
+            margin: 0 auto;
+            padding: 24px;
+            line-height: 1.6;
+            color: #333;
+            background-color: #fff;
+        }
+        .header {
+            text-align: center;
+            margin-bottom: 48px;
+            padding-bottom: 24px;
+            border-bottom: 1px solid #e1e5e9;
+        }
+        .header h1 {
+            color: #1a1a1a;
+            margin-bottom: 8px;
+            font-size: 2.25rem;
+            font-weight: 600;
+        }
+        .header p {
+            color: #6b7280;
+            font-size: 0.875rem;
+            margin: 0;
+        }
+        h2 {
+            color: #1a1a1a;
+            margin-top: 40px;
+            margin-bottom: 16px;
+            border-bottom: 1px solid #e1e5e9;
+            padding-bottom: 8px;
+            font-size: 1.5rem;
+            font-weight: 600;
+        }
+        ul {
+            padding-left: 24px;
+            margin: 16px 0;
+        }
+        li {
+            margin-bottom: 8px;
+        }
+        p {
+            margin: 16px 0;
+        }
+        a {
+            color: #007aff;
+        }
+        .contact {
+            background: #f9fafb;
+            padding: 24px;
+            border: 1px solid #e1e5e9;
+            border-radius: 8px;
+            margin-top: 32px;
+        }
+        .meta {
+            color: #6b7280;
+            font-size: 0.875rem;
+            margin-top: 40px;
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>LaKiite サポート</h1>
+        <p>LaKiiteに関するお問い合わせ窓口です。</p>
+    </div>
+
+    <h2>お問い合わせ</h2>
+    <div class="contact">
+        <p>LaKiiteのご利用に関するご質問、不具合の報告、アカウントやデータ削除に関するご依頼は、以下のメールアドレスまでご連絡ください。</p>
+        <p><strong>メールアドレス:</strong> <a href="mailto:g.g.rereagirx84@gmail.com?subject=LaKiite%20%E3%82%B5%E3%83%9D%E3%83%BC%E3%83%88">g.g.rereagirx84@gmail.com</a></p>
+        <p><strong>返信目安:</strong> 通常3営業日以内に確認します。</p>
+    </div>
+
+    <h2>対応内容</h2>
+    <ul>
+        <li>アカウント登録、ログイン、アカウント削除に関するお問い合わせ</li>
+        <li>予定の作成、共有、表示に関するお問い合わせ</li>
+        <li>友だち、グループ、招待に関するお問い合わせ</li>
+        <li>通知、コメント、リアクションに関するお問い合わせ</li>
+        <li>不具合、表示崩れ、動作不良の報告</li>
+        <li>個人データの確認、修正、削除に関するご依頼</li>
+    </ul>
+
+    <h2>お問い合わせ時に記載いただきたい内容</h2>
+    <ul>
+        <li>ご利用中の端末名とOSバージョン</li>
+        <li>LaKiiteのアプリバージョン</li>
+        <li>発生している問題の内容</li>
+        <li>問題が発生した日時と操作手順</li>
+        <li>アカウント関連のご依頼の場合、登録メールアドレス</li>
+    </ul>
+
+    <h2>運営者</h2>
+    <ul>
+        <li><strong>運営者:</strong> Inoworl / Keisuke Shimizu</li>
+        <li><strong>アプリ名:</strong> LaKiite</li>
+    </ul>
+
+    <p class="meta">Copyright 2026 Inoworl / Keisuke Shimizu</p>
+</body>
+</html>

--- a/web/support.html
+++ b/web/support.html
@@ -76,7 +76,7 @@
     <h2>お問い合わせ</h2>
     <div class="contact">
         <p>LaKiiteのご利用に関するご質問、不具合の報告、アカウントやデータ削除に関するご依頼は、以下のメールアドレスまでご連絡ください。</p>
-        <p><strong>メールアドレス:</strong> <a href="mailto:g.g.rereagirx84@gmail.com?subject=LaKiite%20%E3%82%B5%E3%83%9D%E3%83%BC%E3%83%88">g.g.rereagirx84@gmail.com</a></p>
+        <p><strong>メールアドレス:</strong> <a href="mailto:business-contact@inoworl.com?subject=LaKiite%20%E3%82%B5%E3%83%9D%E3%83%BC%E3%83%88">business-contact@inoworl.com</a></p>
         <p><strong>返信目安:</strong> 通常3営業日以内に確認します。</p>
     </div>
 


### PR DESCRIPTION
## Summary
- Promote the LaKiite support page and Hosting updates from dev to main.
- This makes flutter-app/web the source for production Firebase Hosting.

## Verification
- Dev Firebase Hosting workflow succeeded: https://github.com/keishimizu26629/LaKiite-flutter-app/actions/runs/26678999610

## Notes
- After merge, the main push should run the prod Firebase Hosting deploy.