### PR TITLE
[codex] add signup password confirmation

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -162,7 +162,15 @@ class MyApp extends ConsumerWidget {
     );
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (Platform.isAndroid) {
+      const skipPushNotificationRuntime = bool.fromEnvironment(
+            'TEST_MODE',
+            defaultValue: false,
+          ) ||
+          bool.fromEnvironment('FLUTTER_TEST', defaultValue: false) ||
+          bool.fromEnvironment('USE_FIREBASE_EMULATOR', defaultValue: false);
+      if (!skipPushNotificationRuntime &&
+          Platform.isAndroid &&
+          Firebase.apps.isNotEmpty) {
         PushNotificationService.instance.requestAndroidNotificationPermission();
       }
       NotificationNavigationService.instance.flushPendingNavigation();

--- a/lib/presentation/signup/signup.dart
+++ b/lib/presentation/signup/signup.dart
@@ -16,20 +16,30 @@ class SignupPage extends ConsumerStatefulWidget {
 class _SignupPageState extends ConsumerState<SignupPage> {
   final _emailController = TextEditingController();
   final _passwordController = TextEditingController();
+  final _confirmPasswordController = TextEditingController();
   final _nameController = TextEditingController();
   final _displayNameController = TextEditingController();
   bool _isLoading = false;
+  bool _obscurePassword = true;
+  bool _obscureConfirmPassword = true;
 
   @override
   void dispose() {
     _emailController.dispose();
     _passwordController.dispose();
+    _confirmPasswordController.dispose();
     _nameController.dispose();
+    _displayNameController.dispose();
     super.dispose();
   }
 
   Future<void> _handleSignup() async {
     if (_isLoading) return;
+
+    if (_passwordController.text != _confirmPasswordController.text) {
+      _showSignupError('パスワードが一致しません');
+      return;
+    }
 
     AppLogger.debugOnly('SignupPage._handleSignup開始');
     setState(() {
@@ -75,6 +85,32 @@ class _SignupPageState extends ConsumerState<SignupPage> {
     context.pop();
   }
 
+  Widget _buildPasswordField({
+    required TextEditingController controller,
+    required String labelText,
+    required bool obscureText,
+    required VoidCallback onToggleVisibility,
+    required TextInputAction textInputAction,
+  }) {
+    return TextField(
+      controller: controller,
+      decoration: InputDecoration(
+        labelText: labelText,
+        border: const OutlineInputBorder(),
+        suffixIcon: IconButton(
+          tooltip: obscureText ? '$labelTextを表示' : '$labelTextを非表示',
+          icon: Icon(
+            obscureText ? Icons.visibility : Icons.visibility_off,
+          ),
+          onPressed: onToggleVisibility,
+        ),
+      ),
+      obscureText: obscureText,
+      autofillHints: const [AutofillHints.newPassword],
+      textInputAction: textInputAction,
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -116,13 +152,27 @@ class _SignupPageState extends ConsumerState<SignupPage> {
                 textInputAction: TextInputAction.next,
               ),
               const SizedBox(height: 16),
-              TextField(
+              _buildPasswordField(
                 controller: _passwordController,
-                decoration: const InputDecoration(
-                  labelText: 'パスワード',
-                  border: OutlineInputBorder(),
-                ),
-                obscureText: true,
+                labelText: 'パスワード',
+                obscureText: _obscurePassword,
+                onToggleVisibility: () {
+                  setState(() {
+                    _obscurePassword = !_obscurePassword;
+                  });
+                },
+                textInputAction: TextInputAction.next,
+              ),
+              const SizedBox(height: 16),
+              _buildPasswordField(
+                controller: _confirmPasswordController,
+                labelText: 'パスワード再確認',
+                obscureText: _obscureConfirmPassword,
+                onToggleVisibility: () {
+                  setState(() {
+                    _obscureConfirmPassword = !_obscureConfirmPassword;
+                  });
+                },
                 textInputAction: TextInputAction.done,
               ),
               const SizedBox(height: 32),

--- a/test/presentation/auth/signup_widget_test.dart
+++ b/test/presentation/auth/signup_widget_test.dart
@@ -29,6 +29,7 @@ void main() {
       expect(find.text('表示名(ニックネーム)'), findsOneWidget);
       expect(find.text('メールアドレス'), findsOneWidget);
       expect(find.text('パスワード'), findsOneWidget);
+      expect(find.text('パスワード再確認'), findsOneWidget);
       expect(find.byType(ElevatedButton), findsAtLeastNWidgets(1)); // 新規登録ボタン
       // Googleログインはファーストリリースでは除外
       // expect(find.text('Googleで登録'), findsOneWidget);
@@ -62,7 +63,29 @@ void main() {
       final passwordField = find.widgetWithText(TextField, 'パスワード');
       await tester.enterText(passwordField, 'password123');
 
+      // パスワード再確認入力
+      final confirmPasswordField = find.widgetWithText(TextField, 'パスワード再確認');
+      await tester.enterText(confirmPasswordField, 'password123');
+
       await tester.pumpAndSettle();
+    });
+
+    testWidgets('パスワード再確認フィールドが入力できる', (tester) async {
+      await tester.pumpWidget(
+        TestUtils.createTestApp(
+          overrides: TestProviders.forSignupForm,
+          child: const SignupPage(),
+        ),
+      );
+
+      final confirmPasswordField = find.widgetWithText(TextField, 'パスワード再確認');
+      expect(confirmPasswordField, findsOneWidget);
+
+      await tester.enterText(confirmPasswordField, 'password123');
+      expect(
+        tester.widget<TextField>(confirmPasswordField).controller?.text,
+        'password123',
+      );
     });
 
     testWidgets('パスワードフィールドが隠されている', (tester) async {
@@ -82,6 +105,60 @@ void main() {
 
       // obscureText が true であることを確認
       expect(textField.obscureText, isTrue);
+    });
+
+    testWidgets('パスワード表示ボタンで入力内容を表示できる', (tester) async {
+      await tester.pumpWidget(
+        TestUtils.createTestApp(
+          overrides: TestProviders.forSignupForm,
+          child: const SignupPage(),
+        ),
+      );
+
+      final passwordField = find.widgetWithText(TextField, 'パスワード');
+      expect(tester.widget<TextField>(passwordField).obscureText, isTrue);
+
+      await tester.tap(find.byTooltip('パスワードを表示'));
+      await tester.pump();
+
+      expect(tester.widget<TextField>(passwordField).obscureText, isFalse);
+      expect(find.byTooltip('パスワードを非表示'), findsOneWidget);
+    });
+
+    testWidgets('パスワード不一致の場合はエラーを表示する', (tester) async {
+      await tester.pumpWidget(
+        TestUtils.createTestApp(
+          overrides: TestProviders.forSignupForm,
+          child: const SignupPage(),
+        ),
+      );
+
+      await tester.enterText(
+        find.widgetWithText(TextField, '名前(フルネーム)'),
+        'テストユーザー',
+      );
+      await tester.enterText(
+        find.widgetWithText(TextField, 'メールアドレス'),
+        'test@example.com',
+      );
+      await tester.enterText(
+        find.widgetWithText(TextField, 'パスワード'),
+        'password123',
+      );
+      await tester.enterText(
+        find.widgetWithText(TextField, 'パスワード再確認'),
+        'password456',
+      );
+
+      await tester.tap(
+        find.descendant(
+          of: find.byType(ElevatedButton),
+          matching: find.text('新規登録'),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('パスワードが一致しません'), findsOneWidget);
     });
 
     testWidgets('新規登録処理が正常に動作する（修正版）', (tester) async {
@@ -125,6 +202,10 @@ void main() {
         find.widgetWithText(TextField, 'パスワード'),
         'password123',
       );
+      await tester.enterText(
+        find.widgetWithText(TextField, 'パスワード再確認'),
+        'password123',
+      );
       await tester.pumpAndSettle();
 
       await tester.tap(
@@ -161,6 +242,10 @@ void main() {
       // パスワード入力
       final passwordField = find.widgetWithText(TextField, 'パスワード');
       await tester.enterText(passwordField, 'password123');
+
+      // パスワード再確認入力
+      final confirmPasswordField = find.widgetWithText(TextField, 'パスワード再確認');
+      await tester.enterText(confirmPasswordField, 'password123');
 
       await tester.pumpAndSettle();
 
@@ -230,6 +315,7 @@ void main() {
       expect(find.text('表示名(ニックネーム)'), findsOneWidget);
       expect(find.text('メールアドレス'), findsOneWidget);
       expect(find.text('パスワード'), findsOneWidget);
+      expect(find.text('パスワード再確認'), findsOneWidget);
 
       // ボタンが存在することを確認
       expect(

--- a/test/utils/test_utils.dart
+++ b/test/utils/test_utils.dart
@@ -129,6 +129,7 @@ class TestUtils {
     String displayName = 'テストニックネーム',
     String email = 'test@example.com',
     String password = 'password123',
+    String? confirmPassword,
   }) async {
     // 名前入力（実際のラベルに合わせて修正）
     final nameField = _findTextFieldByLabel('名前(フルネーム)');
@@ -166,6 +167,21 @@ class TestUtils {
       final passwordFieldByKey = find.byKey(const Key('password_field'));
       if (passwordFieldByKey.evaluate().isNotEmpty) {
         await tester.enterText(passwordFieldByKey, password);
+      }
+    }
+
+    // パスワード再確認入力
+    final confirmPasswordField = _findTextFieldByLabel('パスワード再確認');
+    if (confirmPasswordField.evaluate().isNotEmpty) {
+      await tester.enterText(confirmPasswordField, confirmPassword ?? password);
+    } else {
+      final confirmPasswordFieldByKey =
+          find.byKey(const Key('confirm_password_field'));
+      if (confirmPasswordFieldByKey.evaluate().isNotEmpty) {
+        await tester.enterText(
+          confirmPasswordFieldByKey,
+          confirmPassword ?? password,
+        );
       }
     }
 


### PR DESCRIPTION
## Summary
- Add a password visibility toggle to the signup password field.
- Add a password confirmation field and stop signup when the values do not match.
- Update signup widget tests and signup test helper for the confirmation field.
- Guard Android push notification permission requests during test/Firebase-skipped startup paths.

## Root Cause
The signup screen only had one obscured password field, so users could not reveal the password or confirm it before registration. While validating on a Galaxy device, integration tests also exposed a test startup path where Firebase initialization is intentionally skipped but the post-frame push notification permission request still created `PushNotificationService`, which touches Firebase Messaging.

## Test Plan
- `fvm flutter analyze lib/main.dart lib/presentation/signup/signup.dart test/presentation/auth/signup_widget_test.dart test/utils/test_utils.dart`
- `fvm flutter test test/presentation/auth/signup_widget_test.dart --dart-define=FLUTTER_TEST=true`
- `fvm flutter test integration_test/login_signup_home_navigation_integration_test.dart -d RFCW31S5JLJ --flavor dev --dart-define-from-file=dart_define/dev_dart_define.json --dart-define=TEST_MODE=true`
- `fvm flutter run -d RFCW31S5JLJ --flavor dev --dart-define-from-file=dart_define/dev_dart_define.json`