### PR TITLE
[codex] Run prod releases on main

### DIFF
--- a/.github/workflows/deploy_prod_android.yml
+++ b/.github/workflows/deploy_prod_android.yml
@@ -1,6 +1,8 @@
 name: '[Release] Prod Android'
 
 on:
+  push:
+    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/deploy_prod_ios.yml
+++ b/.github/workflows/deploy_prod_ios.yml
@@ -1,6 +1,8 @@
 name: "[Release] Prod iOS"
 
 on:
+  push:
+    branches: [main]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- Run the existing prod Android release workflow on pushes to main.
- Run the existing prod iOS release workflow on pushes to main.

## Validation
- ruby YAML parser: ok .github/workflows/deploy_prod_android.yml and .github/workflows/deploy_prod_ios.yml
- git diff --check HEAD~1..HEAD