### PR TITLE
[codex] Remove iOS tracking usage description

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -43,8 +43,6 @@
 	<string>プロフィール画像を撮影・設定するためにカメラを使用します。この機能は任意で、拒否してもアプリの基本機能は利用できます。</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>プロフィール画像を設定するために写真ライブラリにアクセスします。この機能は任意で、拒否してもアプリの基本機能は利用できます。</string>
-	<key>NSUserTrackingUsageDescription</key>
-	<string>アプリの改善と、より関連性の高い広告を表示するために使用します。この設定はいつでも変更できます。</string>
 	<key>SKAdNetworkItems</key>
 	<array>
 		<dict>


### PR DESCRIPTION
## Summary
- Removed `NSUserTrackingUsageDescription` from the iOS `Info.plist`.
- Keeps App Store privacy answers aligned with the app not using tracking.

## Context
App Store Connect blocked submission because the selected iOS build contained `NSUserTrackingUsageDescription`, which indicates the app may request tracking permission. Since LaKiite does not use tracking, the iOS binary should not include this key.

## Validation
- `rg -n "NSUserTrackingUsageDescription|AppTrackingTransparency|ATTracking|requestTrackingAuthorization" ios --glob '!*.p8' --glob '!*.pem' --glob '!*.key'` returned no matches.
- `plutil -lint ios/Runner/Info.plist` returned `ios/Runner/Info.plist: OK`.

## Notes
A new iOS build must be uploaded and selected in App Store Connect for the existing ATT warning on build `10451` to clear.