### PR TITLE
Improve calendar month schedule caching

### DIFF
--- a/lib/domain/value/schedule_month_range.dart
+++ b/lib/domain/value/schedule_month_range.dart
@@ -1,25 +1,22 @@
-/// Firestore schedule queries for a displayed calendar month.
-///
-/// The calendar renders leading and trailing days around the visible month, so
-/// the query intentionally covers the previous month through the next month.
+/// Firestore schedule queries for a single calendar month.
 class ScheduleMonthRange {
   const ScheduleMonthRange({
     required this.startInclusive,
     required this.endExclusive,
   });
 
-  /// Builds the calendar query window for [displayMonth].
+  /// Builds the query window for the calendar month containing [displayMonth].
   factory ScheduleMonthRange.forDisplayMonth(DateTime displayMonth) {
     return ScheduleMonthRange(
-      startInclusive: DateTime(displayMonth.year, displayMonth.month - 1, 1),
-      endExclusive: DateTime(displayMonth.year, displayMonth.month + 2, 1),
+      startInclusive: DateTime(displayMonth.year, displayMonth.month, 1),
+      endExclusive: DateTime(displayMonth.year, displayMonth.month + 1, 1),
     );
   }
 
-  /// First day of the previous month at midnight.
+  /// First day of the month at midnight.
   final DateTime startInclusive;
 
-  /// First day of the month after next at midnight.
+  /// First day of the next month at midnight.
   final DateTime endExclusive;
 
   /// Firestore-compatible lower bound ISO string.

--- a/lib/infrastructure/schedule_repository.dart
+++ b/lib/infrastructure/schedule_repository.dart
@@ -352,6 +352,10 @@ class ScheduleRepository implements IScheduleRepository {
             .get(const GetOptions(source: Source.cache));
 
         if (cachedSnapshot.docs.isNotEmpty) {
+          final cachedBasicSchedules =
+              cachedSnapshot.docs.map(ScheduleMapper.fromFirestore).toList();
+          yield cachedBasicSchedules;
+
           // キャッシュからのデータを非同期でエンリッチして即時返却
           final cachedSchedules = await Future.wait(
             cachedSnapshot.docs.map((doc) async {
@@ -386,6 +390,10 @@ class ScheduleRepository implements IScheduleRepository {
 
       await for (final snapshot in stream) {
         try {
+          final basicSchedules =
+              snapshot.docs.map(ScheduleMapper.fromFirestore).toList();
+          yield basicSchedules;
+
           // バッチ処理でエンリッチメントを高速化
           final schedules = await _enrichSchedulesInBatches(snapshot.docs);
           yield schedules;

--- a/lib/presentation/calendar/schedule_providers.dart
+++ b/lib/presentation/calendar/schedule_providers.dart
@@ -1,8 +1,12 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lakiite/app/di/providers.dart';
 import 'package:lakiite/application/auth/auth_notifier.dart';
 import 'package:lakiite/application/auth/auth_state.dart';
 import 'package:lakiite/domain/entity/schedule.dart';
+
+const calendarMonthScheduleCacheTtl = Duration(minutes: 5);
 
 /// Request parameters for calendar month schedule streams.
 typedef CalendarMonthSchedulesQuery = ({
@@ -39,6 +43,11 @@ final userSchedulesStreamProvider =
 final calendarMonthSchedulesProvider = StreamProvider.autoDispose
     .family<List<Schedule>, CalendarMonthSchedulesQuery>(
   (ref, query) {
+    final keepAliveLink = ref.keepAlive();
+    final cacheTimer =
+        Timer(calendarMonthScheduleCacheTtl, keepAliveLink.close);
+    ref.onDispose(cacheTimer.cancel);
+
     final authState = ref.watch(authNotifierProvider);
     final displayMonth = DateTime(
       query.displayMonth.year,

--- a/lib/presentation/calendar/widgets/calendar_page_view.dart
+++ b/lib/presentation/calendar/widgets/calendar_page_view.dart
@@ -150,6 +150,17 @@ List<DateTime> getCalendarSchedulePrefetchMonths(DateTime visibleMonth) {
   ];
 }
 
+List<Schedule> getCalendarPageSchedules({
+  required String userId,
+  required DateTime visibleMonth,
+  required Map<String, List<Schedule>> scheduleMemoryCache,
+}) {
+  return [
+    for (final month in getCalendarSchedulePrefetchMonths(visibleMonth))
+      ...?scheduleMemoryCache[getCalendarMonthScheduleCacheKey(userId, month)],
+  ];
+}
+
 Map<String, List<Schedule>> cacheCalendarMonthSchedules({
   required Map<String, List<Schedule>> currentCache,
   required String cacheKey,
@@ -695,16 +706,13 @@ class CalendarPageView extends HookConsumerWidget {
 
                   final dateTime = _getVisibleDateTime(index);
                   final monthKey = getMonthKey(dateTime);
-                  final pageScheduleCacheKey = currentUserId == null
-                      ? null
-                      : getCalendarMonthScheduleCacheKey(
-                          currentUserId,
-                          dateTime,
-                        );
                   final pageSchedules = currentUserId == null
                       ? const <Schedule>[]
-                      : scheduleMemoryCache[pageScheduleCacheKey] ??
-                          const <Schedule>[];
+                      : getCalendarPageSchedules(
+                          userId: currentUserId,
+                          visibleMonth: dateTime,
+                          scheduleMemoryCache: scheduleMemoryCache,
+                        );
 
                   // アクティブな範囲内のページにキープアライブを適用
                   final shouldCache = activeMonthIndices.contains(index);

--- a/lib/presentation/calendar/widgets/calendar_page_view.dart
+++ b/lib/presentation/calendar/widgets/calendar_page_view.dart
@@ -46,14 +46,11 @@ const Duration _calendarSettledFetchDelay = Duration(milliseconds: 500);
 
 // PageControllerをキャッシュするプロバイダー
 final calendarPageControllerProvider = Provider<PageController>((ref) {
-  // 現在のインデックスを取得
-  final currentIndex = ref.watch(calendarCurrentIndexProvider);
-
-  // PageControllerを作成（ページ切り替えアニメーション速度を最適化）
+  // PageViewは前月/当月/翌月の3ページだけを持ち、中央ページを基準にする。
   final controller = PageController(
-    initialPage: currentIndex,
+    initialPage: _calendarCenterPage,
     viewportFraction: 1.0,
-    keepPage: true,
+    keepPage: false,
   );
 
   // PageControllerが破棄されるときの処理
@@ -66,6 +63,8 @@ final calendarPageControllerProvider = Provider<PageController>((ref) {
 
 // 画面幅に対してこの割合だけ横に動いたら、低速ドラッグでも月送りとして扱う
 const double _calendarPageTurnThreshold = 0.07;
+const int _calendarCenterPage = 1;
+const List<int> _calendarWindowPageOffsets = [-1, 0, 1];
 
 /// カレンダーの横スワイプ向けに、短い低速ドラッグでも前後月へスナップする物理挙動。
 class CalendarPageScrollPhysics extends PageScrollPhysics {
@@ -212,10 +211,10 @@ void _cacheCalendarMonthSchedulesInProvider({
 }
 
 // 何ヶ月先のデータまで先読みするか
-const int _prefetchMonthsRange = 2;
+const int _prefetchMonthsRange = 1;
 
 // 事前にレンダリングする月の数（前後_preRenderMonthsRange月）
-const int _preRenderMonthsRange = 2;
+const int _preRenderMonthsRange = 1;
 
 // 表示されていない月のページをクリアする間隔
 const int _cleanupIntervalMillis = 60000; // 1分
@@ -239,7 +238,6 @@ class CalendarPageView extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final currentIndexValue = ref.watch(calendarCurrentIndexProvider);
     final activeMonthIndices = ref.watch(activeMonthIndicesProvider);
-    final renderedMonths = ref.watch(renderedMonthsProvider);
     bool isMounted() => context.mounted;
 
     final visibleDateTime = _getVisibleDateTime(currentIndexValue);
@@ -398,6 +396,35 @@ class CalendarPageView extends HookConsumerWidget {
       _scheduleCleanup(ref, index, isMounted);
     }
 
+    int absoluteIndexForWindowPage(int page) {
+      if (page < 0) {
+        return currentIndexValue - 1;
+      }
+      if (page > 2) {
+        return currentIndexValue + 1;
+      }
+      return currentIndexValue + page - _calendarCenterPage;
+    }
+
+    void resetPageControllerToCenter() {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!isMounted()) {
+          return;
+        }
+        if (!pageController.hasClients) {
+          return;
+        }
+        try {
+          final currentPage = pageController.page?.round();
+          if (currentPage != _calendarCenterPage) {
+            pageController.jumpToPage(_calendarCenterPage);
+          }
+        } catch (e) {
+          AppLogger.error('中央ページ復帰エラー: $e');
+        }
+      });
+    }
+
     void commitPageChange(
       int index, {
       required bool updateCacheWindow,
@@ -412,15 +439,7 @@ class CalendarPageView extends HookConsumerWidget {
             ref.read(calendarCurrentIndexProvider.notifier).update(safeIndex);
           }
 
-          Future.delayed(const Duration(milliseconds: 50), () {
-            if (pageController.hasClients) {
-              try {
-                pageController.jumpToPage(safeIndex);
-              } catch (e) {
-                AppLogger.error('ページジャンプエラー: $e');
-              }
-            }
-          });
+          resetPageControllerToCenter();
 
           return;
         }
@@ -459,8 +478,8 @@ class CalendarPageView extends HookConsumerWidget {
             final currentPage = pageController.page?.round() ?? -1;
 
             // ページが期待値と異なる場合は修正
-            if (currentPage != currentIndexValue && currentPage != -1) {
-              pageController.jumpToPage(currentIndexValue);
+            if (currentPage != _calendarCenterPage && currentPage != -1) {
+              pageController.jumpToPage(_calendarCenterPage);
             }
 
             // 初期表示時に前後の月をレンダリング済みとしてマーク
@@ -611,7 +630,7 @@ class CalendarPageView extends HookConsumerWidget {
                   dragDistance.value = 0;
                   dragStartIndex.value = notification.dragDetails == null
                       ? null
-                      : pageController.page?.round() ?? currentIndexValue;
+                      : pageController.page?.round() ?? _calendarCenterPage;
 
                   // スクロール中は最適化モードを有効にして軽量レンダリング
                   if (ref.exists(calendarOptimizationProvider)) {
@@ -631,9 +650,7 @@ class CalendarPageView extends HookConsumerWidget {
                   if (dragDistance.value.abs() >= dragThreshold) {
                     final targetPage = dragStartIndex.value! +
                         (dragDistance.value < 0 ? 1 : -1);
-                    if (targetPage >= 800 && targetPage <= 1600) {
-                      pendingPageTarget.value = targetPage;
-                    }
+                    pendingPageTarget.value = targetPage.clamp(0, 2).toInt();
                   }
                 }
                 // スクロール終了時
@@ -649,10 +666,14 @@ class CalendarPageView extends HookConsumerWidget {
                   pendingPageChangedIndex.value = null;
 
                   if (settledIndex != null) {
+                    final nextIndex = absoluteIndexForWindowPage(settledIndex);
                     commitPageChange(
-                      settledIndex,
+                      nextIndex,
                       updateCacheWindow: false,
                     );
+                    if (settledIndex != _calendarCenterPage) {
+                      resetPageControllerToCenter();
+                    }
                   }
 
                   // タイマーをキャンセルして再設定
@@ -676,7 +697,7 @@ class CalendarPageView extends HookConsumerWidget {
                 }
                 return false;
               },
-              child: PageView.builder(
+              child: PageView(
                 controller: pageController,
                 physics: CalendarPageScrollPhysics(
                   pageTarget: () => pendingPageTarget.value,
@@ -685,73 +706,17 @@ class CalendarPageView extends HookConsumerWidget {
                 allowImplicitScrolling: true,
                 // スクロール開始時に最適化モードを有効化
                 dragStartBehavior: DragStartBehavior.start,
-                itemBuilder: (context, index) {
-                  // インデックスが事前レンダリング範囲外で未レンダリングの場合は空のプレースホルダーを表示
-                  final isPreRendered =
-                      (index >= currentIndexValue - _preRenderMonthsRange &&
-                          index <= currentIndexValue + _preRenderMonthsRange);
-                  final isAlreadyRendered = renderedMonths.contains(index);
-
-                  if (!isPreRendered && !isAlreadyRendered) {
-                    // 事前レンダリング範囲外で未レンダリングの場合は時間差でレンダリングをスケジュール
-                    Future.delayed(const Duration(milliseconds: 100), () {
-                      if (!isMounted()) {
-                        return;
-                      }
-                      if (_isSliding) {
-                        return;
-                      }
-                      if (ref.exists(renderedMonthsProvider)) {
-                        final current = ref.read(renderedMonthsProvider);
-                        if (!current.contains(index)) {
-                          ref.read(renderedMonthsProvider.notifier).state = {
-                            ...current,
-                            index
-                          };
-                        }
-                      }
-                    });
-
-                    // 軽量なプレースホルダーを表示
-                    return CalendarPlaceholder(
-                      key: ValueKey('calendar_placeholder_$index'),
-                      index: index,
-                    );
-                  }
-
-                  final dateTime = _getVisibleDateTime(index);
-                  final monthKey = getMonthKey(dateTime);
-                  final pageSchedules = currentUserId == null
-                      ? const <Schedule>[]
-                      : getCalendarPageSchedules(
-                          userId: currentUserId,
-                          visibleMonth: dateTime,
-                          scheduleMemoryCache: scheduleMemoryCache,
-                          providerMonthSchedules: providerMonthSchedules,
-                        );
-
-                  // アクティブな範囲内のページにキープアライブを適用
-                  final shouldCache = activeMonthIndices.contains(index);
-
-                  // キーを追加して再構築を防止
-                  return RepaintBoundary(
-                    child: shouldCache
-                        ? KeepAliveCalendarPage(
-                            key: ValueKey(
-                                'calendar_page_${dateTime.year}_${dateTime.month}'),
-                            visiblePageDate: dateTime,
-                            monthKey: monthKey,
-                            schedules: pageSchedules,
-                          )
-                        : CalendarPageFrame(
-                            key: ValueKey(
-                                'calendar_page_${dateTime.year}_${dateTime.month}'),
-                            visiblePageDate: dateTime,
-                            monthKey: monthKey,
-                            schedules: pageSchedules,
-                          ),
-                  );
-                },
+                children: [
+                  for (final pageOffset in _calendarWindowPageOffsets)
+                    _buildCalendarWindowPage(
+                      userId: currentUserId,
+                      centerIndex: currentIndexValue,
+                      pageIndex: currentIndexValue + pageOffset,
+                      scheduleMemoryCache: scheduleMemoryCache,
+                      providerMonthSchedules: providerMonthSchedules,
+                      activeMonthIndices: activeMonthIndices,
+                    ),
+                ],
                 onPageChanged: (index) {
                   if (_isSliding) {
                     pendingPageChangedIndex.value = index;
@@ -759,18 +724,60 @@ class CalendarPageView extends HookConsumerWidget {
                   }
 
                   // ビルド中に状態を変更しないよう、非同期処理で実行
-                  Future.microtask(
-                    () => commitPageChange(
-                      index,
+                  Future.microtask(() {
+                    final nextIndex = absoluteIndexForWindowPage(index);
+                    commitPageChange(
+                      nextIndex,
                       updateCacheWindow: true,
-                    ),
-                  );
+                    );
+                    if (index != _calendarCenterPage) {
+                      resetPageControllerToCenter();
+                    }
+                  });
                 },
               ),
             ),
           ),
         ],
       ),
+    );
+  }
+
+  Widget _buildCalendarWindowPage({
+    required String? userId,
+    required int centerIndex,
+    required int pageIndex,
+    required Map<String, List<Schedule>> scheduleMemoryCache,
+    required Map<String, List<Schedule>> providerMonthSchedules,
+    required Set<int> activeMonthIndices,
+  }) {
+    final dateTime = _getVisibleDateTime(pageIndex);
+    final monthKey = getMonthKey(dateTime);
+    final pageSchedules = userId == null
+        ? const <Schedule>[]
+        : getCalendarPageSchedules(
+            userId: userId,
+            visibleMonth: dateTime,
+            scheduleMemoryCache: scheduleMemoryCache,
+            providerMonthSchedules: providerMonthSchedules,
+          );
+    final shouldCache = activeMonthIndices.contains(pageIndex) ||
+        (pageIndex - centerIndex).abs() <= _preRenderMonthsRange;
+
+    return RepaintBoundary(
+      child: shouldCache
+          ? KeepAliveCalendarPage(
+              key: ValueKey('calendar_page_${dateTime.year}_${dateTime.month}'),
+              visiblePageDate: dateTime,
+              monthKey: monthKey,
+              schedules: pageSchedules,
+            )
+          : CalendarPageFrame(
+              key: ValueKey('calendar_page_${dateTime.year}_${dateTime.month}'),
+              visiblePageDate: dateTime,
+              monthKey: monthKey,
+              schedules: pageSchedules,
+            ),
     );
   }
 

--- a/lib/presentation/calendar/widgets/calendar_page_view.dart
+++ b/lib/presentation/calendar/widgets/calendar_page_view.dart
@@ -129,16 +129,65 @@ final holidaysProvider = FutureProvider<Map<String, String>>((ref) async {
 // 事前にキャッシュする祝日データを管理するプロバイダー
 final cachedHolidaysProvider = StateProvider<Map<String, String>>((ref) => {});
 
+final calendarMonthScheduleMemoryCacheProvider =
+    StateProvider<Map<String, List<Schedule>>>((ref) => {});
+
 // カレンダー表示用の月キーを生成
 String getMonthKey(DateTime date) {
   return '${date.year}-${date.month.toString().padLeft(2, '0')}';
+}
+
+String getCalendarMonthScheduleCacheKey(String userId, DateTime date) {
+  return '$userId:${getMonthKey(date)}';
+}
+
+Map<String, List<Schedule>> cacheCalendarMonthSchedules({
+  required Map<String, List<Schedule>> currentCache,
+  required String cacheKey,
+  required List<Schedule>? schedules,
+}) {
+  if (schedules == null) {
+    return currentCache;
+  }
+
+  if (identical(currentCache[cacheKey], schedules)) {
+    return currentCache;
+  }
+
+  return {
+    ...currentCache,
+    cacheKey: schedules,
+  };
+}
+
+void _cacheCalendarMonthSchedulesInProvider({
+  required WidgetRef ref,
+  required String cacheKey,
+  required List<Schedule>? schedules,
+}) {
+  if (schedules == null ||
+      !ref.exists(calendarMonthScheduleMemoryCacheProvider)) {
+    return;
+  }
+
+  final currentCache = ref.read(calendarMonthScheduleMemoryCacheProvider);
+  final nextCache = cacheCalendarMonthSchedules(
+    currentCache: currentCache,
+    cacheKey: cacheKey,
+    schedules: schedules,
+  );
+  if (identical(nextCache, currentCache)) {
+    return;
+  }
+
+  ref.read(calendarMonthScheduleMemoryCacheProvider.notifier).state = nextCache;
 }
 
 // 何ヶ月先のデータまで先読みするか
 const int _prefetchMonthsRange = 2;
 
 // スケジュールデータとして先読みする前後月の範囲
-const int _schedulePrefetchMonthsRange = 1;
+const int _schedulePrefetchMonthsRange = 2;
 
 // 事前にレンダリングする月の数（前後_preRenderMonthsRange月）
 const int _preRenderMonthsRange = 2;
@@ -182,6 +231,24 @@ class CalendarPageView extends HookConsumerWidget {
               ),
             ),
           );
+    final visibleMonthScheduleCacheKey = currentUserId == null
+        ? null
+        : getCalendarMonthScheduleCacheKey(currentUserId, visibleDateTime);
+    final visibleCachedSchedules = ref.watch(
+      calendarMonthScheduleMemoryCacheProvider.select(
+        (cache) => visibleMonthScheduleCacheKey == null
+            ? null
+            : cache[visibleMonthScheduleCacheKey],
+      ),
+    );
+    final monthScheduleCacheInputs =
+        <({String cacheKey, List<Schedule>? schedules})>[];
+    if (currentUserId != null && visibleMonthScheduleCacheKey != null) {
+      monthScheduleCacheInputs.add((
+        cacheKey: visibleMonthScheduleCacheKey,
+        schedules: visibleMonthSchedules.valueOrNull,
+      ));
+    }
     if (currentUserId != null) {
       for (int offset = -_schedulePrefetchMonthsRange;
           offset <= _schedulePrefetchMonthsRange;
@@ -190,16 +257,22 @@ class CalendarPageView extends HookConsumerWidget {
           continue;
         }
 
-        ref.watch(
-          calendarMonthSchedulesProvider(
-            (
-              userId: currentUserId,
-              displayMonth: DateTime(
-                visibleDateTime.year,
-                visibleDateTime.month + offset,
-                1,
-              ),
-            ),
+        final prefetchMonth = DateTime(
+          visibleDateTime.year,
+          visibleDateTime.month + offset,
+          1,
+        );
+        final prefetchSchedules = ref.watch(
+          calendarMonthSchedulesProvider((
+            userId: currentUserId,
+            displayMonth: prefetchMonth,
+          )),
+        );
+        monthScheduleCacheInputs.add(
+          (
+            cacheKey:
+                getCalendarMonthScheduleCacheKey(currentUserId, prefetchMonth),
+            schedules: prefetchSchedules.valueOrNull,
           ),
         );
       }
@@ -240,6 +313,32 @@ class CalendarPageView extends HookConsumerWidget {
         _cleanupTimer = null;
       };
     }, []);
+
+    useEffect(() {
+      if (monthScheduleCacheInputs.isEmpty) {
+        return null;
+      }
+
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!isMounted()) {
+          return;
+        }
+
+        for (final input in monthScheduleCacheInputs) {
+          _cacheCalendarMonthSchedulesInProvider(
+            ref: ref,
+            cacheKey: input.cacheKey,
+            schedules: input.schedules,
+          );
+        }
+      });
+
+      return null;
+    }, [
+      currentUserId,
+      visibleDateTime,
+      for (final input in monthScheduleCacheInputs) input.schedules,
+    ]);
 
     void updateMonthCacheWindow(int index) {
       if (ref.exists(holidaysProvider) && ref.exists(cachedHolidaysProvider)) {
@@ -478,8 +577,9 @@ class CalendarPageView extends HookConsumerWidget {
           // ローディングインジケーター（現在表示中の月のデータ読み込み状態を表示）
           Consumer(
             builder: (context, ref, child) {
-              final isLoading =
-                  currentUserId != null && visibleMonthSchedules.isLoading;
+              final isLoading = currentUserId != null &&
+                  visibleMonthSchedules.isLoading &&
+                  visibleCachedSchedules == null;
               return isLoading
                   ? const LinearProgressIndicator(
                       backgroundColor: Colors.transparent,
@@ -945,11 +1045,52 @@ class CalendarPageContent extends HookConsumerWidget {
               ),
             ),
           );
+    final scheduleCacheKey = currentUserId == null
+        ? null
+        : getCalendarMonthScheduleCacheKey(currentUserId, visiblePageDate);
+    final cachedSchedules = ref.watch(
+      calendarMonthScheduleMemoryCacheProvider.select(
+        (cache) => scheduleCacheKey == null ? null : cache[scheduleCacheKey],
+      ),
+    );
+    final latestSchedules = schedulesAsync.valueOrNull;
+
+    useEffect(() {
+      if (scheduleCacheKey == null || latestSchedules == null) {
+        return null;
+      }
+
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!context.mounted ||
+            !ref.exists(calendarMonthScheduleMemoryCacheProvider)) {
+          return;
+        }
+
+        final currentCache = ref.read(calendarMonthScheduleMemoryCacheProvider);
+        if (identical(currentCache[scheduleCacheKey], latestSchedules)) {
+          return;
+        }
+
+        final nextCache = cacheCalendarMonthSchedules(
+          currentCache: currentCache,
+          cacheKey: scheduleCacheKey,
+          schedules: latestSchedules,
+        );
+        if (identical(nextCache, currentCache)) {
+          return;
+        }
+
+        ref.read(calendarMonthScheduleMemoryCacheProvider.notifier).state =
+            nextCache;
+      });
+
+      return null;
+    }, [scheduleCacheKey, latestSchedules]);
 
     // メモ化して再計算を防止
     final currentDates =
         useMemoized(() => _getCurrentDates(visiblePageDate), [visiblePageDate]);
-    final schedules = schedulesAsync.valueOrNull ?? const <Schedule>[];
+    final schedules = latestSchedules ?? cachedSchedules ?? const <Schedule>[];
 
     // 日付ごとにスケジュールをフィルタリング（最適化）- 高速アルゴリズムを使用
     final dateSchedulesMap = useMemoized(() {

--- a/lib/presentation/calendar/widgets/calendar_page_view.dart
+++ b/lib/presentation/calendar/widgets/calendar_page_view.dart
@@ -668,6 +668,7 @@ class CalendarPageView extends HookConsumerWidget {
                   pageTarget: () => pendingPageTarget.value,
                 ),
                 pageSnapping: false,
+                allowImplicitScrolling: true,
                 // スクロール開始時に最適化モードを有効化
                 dragStartBehavior: DragStartBehavior.start,
                 itemBuilder: (context, index) {

--- a/lib/presentation/calendar/widgets/calendar_page_view.dart
+++ b/lib/presentation/calendar/widgets/calendar_page_view.dart
@@ -154,11 +154,19 @@ List<Schedule> getCalendarPageSchedules({
   required String userId,
   required DateTime visibleMonth,
   required Map<String, List<Schedule>> scheduleMemoryCache,
+  Map<String, List<Schedule>> providerMonthSchedules = const {},
 }) {
-  return [
-    for (final month in getCalendarSchedulePrefetchMonths(visibleMonth))
-      ...?scheduleMemoryCache[getCalendarMonthScheduleCacheKey(userId, month)],
-  ];
+  final schedules = <Schedule>[];
+  for (final month in getCalendarSchedulePrefetchMonths(visibleMonth)) {
+    final cacheKey = getCalendarMonthScheduleCacheKey(userId, month);
+    final monthSchedules = providerMonthSchedules.containsKey(cacheKey)
+        ? providerMonthSchedules[cacheKey]
+        : scheduleMemoryCache[cacheKey];
+    if (monthSchedules != null) {
+      schedules.addAll(monthSchedules);
+    }
+  }
+  return schedules;
 }
 
 Map<String, List<Schedule>> cacheCalendarMonthSchedules({
@@ -253,6 +261,7 @@ class CalendarPageView extends HookConsumerWidget {
     );
     final monthScheduleCacheInputs =
         <({String cacheKey, List<Schedule>? schedules})>[];
+    final providerMonthSchedules = <String, List<Schedule>>{};
     if (currentUserId != null && visibleMonthScheduleCacheKey != null) {
       for (final prefetchMonth
           in getCalendarSchedulePrefetchMonths(visibleDateTime)) {
@@ -260,15 +269,20 @@ class CalendarPageView extends HookConsumerWidget {
           userId: currentUserId,
           displayMonth: prefetchMonth,
         )));
+        final prefetchCacheKey =
+            getCalendarMonthScheduleCacheKey(currentUserId, prefetchMonth);
+        final prefetchScheduleValues = prefetchSchedules.valueOrNull;
         if (prefetchMonth.year == visibleDateTime.year &&
             prefetchMonth.month == visibleDateTime.month) {
           visibleMonthSchedules = prefetchSchedules;
         }
+        if (prefetchSchedules.hasValue && prefetchScheduleValues != null) {
+          providerMonthSchedules[prefetchCacheKey] = prefetchScheduleValues;
+        }
         monthScheduleCacheInputs.add(
           (
-            cacheKey:
-                getCalendarMonthScheduleCacheKey(currentUserId, prefetchMonth),
-            schedules: prefetchSchedules.valueOrNull,
+            cacheKey: prefetchCacheKey,
+            schedules: prefetchScheduleValues,
           ),
         );
       }
@@ -713,6 +727,7 @@ class CalendarPageView extends HookConsumerWidget {
                           userId: currentUserId,
                           visibleMonth: dateTime,
                           scheduleMemoryCache: scheduleMemoryCache,
+                          providerMonthSchedules: providerMonthSchedules,
                         );
 
                   // アクティブな範囲内のページにキープアライブを適用

--- a/lib/presentation/calendar/widgets/calendar_page_view.dart
+++ b/lib/presentation/calendar/widgets/calendar_page_view.dart
@@ -141,6 +141,15 @@ String getCalendarMonthScheduleCacheKey(String userId, DateTime date) {
   return '$userId:${getMonthKey(date)}';
 }
 
+List<DateTime> getCalendarSchedulePrefetchMonths(DateTime visibleMonth) {
+  final month = DateTime(visibleMonth.year, visibleMonth.month);
+  return [
+    DateTime(month.year, month.month - 1),
+    month,
+    DateTime(month.year, month.month + 1),
+  ];
+}
+
 Map<String, List<Schedule>> cacheCalendarMonthSchedules({
   required Map<String, List<Schedule>> currentCache,
   required String cacheKey,
@@ -186,9 +195,6 @@ void _cacheCalendarMonthSchedulesInProvider({
 // 何ヶ月先のデータまで先読みするか
 const int _prefetchMonthsRange = 2;
 
-// スケジュールデータとして先読みする前後月の範囲
-const int _schedulePrefetchMonthsRange = 2;
-
 // 事前にレンダリングする月の数（前後_preRenderMonthsRange月）
 const int _preRenderMonthsRange = 2;
 
@@ -221,16 +227,9 @@ class CalendarPageView extends HookConsumerWidget {
     final visibleMonth = _getMonthName(visibleDateTime.month);
     final visibleYear = visibleDateTime.year.toString();
     final currentUserId = ref.watch(currentUserIdProvider);
-    final visibleMonthSchedules = currentUserId == null
-        ? const AsyncValue<List<Schedule>>.data([])
-        : ref.watch(
-            calendarMonthSchedulesProvider(
-              (
-                userId: currentUserId,
-                displayMonth: visibleDateTime,
-              ),
-            ),
-          );
+    final scheduleMemoryCache =
+        ref.watch(calendarMonthScheduleMemoryCacheProvider);
+    var visibleMonthSchedules = const AsyncValue<List<Schedule>>.data([]);
     final visibleMonthScheduleCacheKey = currentUserId == null
         ? null
         : getCalendarMonthScheduleCacheKey(currentUserId, visibleDateTime);
@@ -244,30 +243,16 @@ class CalendarPageView extends HookConsumerWidget {
     final monthScheduleCacheInputs =
         <({String cacheKey, List<Schedule>? schedules})>[];
     if (currentUserId != null && visibleMonthScheduleCacheKey != null) {
-      monthScheduleCacheInputs.add((
-        cacheKey: visibleMonthScheduleCacheKey,
-        schedules: visibleMonthSchedules.valueOrNull,
-      ));
-    }
-    if (currentUserId != null) {
-      for (int offset = -_schedulePrefetchMonthsRange;
-          offset <= _schedulePrefetchMonthsRange;
-          offset++) {
-        if (offset == 0) {
-          continue;
+      for (final prefetchMonth
+          in getCalendarSchedulePrefetchMonths(visibleDateTime)) {
+        final prefetchSchedules = ref.watch(calendarMonthSchedulesProvider((
+          userId: currentUserId,
+          displayMonth: prefetchMonth,
+        )));
+        if (prefetchMonth.year == visibleDateTime.year &&
+            prefetchMonth.month == visibleDateTime.month) {
+          visibleMonthSchedules = prefetchSchedules;
         }
-
-        final prefetchMonth = DateTime(
-          visibleDateTime.year,
-          visibleDateTime.month + offset,
-          1,
-        );
-        final prefetchSchedules = ref.watch(
-          calendarMonthSchedulesProvider((
-            userId: currentUserId,
-            displayMonth: prefetchMonth,
-          )),
-        );
         monthScheduleCacheInputs.add(
           (
             cacheKey:
@@ -710,6 +695,16 @@ class CalendarPageView extends HookConsumerWidget {
 
                   final dateTime = _getVisibleDateTime(index);
                   final monthKey = getMonthKey(dateTime);
+                  final pageScheduleCacheKey = currentUserId == null
+                      ? null
+                      : getCalendarMonthScheduleCacheKey(
+                          currentUserId,
+                          dateTime,
+                        );
+                  final pageSchedules = currentUserId == null
+                      ? const <Schedule>[]
+                      : scheduleMemoryCache[pageScheduleCacheKey] ??
+                          const <Schedule>[];
 
                   // アクティブな範囲内のページにキープアライブを適用
                   final shouldCache = activeMonthIndices.contains(index);
@@ -722,12 +717,14 @@ class CalendarPageView extends HookConsumerWidget {
                                 'calendar_page_${dateTime.year}_${dateTime.month}'),
                             visiblePageDate: dateTime,
                             monthKey: monthKey,
+                            schedules: pageSchedules,
                           )
                         : CalendarPageFrame(
                             key: ValueKey(
                                 'calendar_page_${dateTime.year}_${dateTime.month}'),
                             visiblePageDate: dateTime,
                             monthKey: monthKey,
+                            schedules: pageSchedules,
                           ),
                   );
                 },
@@ -870,17 +867,20 @@ class CalendarPageFrame extends StatelessWidget {
   const CalendarPageFrame({
     required this.visiblePageDate,
     required this.monthKey,
+    this.schedules = const [],
     super.key,
   });
 
   final DateTime visiblePageDate;
   final String monthKey;
+  final List<Schedule> schedules;
 
   @override
   Widget build(BuildContext context) {
     return CalendarPageContent(
       visiblePageDate: visiblePageDate,
       monthKey: monthKey,
+      schedules: schedules,
     );
   }
 }
@@ -890,11 +890,13 @@ class KeepAliveCalendarPage extends StatefulWidget {
   const KeepAliveCalendarPage({
     required this.visiblePageDate,
     required this.monthKey,
+    this.schedules = const [],
     super.key,
   });
 
   final DateTime visiblePageDate;
   final String monthKey;
+  final List<Schedule> schedules;
 
   @override
   State<KeepAliveCalendarPage> createState() => _KeepAliveCalendarPageState();
@@ -912,6 +914,7 @@ class _KeepAliveCalendarPageState extends State<KeepAliveCalendarPage>
     return CalendarPageContent(
       visiblePageDate: widget.visiblePageDate,
       monthKey: widget.monthKey,
+      schedules: widget.schedules,
     );
   }
 }
@@ -921,11 +924,13 @@ class CalendarPageContent extends HookConsumerWidget {
   const CalendarPageContent({
     required this.visiblePageDate,
     required this.monthKey,
+    this.schedules = const [],
     super.key,
   });
 
   final DateTime visiblePageDate;
   final String monthKey;
+  final List<Schedule> schedules;
 
   List<DateTime> _getCurrentDates(DateTime dateTime) {
     final List<DateTime> result = [];
@@ -1034,63 +1039,10 @@ class CalendarPageContent extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     // 最適化モードの取得
     final isOptimized = ref.watch(calendarOptimizationProvider);
-    final currentUserId = ref.watch(currentUserIdProvider);
-    final schedulesAsync = currentUserId == null
-        ? const AsyncValue<List<Schedule>>.data([])
-        : ref.watch(
-            calendarMonthSchedulesProvider(
-              (
-                userId: currentUserId,
-                displayMonth: visiblePageDate,
-              ),
-            ),
-          );
-    final scheduleCacheKey = currentUserId == null
-        ? null
-        : getCalendarMonthScheduleCacheKey(currentUserId, visiblePageDate);
-    final cachedSchedules = ref.watch(
-      calendarMonthScheduleMemoryCacheProvider.select(
-        (cache) => scheduleCacheKey == null ? null : cache[scheduleCacheKey],
-      ),
-    );
-    final latestSchedules = schedulesAsync.valueOrNull;
-
-    useEffect(() {
-      if (scheduleCacheKey == null || latestSchedules == null) {
-        return null;
-      }
-
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (!context.mounted ||
-            !ref.exists(calendarMonthScheduleMemoryCacheProvider)) {
-          return;
-        }
-
-        final currentCache = ref.read(calendarMonthScheduleMemoryCacheProvider);
-        if (identical(currentCache[scheduleCacheKey], latestSchedules)) {
-          return;
-        }
-
-        final nextCache = cacheCalendarMonthSchedules(
-          currentCache: currentCache,
-          cacheKey: scheduleCacheKey,
-          schedules: latestSchedules,
-        );
-        if (identical(nextCache, currentCache)) {
-          return;
-        }
-
-        ref.read(calendarMonthScheduleMemoryCacheProvider.notifier).state =
-            nextCache;
-      });
-
-      return null;
-    }, [scheduleCacheKey, latestSchedules]);
 
     // メモ化して再計算を防止
     final currentDates =
         useMemoized(() => _getCurrentDates(visiblePageDate), [visiblePageDate]);
-    final schedules = latestSchedules ?? cachedSchedules ?? const <Schedule>[];
 
     // 日付ごとにスケジュールをフィルタリング（最適化）- 高速アルゴリズムを使用
     final dateSchedulesMap = useMemoized(() {

--- a/test/domain/value/schedule_month_range_test.dart
+++ b/test/domain/value/schedule_month_range_test.dart
@@ -3,18 +3,18 @@ import 'package:lakiite/domain/value/schedule_month_range.dart';
 
 void main() {
   group('ScheduleMonthRange', () {
-    test('表示月の前月月初から翌々月月初直前までを取得範囲にする', () {
+    test('表示月の月初から翌月月初直前までを取得範囲にする', () {
       final range = ScheduleMonthRange.forDisplayMonth(DateTime(2026, 3, 20));
 
-      expect(range.startInclusive, DateTime(2026, 2, 1));
-      expect(range.endExclusive, DateTime(2026, 5, 1));
+      expect(range.startInclusive, DateTime(2026, 3, 1));
+      expect(range.endExclusive, DateTime(2026, 4, 1));
     });
 
     test('Firestore のISO文字列として月範囲境界を表現する', () {
       final range = ScheduleMonthRange.forDisplayMonth(DateTime(2026, 1, 31));
 
-      expect(range.startInclusiveIso, '2025-12-01T00:00:00.000');
-      expect(range.endExclusiveIso, '2026-03-01T00:00:00.000');
+      expect(range.startInclusiveIso, '2026-01-01T00:00:00.000');
+      expect(range.endExclusiveIso, '2026-02-01T00:00:00.000');
     });
   });
 }

--- a/test/mock/repository/mock_schedule_repository.dart
+++ b/test/mock/repository/mock_schedule_repository.dart
@@ -7,6 +7,7 @@ class MockScheduleRepository extends BaseMock implements IScheduleRepository {
   bool _shouldFailSave = false;
   bool _shouldFailDelete = false;
   bool _shouldFailGet = false;
+  int watchUserSchedulesForMonthCallCount = 0;
 
   void setShouldFailSave(bool shouldFail) {
     _shouldFailSave = shouldFail;
@@ -117,6 +118,7 @@ class MockScheduleRepository extends BaseMock implements IScheduleRepository {
   @override
   Stream<List<Schedule>> watchUserSchedulesForMonth(
       String userId, DateTime displayMonth) {
+    watchUserSchedulesForMonthCallCount++;
     return Stream.periodic(const Duration(milliseconds: 100), (_) {
       return _schedules.where((s) {
         return s.ownerId == userId &&
@@ -143,5 +145,6 @@ class MockScheduleRepository extends BaseMock implements IScheduleRepository {
     _shouldFailSave = false;
     _shouldFailDelete = false;
     _shouldFailGet = false;
+    watchUserSchedulesForMonthCallCount = 0;
   }
 }

--- a/test/presentation/calendar/calendar_month_schedule_cache_test.dart
+++ b/test/presentation/calendar/calendar_month_schedule_cache_test.dart
@@ -1,9 +1,21 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lakiite/domain/entity/schedule.dart';
 import 'package:lakiite/presentation/calendar/widgets/calendar_page_view.dart';
 
+import '../../mock/providers/test_providers.dart';
+import '../../utils/test_utils.dart';
+
 void main() {
   group('calendar month schedule cache', () {
+    setUp(() {
+      TestProviders.reset();
+    });
+
+    tearDown(() {
+      TestProviders.reset();
+    });
+
     test('先読み済みの月予定を月別キャッシュへ保存する', () {
       final schedules = [
         _schedule(
@@ -41,6 +53,37 @@ void main() {
       );
 
       expect(cache, same(currentCache));
+    });
+
+    test('取得対象は表示月と前後1ヶ月の3ヶ月だけにする', () {
+      final months = getCalendarSchedulePrefetchMonths(DateTime(2026, 5, 30));
+
+      expect(months, [
+        DateTime(2026, 4),
+        DateTime(2026, 5),
+        DateTime(2026, 6),
+      ]);
+    });
+
+    testWidgets('月ページ本体は予定Providerを購読しない', (tester) async {
+      final overrides = TestProviders.authenticated;
+      final scheduleRepository = TestProviders.mockScheduleRepository;
+
+      await tester.pumpWidget(
+        TestUtils.createTestApp(
+          overrides: overrides,
+          child: Scaffold(
+            body: CalendarPageContent(
+              visiblePageDate: DateTime(2026, 5),
+              monthKey: '2026-05',
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 150));
+
+      expect(scheduleRepository.watchUserSchedulesForMonthCallCount, 0);
     });
   });
 }

--- a/test/presentation/calendar/calendar_month_schedule_cache_test.dart
+++ b/test/presentation/calendar/calendar_month_schedule_cache_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lakiite/domain/entity/schedule.dart';
+import 'package:lakiite/presentation/calendar/widgets/calendar_page_view.dart';
+
+void main() {
+  group('calendar month schedule cache', () {
+    test('先読み済みの月予定を月別キャッシュへ保存する', () {
+      final schedules = [
+        _schedule(
+          id: 'schedule-1',
+          title: '先読み予定',
+          startDateTime: DateTime(2026, 5, 30, 9),
+          endDateTime: DateTime(2026, 5, 30, 10),
+        ),
+      ];
+
+      final cache = cacheCalendarMonthSchedules(
+        currentCache: const {},
+        cacheKey: 'user-1:2026-05',
+        schedules: schedules,
+      );
+
+      expect(cache['user-1:2026-05'], same(schedules));
+    });
+
+    test('予定がまだ届いていない場合は既存キャッシュを維持する', () {
+      final existingSchedules = [
+        _schedule(
+          id: 'schedule-1',
+          title: '既存予定',
+          startDateTime: DateTime(2026, 5, 30, 9),
+          endDateTime: DateTime(2026, 5, 30, 10),
+        ),
+      ];
+      final currentCache = {'user-1:2026-05': existingSchedules};
+
+      final cache = cacheCalendarMonthSchedules(
+        currentCache: currentCache,
+        cacheKey: 'user-1:2026-05',
+        schedules: null,
+      );
+
+      expect(cache, same(currentCache));
+    });
+  });
+}
+
+Schedule _schedule({
+  required String id,
+  required String title,
+  required DateTime startDateTime,
+  required DateTime endDateTime,
+}) {
+  return Schedule(
+    id: id,
+    title: title,
+    description: '',
+    startDateTime: startDateTime,
+    endDateTime: endDateTime,
+    ownerId: 'user-1',
+    ownerDisplayName: 'User 1',
+    sharedLists: const [],
+    visibleTo: const ['user-1'],
+    createdAt: DateTime(2026, 5, 1),
+    updatedAt: DateTime(2026, 5, 1),
+  );
+}

--- a/test/presentation/calendar/calendar_month_schedule_cache_test.dart
+++ b/test/presentation/calendar/calendar_month_schedule_cache_test.dart
@@ -65,6 +65,47 @@ void main() {
       ]);
     });
 
+    test('月ページには表示月と前後1ヶ月のキャッシュを合成して渡す', () {
+      final aprilSchedule = _schedule(
+        id: 'april',
+        title: '4月予定',
+        startDateTime: DateTime(2026, 4, 30, 9),
+        endDateTime: DateTime(2026, 4, 30, 10),
+      );
+      final maySchedule = _schedule(
+        id: 'may',
+        title: '5月予定',
+        startDateTime: DateTime(2026, 5, 30, 9),
+        endDateTime: DateTime(2026, 5, 30, 10),
+      );
+      final juneSchedule = _schedule(
+        id: 'june',
+        title: '6月予定',
+        startDateTime: DateTime(2026, 6, 1, 9),
+        endDateTime: DateTime(2026, 6, 1, 10),
+      );
+
+      final schedules = getCalendarPageSchedules(
+        userId: 'user-1',
+        visibleMonth: DateTime(2026, 5),
+        scheduleMemoryCache: {
+          'user-1:2026-04': [aprilSchedule],
+          'user-1:2026-05': [maySchedule],
+          'user-1:2026-06': [juneSchedule],
+          'user-1:2026-07': [
+            _schedule(
+              id: 'july',
+              title: '7月予定',
+              startDateTime: DateTime(2026, 7, 1, 9),
+              endDateTime: DateTime(2026, 7, 1, 10),
+            ),
+          ],
+        },
+      );
+
+      expect(schedules, [aprilSchedule, maySchedule, juneSchedule]);
+    });
+
     testWidgets('月ページ本体は予定Providerを購読しない', (tester) async {
       final overrides = TestProviders.authenticated;
       final scheduleRepository = TestProviders.mockScheduleRepository;

--- a/test/presentation/calendar/calendar_month_schedule_cache_test.dart
+++ b/test/presentation/calendar/calendar_month_schedule_cache_test.dart
@@ -106,6 +106,34 @@ void main() {
       expect(schedules, [aprilSchedule, maySchedule, juneSchedule]);
     });
 
+    test('Providerの値がある月はキャッシュ更新前でもProvider値を優先して渡す', () {
+      final cachedMaySchedule = _schedule(
+        id: 'cached-may',
+        title: '古い5月予定',
+        startDateTime: DateTime(2026, 5, 30, 9),
+        endDateTime: DateTime(2026, 5, 30, 10),
+      );
+      final liveMaySchedule = _schedule(
+        id: 'live-may',
+        title: '最新5月予定',
+        startDateTime: DateTime(2026, 5, 30, 9),
+        endDateTime: DateTime(2026, 5, 30, 10),
+      );
+
+      final schedules = getCalendarPageSchedules(
+        userId: 'user-1',
+        visibleMonth: DateTime(2026, 5),
+        scheduleMemoryCache: {
+          'user-1:2026-05': [cachedMaySchedule],
+        },
+        providerMonthSchedules: {
+          'user-1:2026-05': [liveMaySchedule],
+        },
+      );
+
+      expect(schedules, [liveMaySchedule]);
+    });
+
     testWidgets('月ページ本体は予定Providerを購読しない', (tester) async {
       final overrides = TestProviders.authenticated;
       final scheduleRepository = TestProviders.mockScheduleRepository;

--- a/test/presentation/calendar/calendar_schedule_providers_test.dart
+++ b/test/presentation/calendar/calendar_schedule_providers_test.dart
@@ -259,7 +259,7 @@ void main() {
       authSubscription.close();
     });
 
-    test('calendarMonthSchedulesProvider は購読終了時にrepository購読を破棄する', () async {
+    test('calendarMonthSchedulesProvider は購読終了直後も短時間キャッシュを保持する', () async {
       final authSubscription = _listenAuthenticatedAuthState(
         container,
         mockAuthRepository,
@@ -284,7 +284,19 @@ void main() {
       await container.pump();
       await Future<void>.delayed(const Duration(milliseconds: 50));
 
-      expect(container.exists(provider), isFalse);
+      expect(container.exists(provider), isTrue);
+      expect(scheduleRepository.watchUserSchedulesForMonthCancelCount, 0);
+
+      final secondSubscription = container.listen(
+        provider,
+        (_, __) {},
+        fireImmediately: true,
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(scheduleRepository.watchUserSchedulesForMonthCallCount, 1);
+
+      secondSubscription.close();
       authSubscription.close();
     });
 

--- a/test/presentation/calendar/calendar_scroll_behavior_test.dart
+++ b/test/presentation/calendar/calendar_scroll_behavior_test.dart
@@ -61,7 +61,7 @@ void main() {
       expect(pageView.pageSnapping, isFalse);
     });
 
-    testWidgets('カレンダーは表示月の前後ページも事前に作成する', (tester) async {
+    testWidgets('カレンダーは表示月と前後月の3ページだけを固定作成する', (tester) async {
       await tester.pumpWidget(
         TestUtils.createTestApp(
           overrides: TestProviders.authenticated,
@@ -73,10 +73,14 @@ void main() {
       await tester.pump();
 
       final pageView = tester.widget<PageView>(find.byType(PageView));
+      final pageController = pageView.controller as PageController;
+
+      expect(pageController.initialPage, 1);
       expect(pageView.allowImplicitScrolling, isTrue);
+      expect(pageView.childrenDelegate, isA<SliverChildListDelegate>());
       expect(
         find.byType(CalendarPageContent, skipOffstage: false),
-        findsAtLeastNWidgets(3),
+        findsNWidgets(3),
       );
     });
 

--- a/test/presentation/calendar/calendar_scroll_behavior_test.dart
+++ b/test/presentation/calendar/calendar_scroll_behavior_test.dart
@@ -61,6 +61,25 @@ void main() {
       expect(pageView.pageSnapping, isFalse);
     });
 
+    testWidgets('カレンダーは表示月の前後ページも事前に作成する', (tester) async {
+      await tester.pumpWidget(
+        TestUtils.createTestApp(
+          overrides: TestProviders.authenticated,
+          child: const Scaffold(
+            body: CalendarPageView(),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final pageView = tester.widget<PageView>(find.byType(PageView));
+      expect(pageView.allowImplicitScrolling, isTrue);
+      expect(
+        find.byType(CalendarPageContent, skipOffstage: false),
+        findsAtLeastNWidgets(3),
+      );
+    });
+
     testWidgets('カレンダーは短めの低速スワイプでも前後の月へ移動する', (tester) async {
       await tester.pumpWidget(
         TestUtils.createTestApp(


### PR DESCRIPTION
## Summary
- keep calendar month schedule streams alive briefly after page changes
- reuse the existing month stream when users swipe away and quickly return
- update provider regression coverage so month schedules are not disposed immediately

## Verification
- fvm flutter test test/presentation/calendar/calendar_schedule_providers_test.dart test/presentation/calendar/calendar_scroll_behavior_test.dart test/presentation/calendar/month_calendar_schedule_cell_test.dart test/presentation/calendar/daily_all_day_schedule_list_test.dart
- fvm flutter analyze
- git diff --check
- Galaxy SCG19 (RFCW31S5JLJ) dev flavor: swiped month calendar from May 2026 to June 2026 and back, confirmed May schedules remained visible without blank reload