### PR TITLE
fix: remove push token before logout

### DIFF
--- a/lib/application/auth/auth_notifier.dart
+++ b/lib/application/auth/auth_notifier.dart
@@ -214,6 +214,9 @@ class AuthNotifier extends _$AuthNotifier {
   /// - 認証状態を未認証に更新
   /// - 全てのキャッシュをクリア
   Future<void> signOut() async {
+    final signingOutUserId =
+        state.asData?.value.user?.id ?? FirebaseAuth.instance.currentUser?.uid;
+
     // ローディング状態に設定
     state = const AsyncLoading();
 
@@ -222,14 +225,10 @@ class AuthNotifier extends _$AuthNotifier {
       try {
         AppLogger.debug('サインアウト処理を開始します');
 
-        // 1. 先に認証をサインアウトして、Router と認証状態を安定させる
-        await _authRepository.signOut();
-        AppLogger.debug('認証サインアウトが完了しました');
-
-        // 2. FCMトークンを削除
+        // 1. 認証状態が残っているうちに現在端末のFCMトークンをユーザーから外す
         try {
           if (_fcmTokenService != null) {
-            await _fcmTokenService!.removeFcmToken();
+            await _fcmTokenService!.removeFcmToken(userId: signingOutUserId);
             AppLogger.debug('FCMトークンを削除しました');
           } else {
             AppLogger.debug('FCMトークンサービスが初期化されていないため、FCMトークン削除をスキップします');
@@ -237,6 +236,10 @@ class AuthNotifier extends _$AuthNotifier {
         } catch (e) {
           AppLogger.warning('FCMトークン削除エラー（無視して続行）: $e');
         }
+
+        // 2. 認証をサインアウトして、Router と認証状態を安定させる
+        await _authRepository.signOut();
+        AppLogger.debug('認証サインアウトが完了しました');
 
         // 3. WebView 関連の強制クリーンアップ
         try {

--- a/lib/infrastructure/firebase/push_notification_service.dart
+++ b/lib/infrastructure/firebase/push_notification_service.dart
@@ -168,6 +168,16 @@ class PushNotificationService {
     }
   }
 
+  Future<void> deleteCurrentToken() async {
+    try {
+      await _messaging.deleteToken();
+      AppLogger.debug('現在端末のFCMトークンを削除しました');
+    } catch (e, stack) {
+      AppLogger.error('現在端末のFCMトークン削除エラー: $e');
+      AppLogger.error('スタックトレース: $stack');
+    }
+  }
+
   Future<String?> forceUpdateFCMToken() async {
     try {
       AppLogger.debug('FCMトークンの強制更新を開始');

--- a/lib/infrastructure/user_fcm_token_service.dart
+++ b/lib/infrastructure/user_fcm_token_service.dart
@@ -53,35 +53,40 @@ class UserFcmTokenService {
   }
 
   /// ユーザーのFCMトークンを削除する（ログアウト時など）
-  Future<void> removeFcmToken() async {
+  Future<void> removeFcmToken({String? userId}) async {
     try {
       final user = _auth.currentUser;
-      if (user == null) {
+      final targetUserId = userId ?? user?.uid;
+      if (targetUserId == null) {
         AppLogger.warning('FCMトークン削除: ユーザーがログインしていません');
+        await _pushNotificationService.deleteCurrentToken();
         return;
       }
 
-      AppLogger.debug('FCMトークン削除: ユーザーID=${user.uid}');
+      AppLogger.debug('FCMトークン削除: ユーザーID=$targetUserId');
 
       try {
         // Firestoreのユーザードキュメントを取得して存在確認
-        final docRef = _firestore.collection('users').doc(user.uid);
+        final docRef = _firestore.collection('users').doc(targetUserId);
         final docSnapshot = await docRef.get();
 
         if (!docSnapshot.exists) {
           AppLogger.warning('FCMトークン削除: ユーザードキュメントが存在しません');
+          await _pushNotificationService.deleteCurrentToken();
           return;
         }
 
         final token = await _pushNotificationService.refreshToken();
         if (token == null) {
           AppLogger.warning('FCMトークン削除: 現在端末のトークンが取得できませんでした');
+          await _pushNotificationService.deleteCurrentToken();
           return;
         }
 
         await docRef.update({
           _tokensField: FieldValue.arrayRemove([token]),
         });
+        await _pushNotificationService.deleteCurrentToken();
 
         AppLogger.debug('FCMトークン削除: 完了');
       } catch (e) {
@@ -98,6 +103,7 @@ class UserFcmTokenService {
         } else {
           AppLogger.error('FCMトークン削除エラー: $e');
         }
+        await _pushNotificationService.deleteCurrentToken();
         // エラーはログに記録するだけで例外は投げない（ログアウト処理を続行させるため）
       }
     } catch (e, stack) {


### PR DESCRIPTION
## Summary
- remove the current device FCM token from the user document before FirebaseAuth sign-out
- pass the signing-out user id into token removal so Firestore can still update after auth state starts changing
- delete the local FCM token on logout cleanup paths for both iOS and Android

## Verification
- fvm flutter analyze --no-fatal-infos
- fvm flutter test test/infrastructure/user_fcm_token_service_test.dart --dart-define=FLUTTER_TEST=true
- fvm flutter test test/application/auth/auth_notifier_test.dart --dart-define=FLUTTER_TEST=true
- Android device SCG19 dev flavor: logged in as test-1@test.com, confirmed FCM token update, logged out, confirmed logs for FCM token removal and local token deletion
