### PR TITLE
fix: refresh monthly calendar schedules

### DIFF
--- a/lib/domain/value/schedule_month_range.dart
+++ b/lib/domain/value/schedule_month_range.dart
@@ -2,8 +2,8 @@ import 'package:lakiite/domain/entity/schedule.dart';
 
 /// Firestore schedule queries for a displayed calendar month.
 ///
-/// The calendar renders leading and trailing days around the visible month, so
-/// the query intentionally covers the previous month through the next month.
+/// The calendar renders a fixed 6-week grid, including leading and trailing
+/// days around the visible month.
 class ScheduleMonthRange {
   const ScheduleMonthRange({
     required this.startInclusive,
@@ -12,16 +12,22 @@ class ScheduleMonthRange {
 
   /// Builds the calendar query window for [displayMonth].
   factory ScheduleMonthRange.forDisplayMonth(DateTime displayMonth) {
+    final firstDayOfMonth = DateTime(displayMonth.year, displayMonth.month, 1);
+    final leadingDays = firstDayOfMonth.weekday % DateTime.daysPerWeek;
+    final startInclusive = firstDayOfMonth.subtract(
+      Duration(days: leadingDays),
+    );
+
     return ScheduleMonthRange(
-      startInclusive: DateTime(displayMonth.year, displayMonth.month - 1, 1),
-      endExclusive: DateTime(displayMonth.year, displayMonth.month + 2, 1),
+      startInclusive: startInclusive,
+      endExclusive: startInclusive.add(const Duration(days: 42)),
     );
   }
 
-  /// First day of the previous month at midnight.
+  /// First day rendered in the 42-day calendar grid at midnight.
   final DateTime startInclusive;
 
-  /// First day of the month after next at midnight.
+  /// Day after the last rendered day in the 42-day calendar grid at midnight.
   final DateTime endExclusive;
 
   /// Firestore-compatible lower bound ISO string.

--- a/lib/domain/value/schedule_month_range.dart
+++ b/lib/domain/value/schedule_month_range.dart
@@ -1,3 +1,5 @@
+import 'package:lakiite/domain/entity/schedule.dart';
+
 /// Firestore schedule queries for a displayed calendar month.
 ///
 /// The calendar renders leading and trailing days around the visible month, so
@@ -27,6 +29,14 @@ class ScheduleMonthRange {
 
   /// Firestore-compatible upper bound ISO string.
   String get endExclusiveIso => _toFirestoreIso(endExclusive);
+
+  bool overlaps(Schedule schedule) {
+    final scheduleStart = schedule.startDateTime;
+    final scheduleEnd = schedule.endDateTime;
+
+    return scheduleStart.isBefore(endExclusive) &&
+        !scheduleEnd.isBefore(startInclusive);
+  }
 
   static String _toFirestoreIso(DateTime dateTime) {
     final year = dateTime.year.toString().padLeft(4, '0');

--- a/lib/infrastructure/schedule_enrichment_cache.dart
+++ b/lib/infrastructure/schedule_enrichment_cache.dart
@@ -1,0 +1,50 @@
+class ScheduleEnrichmentCache {
+  ScheduleEnrichmentCache({
+    Duration expiryDuration = const Duration(minutes: 10),
+  }) : _expiryDuration = expiryDuration;
+
+  final Duration _expiryDuration;
+  final Map<String, int> _reactionCountCache = {};
+  final Map<String, int> _commentCountCache = {};
+  final Map<String, DateTime> _lastUpdated = {};
+
+  ({int reactionCount, int commentCount})? getInteractionCounts(
+    String scheduleId,
+  ) {
+    final lastUpdated = _lastUpdated[scheduleId];
+    if (lastUpdated == null ||
+        DateTime.now().difference(lastUpdated) >= _expiryDuration) {
+      return null;
+    }
+
+    final reactionCount = _reactionCountCache[scheduleId];
+    final commentCount = _commentCountCache[scheduleId];
+    if (reactionCount == null || commentCount == null) {
+      return null;
+    }
+
+    return (reactionCount: reactionCount, commentCount: commentCount);
+  }
+
+  void storeInteractionCounts(
+    String scheduleId, {
+    required int reactionCount,
+    required int commentCount,
+  }) {
+    _reactionCountCache[scheduleId] = reactionCount;
+    _commentCountCache[scheduleId] = commentCount;
+    _lastUpdated[scheduleId] = DateTime.now();
+  }
+
+  void invalidateSchedule(String scheduleId) {
+    _reactionCountCache.remove(scheduleId);
+    _commentCountCache.remove(scheduleId);
+    _lastUpdated.remove(scheduleId);
+  }
+
+  void clear() {
+    _reactionCountCache.clear();
+    _commentCountCache.clear();
+    _lastUpdated.clear();
+  }
+}

--- a/lib/infrastructure/schedule_repository.dart
+++ b/lib/infrastructure/schedule_repository.dart
@@ -5,6 +5,7 @@ import '../domain/interfaces/i_schedule_repository.dart';
 import '../domain/value/schedule_month_range.dart';
 import '../utils/logger.dart';
 import 'mapper/schedule_mapper.dart';
+import 'schedule_enrichment_cache.dart';
 
 class ScheduleRepository implements IScheduleRepository {
   ScheduleRepository()
@@ -13,16 +14,7 @@ class ScheduleRepository implements IScheduleRepository {
   final FirebaseFirestore _firestore;
   final FirebaseAuth _auth;
 
-  // スケジュールのエンリッチメント結果をキャッシュ
-  final Map<String, Schedule> _scheduleCache = {};
-  // リアクション数のキャッシュ
-  final Map<String, int> _reactionCountCache = {};
-  // コメント数のキャッシュ
-  final Map<String, int> _commentCountCache = {};
-  // キャッシュの有効期限（10分）
-  static const _cacheExpiryDuration = Duration(minutes: 10);
-  // キャッシュの最終更新時間
-  final Map<String, DateTime> _cacheLastUpdated = {};
+  final ScheduleEnrichmentCache _enrichmentCache = ScheduleEnrichmentCache();
 
   Future<void> _ensureAuthenticated() async {
     // 認証の初期化を待つ
@@ -35,35 +27,13 @@ class ScheduleRepository implements IScheduleRepository {
     }
   }
 
-  // キャッシュが有効かどうかを確認
-  bool _isCacheValid(String scheduleId) {
-    if (!_cacheLastUpdated.containsKey(scheduleId)) {
-      return false;
-    }
-
-    final lastUpdated = _cacheLastUpdated[scheduleId]!;
-    final now = DateTime.now();
-    return now.difference(lastUpdated) < _cacheExpiryDuration;
-  }
-
-  // キャッシュを更新
-  void _updateCache(String scheduleId, Schedule schedule) {
-    _scheduleCache[scheduleId] = schedule;
-    _cacheLastUpdated[scheduleId] = DateTime.now();
-  }
-
   // リアクション数とコメント数を一括で取得（バッチ処理）
   Future<(int, int)> _fetchInteractionCounts(DocumentReference docRef) async {
     final scheduleId = docRef.id;
 
-    // キャッシュが有効な場合はキャッシュから返す
-    if (_isCacheValid(scheduleId) &&
-        _reactionCountCache.containsKey(scheduleId) &&
-        _commentCountCache.containsKey(scheduleId)) {
-      return (
-        _reactionCountCache[scheduleId]!,
-        _commentCountCache[scheduleId]!
-      );
+    final cachedCounts = _enrichmentCache.getInteractionCounts(scheduleId);
+    if (cachedCounts != null) {
+      return (cachedCounts.reactionCount, cachedCounts.commentCount);
     }
 
     // 並列でリアクション数とコメント数を取得
@@ -74,23 +44,17 @@ class ScheduleRepository implements IScheduleRepository {
     final reactionCount = results[0].count ?? 0;
     final commentCount = results[1].count ?? 0;
 
-    // キャッシュを更新
-    _reactionCountCache[scheduleId] = reactionCount;
-    _commentCountCache[scheduleId] = commentCount;
-    _cacheLastUpdated[scheduleId] = DateTime.now();
+    _enrichmentCache.storeInteractionCounts(
+      scheduleId,
+      reactionCount: reactionCount,
+      commentCount: commentCount,
+    );
 
     return (reactionCount, commentCount);
   }
 
   Future<Schedule> _enrichSchedule(DocumentSnapshot doc) async {
     await _ensureAuthenticated();
-
-    final scheduleId = doc.id;
-
-    // キャッシュが有効な場合はキャッシュから返す
-    if (_isCacheValid(scheduleId) && _scheduleCache.containsKey(scheduleId)) {
-      return _scheduleCache[scheduleId]!;
-    }
 
     try {
       // 基本的なスケジュール情報を取得
@@ -106,33 +70,22 @@ class ScheduleRepository implements IScheduleRepository {
         commentCount: commentCount,
       );
 
-      // キャッシュを更新
-      _updateCache(scheduleId, enrichedSchedule);
-
       return enrichedSchedule;
     } catch (e) {
       AppLogger.error('Error enriching schedule: $e');
       // エラーが発生した場合でも基本的なスケジュール情報は返す
-      final schedule = ScheduleMapper.fromFirestore(doc);
-      _updateCache(scheduleId, schedule);
-      return schedule;
+      return ScheduleMapper.fromFirestore(doc);
     }
   }
 
   // キャッシュをクリア（必要に応じて呼び出す）
   void clearCache() {
-    _scheduleCache.clear();
-    _reactionCountCache.clear();
-    _commentCountCache.clear();
-    _cacheLastUpdated.clear();
+    _enrichmentCache.clear();
   }
 
   // 特定のスケジュールのキャッシュを更新（更新があった場合など）
   void invalidateScheduleCache(String scheduleId) {
-    _scheduleCache.remove(scheduleId);
-    _reactionCountCache.remove(scheduleId);
-    _commentCountCache.remove(scheduleId);
-    _cacheLastUpdated.remove(scheduleId);
+    _enrichmentCache.invalidateSchedule(scheduleId);
   }
 
   @override
@@ -253,6 +206,7 @@ class ScheduleRepository implements IScheduleRepository {
 
       AppLogger.debug('Attempting to update document in Firestore');
       await _firestore.collection('schedules').doc(schedule.id).update(data);
+      invalidateScheduleCache(schedule.id);
       AppLogger.debug('Schedule update completed successfully');
     } catch (e, stackTrace) {
       AppLogger.error('Error updating schedule', e, stackTrace);
@@ -263,6 +217,7 @@ class ScheduleRepository implements IScheduleRepository {
   @override
   Future<void> deleteSchedule(String scheduleId) async {
     await _firestore.collection('schedules').doc(scheduleId).delete();
+    invalidateScheduleCache(scheduleId);
   }
 
   @override
@@ -345,15 +300,19 @@ class ScheduleRepository implements IScheduleRepository {
             .where('visibleTo', arrayContains: userId)
             .where(
               'startDateTime',
+              isLessThan: range.endExclusiveIso,
+            )
+            .where(
+              'endDateTime',
               isGreaterThanOrEqualTo: range.startInclusiveIso,
             )
-            .where('startDateTime', isLessThan: range.endExclusiveIso)
             .orderBy('startDateTime', descending: false)
+            .orderBy('endDateTime', descending: false)
             .get(const GetOptions(source: Source.cache));
 
         if (cachedSnapshot.docs.isNotEmpty) {
           // キャッシュからのデータを非同期でエンリッチして即時返却
-          final cachedSchedules = await Future.wait(
+          final cachedSchedules = (await Future.wait(
             cachedSnapshot.docs.map((doc) async {
               try {
                 return await _enrichSchedule(doc);
@@ -362,7 +321,9 @@ class ScheduleRepository implements IScheduleRepository {
                 return ScheduleMapper.fromFirestore(doc);
               }
             }),
-          );
+          ))
+              .where(range.overlaps)
+              .toList();
 
           // キャッシュデータを即時返却（早く表示するため）
           yield cachedSchedules;
@@ -378,16 +339,22 @@ class ScheduleRepository implements IScheduleRepository {
           .where('visibleTo', arrayContains: userId)
           .where(
             'startDateTime',
+            isLessThan: range.endExclusiveIso,
+          )
+          .where(
+            'endDateTime',
             isGreaterThanOrEqualTo: range.startInclusiveIso,
           )
-          .where('startDateTime', isLessThan: range.endExclusiveIso)
           .orderBy('startDateTime', descending: false)
+          .orderBy('endDateTime', descending: false)
           .snapshots();
 
       await for (final snapshot in stream) {
         try {
           // バッチ処理でエンリッチメントを高速化
-          final schedules = await _enrichSchedulesInBatches(snapshot.docs);
+          final schedules = (await _enrichSchedulesInBatches(snapshot.docs))
+              .where(range.overlaps)
+              .toList();
           yield schedules;
         } catch (e) {
           AppLogger.error('Error processing schedule snapshot for month: $e');

--- a/test/domain/value/schedule_month_range_test.dart
+++ b/test/domain/value/schedule_month_range_test.dart
@@ -4,35 +4,45 @@ import 'package:lakiite/domain/value/schedule_month_range.dart';
 
 void main() {
   group('ScheduleMonthRange', () {
-    test('表示月の前月月初から翌々月月初直前までを取得範囲にする', () {
-      final range = ScheduleMonthRange.forDisplayMonth(DateTime(2026, 3, 20));
+    test('表示月の42日カレンダーグリッドだけを取得範囲にする', () {
+      final range = ScheduleMonthRange.forDisplayMonth(DateTime(2026, 4, 20));
 
-      expect(range.startInclusive, DateTime(2026, 2, 1));
-      expect(range.endExclusive, DateTime(2026, 5, 1));
+      expect(range.startInclusive, DateTime(2026, 3, 29));
+      expect(range.endExclusive, DateTime(2026, 5, 10));
     });
 
-    test('Firestore のISO文字列として月範囲境界を表現する', () {
+    test('Firestore のISO文字列として42日グリッド境界を表現する', () {
       final range = ScheduleMonthRange.forDisplayMonth(DateTime(2026, 1, 31));
 
-      expect(range.startInclusiveIso, '2025-12-01T00:00:00.000');
-      expect(range.endExclusiveIso, '2026-03-01T00:00:00.000');
+      expect(range.startInclusiveIso, '2025-12-28T00:00:00.000');
+      expect(range.endExclusiveIso, '2026-02-08T00:00:00.000');
     });
 
     test('取得開始日より前に始まり表示範囲内で終わる予定も対象にする', () {
-      final range = ScheduleMonthRange.forDisplayMonth(DateTime(2026, 3, 20));
+      final range = ScheduleMonthRange.forDisplayMonth(DateTime(2026, 4, 20));
       final schedule = _schedule(
-        startDateTime: DateTime(2026, 1, 20),
-        endDateTime: DateTime(2026, 2, 3),
+        startDateTime: DateTime(2026, 3, 20),
+        endDateTime: DateTime(2026, 3, 29),
       );
 
       expect(range.overlaps(schedule), isTrue);
     });
 
-    test('表示範囲終了日に始まる予定は対象外にする', () {
-      final range = ScheduleMonthRange.forDisplayMonth(DateTime(2026, 3, 20));
+    test('42日グリッドより前に終わる予定は対象外にする', () {
+      final range = ScheduleMonthRange.forDisplayMonth(DateTime(2026, 4, 20));
       final schedule = _schedule(
-        startDateTime: DateTime(2026, 5, 1),
-        endDateTime: DateTime(2026, 5, 1, 1),
+        startDateTime: DateTime(2026, 3, 20),
+        endDateTime: DateTime(2026, 3, 28, 23, 59),
+      );
+
+      expect(range.overlaps(schedule), isFalse);
+    });
+
+    test('表示範囲終了日に始まる予定は対象外にする', () {
+      final range = ScheduleMonthRange.forDisplayMonth(DateTime(2026, 4, 20));
+      final schedule = _schedule(
+        startDateTime: DateTime(2026, 5, 10),
+        endDateTime: DateTime(2026, 5, 10, 1),
       );
 
       expect(range.overlaps(schedule), isFalse);

--- a/test/domain/value/schedule_month_range_test.dart
+++ b/test/domain/value/schedule_month_range_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lakiite/domain/entity/schedule.dart';
 import 'package:lakiite/domain/value/schedule_month_range.dart';
 
 void main() {
@@ -16,5 +17,44 @@ void main() {
       expect(range.startInclusiveIso, '2025-12-01T00:00:00.000');
       expect(range.endExclusiveIso, '2026-03-01T00:00:00.000');
     });
+
+    test('取得開始日より前に始まり表示範囲内で終わる予定も対象にする', () {
+      final range = ScheduleMonthRange.forDisplayMonth(DateTime(2026, 3, 20));
+      final schedule = _schedule(
+        startDateTime: DateTime(2026, 1, 20),
+        endDateTime: DateTime(2026, 2, 3),
+      );
+
+      expect(range.overlaps(schedule), isTrue);
+    });
+
+    test('表示範囲終了日に始まる予定は対象外にする', () {
+      final range = ScheduleMonthRange.forDisplayMonth(DateTime(2026, 3, 20));
+      final schedule = _schedule(
+        startDateTime: DateTime(2026, 5, 1),
+        endDateTime: DateTime(2026, 5, 1, 1),
+      );
+
+      expect(range.overlaps(schedule), isFalse);
+    });
   });
+}
+
+Schedule _schedule({
+  required DateTime startDateTime,
+  required DateTime endDateTime,
+}) {
+  return Schedule(
+    id: 'schedule-id',
+    title: '予定',
+    description: '',
+    startDateTime: startDateTime,
+    endDateTime: endDateTime,
+    ownerId: 'owner-id',
+    ownerDisplayName: 'Owner',
+    sharedLists: const [],
+    visibleTo: const ['owner-id'],
+    createdAt: DateTime(2026),
+    updatedAt: DateTime(2026),
+  );
 }

--- a/test/infrastructure/schedule_enrichment_cache_test.dart
+++ b/test/infrastructure/schedule_enrichment_cache_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lakiite/infrastructure/schedule_enrichment_cache.dart';
+
+void main() {
+  group('ScheduleEnrichmentCache', () {
+    test('予定本体はキャッシュせず、interaction countだけを再利用する', () {
+      final cache = ScheduleEnrichmentCache();
+
+      cache.storeInteractionCounts(
+        'schedule-1',
+        reactionCount: 2,
+        commentCount: 3,
+      );
+
+      expect(
+        cache.getInteractionCounts('schedule-1'),
+        (reactionCount: 2, commentCount: 3),
+      );
+    });
+
+    test('invalidateScheduleはinteraction countを破棄する', () {
+      final cache = ScheduleEnrichmentCache();
+
+      cache.storeInteractionCounts(
+        'schedule-1',
+        reactionCount: 2,
+        commentCount: 3,
+      );
+      cache.invalidateSchedule('schedule-1');
+
+      expect(cache.getInteractionCounts('schedule-1'), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- include schedules that overlap the visible month range, not only schedules starting inside it
- add the matching month-range overlap filter and tests
- stop caching full Schedule objects during stream enrichment so edited schedules update immediately
- keep only reaction/comment count caching

## Root Cause
- month query missed schedules that started before the displayed range but continued into it
- Firestore snapshots were received, but enrichment could return a stale full Schedule from the 10-minute cache

## Test Plan
- `fvm flutter test test/infrastructure/schedule_enrichment_cache_test.dart test/domain/value/schedule_month_range_test.dart test/presentation/calendar/calendar_schedule_providers_test.dart`
- `fvm flutter analyze`
- Android dev flavor実機: edited `LKT1z.` -> `LKT1z. E2E` and confirmed detail/month logs updated immediately, then restored `LKT1z.`