### PR TITLE
fix: restore calendar schedules sooner after swipe

### DIFF
--- a/lib/presentation/calendar/widgets/calendar_page_view.dart
+++ b/lib/presentation/calendar/widgets/calendar_page_view.dart
@@ -41,7 +41,9 @@ bool _isCalendarFirstBuild = true;
 // スライド中かどうかを管理するフラグ
 bool _isSliding = false;
 Timer? _slidingTimer;
+Timer? _scheduleUiRestoreTimer;
 Timer? _cleanupTimer;
+const Duration _calendarScheduleUiRestoreDelay = Duration(milliseconds: 200);
 const Duration _calendarSettledFetchDelay = Duration(milliseconds: 500);
 
 // PageControllerをキャッシュするプロバイダー
@@ -236,6 +238,8 @@ class CalendarPageView extends HookConsumerWidget {
       return () {
         _slidingTimer?.cancel();
         _slidingTimer = null;
+        _scheduleUiRestoreTimer?.cancel();
+        _scheduleUiRestoreTimer = null;
         _cleanupTimer?.cancel();
         _cleanupTimer = null;
       };
@@ -495,6 +499,8 @@ class CalendarPageView extends HookConsumerWidget {
                 if (notification is ScrollStartNotification) {
                   _slidingTimer?.cancel();
                   _slidingTimer = null;
+                  _scheduleUiRestoreTimer?.cancel();
+                  _scheduleUiRestoreTimer = null;
                   _isSliding = true;
                   scrollStarted.value = true;
                   pendingPageTarget.value = null;
@@ -546,6 +552,20 @@ class CalendarPageView extends HookConsumerWidget {
                   }
 
                   // タイマーをキャンセルして再設定
+                  _scheduleUiRestoreTimer?.cancel();
+                  _scheduleUiRestoreTimer =
+                      Timer(_calendarScheduleUiRestoreDelay, () {
+                    if (!isMounted()) {
+                      return;
+                    }
+                    _isSliding = false;
+
+                    if (ref.exists(calendarOptimizationProvider)) {
+                      ref.read(calendarOptimizationProvider.notifier).state =
+                          false;
+                    }
+                  });
+
                   _slidingTimer?.cancel();
                   _slidingTimer = Timer(_calendarSettledFetchDelay, () {
                     if (!isMounted()) {
@@ -553,7 +573,6 @@ class CalendarPageView extends HookConsumerWidget {
                     }
                     _isSliding = false;
 
-                    // スライド完了後に最適化モードを無効化
                     if (ref.exists(calendarOptimizationProvider)) {
                       ref.read(calendarOptimizationProvider.notifier).state =
                           false;

--- a/test/presentation/calendar/calendar_scroll_behavior_test.dart
+++ b/test/presentation/calendar/calendar_scroll_behavior_test.dart
@@ -1,14 +1,124 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:intl/date_symbol_data_local.dart';
+import 'package:lakiite/app/di/providers.dart';
+import 'package:lakiite/application/auth/auth_notifier.dart';
 import 'package:lakiite/config/admob_config.dart';
 import 'package:lakiite/config/app_config.dart';
+import 'package:lakiite/domain/entity/schedule.dart';
+import 'package:lakiite/domain/entity/user.dart';
+import 'package:lakiite/domain/interfaces/i_auth_repository.dart';
+import 'package:lakiite/domain/interfaces/i_schedule_repository.dart';
+import 'package:lakiite/presentation/calendar/schedule_providers.dart';
 import 'package:lakiite/presentation/calendar/widgets/calendar_page_view.dart';
 import 'package:lakiite/presentation/home/home_page.dart';
 
+import '../../mock/base_mock.dart';
 import '../../mock/providers/test_providers.dart';
 import '../../utils/test_utils.dart';
+
+class _StableAuthRepository implements IAuthRepository {
+  _StableAuthRepository(this._currentUser);
+
+  final _controller = StreamController<UserModel?>.broadcast();
+  UserModel? _currentUser;
+
+  @override
+  Stream<UserModel?> authStateChanges() async* {
+    yield _currentUser;
+    yield* _controller.stream;
+  }
+
+  @override
+  Future<void> signOut() async {
+    _currentUser = null;
+    _controller.add(null);
+  }
+
+  @override
+  Future<UserModel?> signIn(String email, String password) async =>
+      _currentUser;
+
+  @override
+  Future<UserModel?> signUp(String email, String password, String name) async =>
+      _currentUser;
+
+  @override
+  Future<bool> deleteAccount() async => true;
+
+  @override
+  Future<bool> deleteAccountWithReauth(String password) async => true;
+
+  @override
+  Future<bool> reauthenticateWithPassword(String password) async => true;
+
+  Future<void> dispose() => _controller.close();
+}
+
+class _StreamingScheduleRepository implements IScheduleRepository {
+  final _controller = StreamController<List<Schedule>>.broadcast();
+  List<Schedule>? _latestSchedules;
+  int watchUserSchedulesForMonthCallCount = 0;
+
+  void emit(List<Schedule> schedules) {
+    _latestSchedules = schedules;
+    _controller.add(schedules);
+  }
+
+  @override
+  Stream<List<Schedule>> watchUserSchedules(String userId) async* {
+    final latestSchedules = _latestSchedules;
+    if (latestSchedules != null) {
+      yield latestSchedules;
+    }
+    yield* _controller.stream;
+  }
+
+  @override
+  Stream<List<Schedule>> watchUserSchedulesForMonth(
+    String userId,
+    DateTime displayMonth,
+  ) async* {
+    watchUserSchedulesForMonthCallCount++;
+    final latestSchedules = _latestSchedules;
+    if (latestSchedules != null) {
+      yield latestSchedules;
+    }
+    yield* _controller.stream;
+  }
+
+  @override
+  Stream<List<Schedule>> watchListSchedules(String listId) =>
+      const Stream.empty();
+
+  @override
+  Stream<Schedule?> watchSchedule(String scheduleId) => const Stream.empty();
+
+  @override
+  Future<Schedule> createSchedule(Schedule schedule) =>
+      Future.error(UnimplementedError());
+
+  @override
+  Future<void> deleteSchedule(String scheduleId) =>
+      Future.error(UnimplementedError());
+
+  @override
+  Future<List<Schedule>> getListSchedules(String listId) =>
+      Future.error(UnimplementedError());
+
+  @override
+  Future<List<Schedule>> getUserSchedules(String userId) =>
+      Future.error(UnimplementedError());
+
+  @override
+  Future<void> updateSchedule(Schedule schedule) =>
+      Future.error(UnimplementedError());
+
+  Future<void> dispose() => _controller.close();
+}
 
 void main() {
   group('Calendar scroll behavior', () {
@@ -198,6 +308,211 @@ void main() {
       await tester.pumpAndSettle();
       await tester.pump(const Duration(milliseconds: 550));
     });
+
+    testWidgets('カレンダーはスライド中の予定更新を表示へ反映せず完了後に反映する', (tester) async {
+      final scheduleRepository = _StreamingScheduleRepository();
+      addTearDown(scheduleRepository.dispose);
+      final userRepository = TestProviders.mockUserRepository;
+      final testUser = BaseMock.createTestUser();
+      final authRepository = _StableAuthRepository(testUser);
+      addTearDown(authRepository.dispose);
+      userRepository.addTestUser(testUser);
+
+      final now = DateTime.now();
+      final initialSchedule = BaseMock.createTestSchedule(
+        id: 'schedule-deferred-ui',
+        title: 'スライド前予定',
+        startDateTime: DateTime(now.year, now.month, 15, 10),
+        endDateTime: DateTime(now.year, now.month, 15, 11),
+      );
+      final updatedSchedule = initialSchedule.copyWith(
+        title: 'スライド後予定',
+        startDateTime: DateTime(now.year, now.month, 16, 10),
+        endDateTime: DateTime(now.year, now.month, 16, 11),
+      );
+      scheduleRepository.emit([initialSchedule]);
+
+      await tester.pumpWidget(
+        TestUtils.createTestApp(
+          overrides: [
+            authRepositoryProvider.overrideWithValue(authRepository),
+            userRepositoryProvider.overrideWithValue(userRepository),
+            scheduleRepositoryProvider.overrideWithValue(scheduleRepository),
+            calendarOptimizationProvider.overrideWith((ref) => false),
+          ],
+          child: const Scaffold(
+            body: CalendarPageView(),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.pump(const Duration(milliseconds: 150));
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(CalendarPageView)),
+      );
+      container.read(calendarOptimizationProvider.notifier).state = false;
+      await tester.pump();
+
+      expect(scheduleRepository.watchUserSchedulesForMonthCallCount,
+          greaterThan(0));
+      final schedulesState = container.read(
+        calendarMonthSchedulesProvider((
+          userId: testUser.id,
+          displayMonth: DateTime(now.year, now.month),
+        )),
+      );
+      expect(schedulesState.valueOrNull, isNotEmpty);
+      expect(_textWidget('スライド前予定'), findsOneWidget);
+      expect(_textWidget('スライド後予定'), findsNothing);
+
+      final gesture = await tester.startGesture(
+        tester.getCenter(find.byType(PageView)),
+      );
+      await gesture.moveBy(const Offset(-80, 0));
+      await tester.pump();
+
+      scheduleRepository.emit([updatedSchedule]);
+      await tester.pump();
+
+      expect(_textWidget('スライド後予定'), findsNothing);
+      final oldLightweightCell = tester.widget<LightweightDateCell>(
+        find.byKey(ValueKey(_dateLiteKey(DateTime(now.year, now.month, 15)))),
+      );
+      final newLightweightCell = tester.widget<LightweightDateCell>(
+        find.byKey(ValueKey(_dateLiteKey(DateTime(now.year, now.month, 16)))),
+      );
+      expect(oldLightweightCell.hasSchedules, isTrue);
+      expect(newLightweightCell.hasSchedules, isFalse);
+
+      await gesture.up();
+      await tester.pumpAndSettle();
+      await tester.pump(const Duration(milliseconds: 550));
+
+      expect(_textWidget('スライド前予定'), findsNothing);
+      expect(_textWidget('スライド後予定'), findsOneWidget);
+    });
+
+    testWidgets('カレンダーはスライド終了後約200msで予定タイトル表示を復帰する', (tester) async {
+      final scheduleRepository = _StreamingScheduleRepository();
+      addTearDown(scheduleRepository.dispose);
+      final userRepository = TestProviders.mockUserRepository;
+      final testUser = BaseMock.createTestUser();
+      final authRepository = _StableAuthRepository(testUser);
+      addTearDown(authRepository.dispose);
+      userRepository.addTestUser(testUser);
+
+      final now = DateTime.now();
+      final initialSchedule = BaseMock.createTestSchedule(
+        id: 'schedule-fast-restore',
+        title: '高速復帰前',
+        startDateTime: DateTime(now.year, now.month, 15, 10),
+        endDateTime: DateTime(now.year, now.month, 15, 11),
+      );
+      final updatedSchedule = initialSchedule.copyWith(title: '高速復帰後');
+      scheduleRepository.emit([initialSchedule]);
+
+      await tester.pumpWidget(
+        TestUtils.createTestApp(
+          overrides: [
+            authRepositoryProvider.overrideWithValue(authRepository),
+            userRepositoryProvider.overrideWithValue(userRepository),
+            scheduleRepositoryProvider.overrideWithValue(scheduleRepository),
+            calendarOptimizationProvider.overrideWith((ref) => false),
+          ],
+          child: const Scaffold(
+            body: CalendarPageView(),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(CalendarPageView)),
+      );
+      container.read(calendarOptimizationProvider.notifier).state = false;
+      await tester.pump();
+
+      expect(_textWidget('高速復帰前'), findsOneWidget);
+
+      final gesture = await tester.startGesture(
+        tester.getCenter(find.byType(PageView)),
+      );
+      await gesture.moveBy(const Offset(-80, 0));
+      await tester.pump();
+
+      scheduleRepository.emit([updatedSchedule]);
+      await tester.pump();
+      expect(_textWidget('高速復帰後'), findsNothing);
+
+      await gesture.up();
+      await tester.pump(const Duration(milliseconds: 250));
+
+      expect(_textWidget('高速復帰前'), findsNothing);
+      expect(_textWidget('高速復帰後'), findsOneWidget);
+    });
+
+    testWidgets('月次ページは最適化中のStream更新で表示用予定位置を動かさない', (tester) async {
+      final scheduleRepository = _StreamingScheduleRepository();
+      addTearDown(scheduleRepository.dispose);
+      final userRepository = TestProviders.mockUserRepository;
+      final testUser = BaseMock.createTestUser();
+      final authRepository = _StableAuthRepository(testUser);
+      addTearDown(authRepository.dispose);
+      userRepository.addTestUser(testUser);
+
+      final now = DateTime.now();
+      final visibleMonth = DateTime(now.year, now.month);
+      final initialSchedule = BaseMock.createTestSchedule(
+        id: 'schedule-page-content-deferred-ui',
+        title: 'ページ単体スライド前',
+        startDateTime: DateTime(now.year, now.month, 15, 10),
+        endDateTime: DateTime(now.year, now.month, 15, 11),
+      );
+      final updatedSchedule = initialSchedule.copyWith(
+        title: 'ページ単体スライド後',
+        startDateTime: DateTime(now.year, now.month, 16, 10),
+        endDateTime: DateTime(now.year, now.month, 16, 11),
+      );
+      scheduleRepository.emit([initialSchedule]);
+
+      await tester.pumpWidget(
+        TestUtils.createTestApp(
+          overrides: [
+            authRepositoryProvider.overrideWithValue(authRepository),
+            userRepositoryProvider.overrideWithValue(userRepository),
+            scheduleRepositoryProvider.overrideWithValue(scheduleRepository),
+            calendarOptimizationProvider.overrideWith((ref) => true),
+          ],
+          child: Scaffold(
+            body: CalendarPageContent(
+              visiblePageDate: visibleMonth,
+              monthKey: getMonthKey(visibleMonth),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      scheduleRepository.emit([updatedSchedule]);
+      await tester.pump();
+
+      final oldLightweightCell = tester.widget<LightweightDateCell>(
+        find.byKey(ValueKey(_dateLiteKey(DateTime(now.year, now.month, 15)))),
+      );
+      final newLightweightCell = tester.widget<LightweightDateCell>(
+        find.byKey(ValueKey(_dateLiteKey(DateTime(now.year, now.month, 16)))),
+      );
+      expect(oldLightweightCell.hasSchedules, isTrue);
+      expect(newLightweightCell.hasSchedules, isFalse);
+
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(CalendarPageContent)),
+      );
+      container.read(calendarOptimizationProvider.notifier).state = false;
+      await tester.pump();
+
+      expect(_textWidget('ページ単体スライド前'), findsNothing);
+      expect(_textWidget('ページ単体スライド後'), findsOneWidget);
+    });
   });
 }
 
@@ -211,4 +526,16 @@ String _visibleMonthLabel(WidgetTester tester) {
 
   expect(monthLabels, isNotEmpty);
   return monthLabels.first;
+}
+
+Finder _textWidget(String text) {
+  return find.byWidgetPredicate(
+    (widget) => widget is Text && widget.data == text,
+  );
+}
+
+String _dateLiteKey(DateTime date) {
+  final dateString =
+      '${date.year}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')}';
+  return 'date_lite_$dateString';
 }


### PR DESCRIPTION
## Summary
- Restore monthly calendar schedule titles about 200ms after swipe end
- Keep the existing 500ms delayed cache/render window update for scroll smoothness
- Add regression coverage for deferred schedule UI updates and faster title restoration

## Why
Monthly calendar schedule titles were perceptibly slow to return after swiping because the optimization mode stayed active for the full 500ms settle delay. The data stream could already be ready, but title rendering was still gated by the UI optimization flag.

## Test Plan
- fvm flutter test test/presentation/calendar/calendar_scroll_behavior_test.dart test/presentation/calendar/calendar_schedule_providers_test.dart test/domain/value/schedule_month_range_test.dart
- fvm flutter analyze
- git diff --check
- Android device SCG19 dev flavor: confirmed May 2026 -> June 2026 -> May 2026, and LKT1z. / LKT2 were visible about 250ms after returning