### PR TITLE
[codex] add login password visibility toggle

### DIFF
--- a/lib/presentation/login/login_page.dart
+++ b/lib/presentation/login/login_page.dart
@@ -5,6 +5,7 @@ import '../signup/signup.dart';
 import '../../application/auth/auth_notifier.dart';
 import '../../utils/auth_error_message.dart';
 import '../../utils/logger.dart';
+import '../widgets/password_text_field.dart';
 
 class LoginPage extends ConsumerStatefulWidget {
   const LoginPage({super.key});
@@ -18,6 +19,7 @@ class _LoginPageState extends ConsumerState<LoginPage> {
   final _emailController = TextEditingController();
   final _passwordController = TextEditingController();
   bool _isLoading = false;
+  bool _obscurePassword = true;
 
   @override
   void dispose() {
@@ -90,13 +92,16 @@ class _LoginPageState extends ConsumerState<LoginPage> {
                 keyboardType: TextInputType.emailAddress,
               ),
               const SizedBox(height: 16),
-              TextField(
+              PasswordTextField(
                 controller: _passwordController,
-                decoration: const InputDecoration(
-                  labelText: 'パスワード',
-                  border: OutlineInputBorder(),
-                ),
-                obscureText: true,
+                labelText: 'パスワード',
+                obscureText: _obscurePassword,
+                onToggleVisibility: () {
+                  setState(() {
+                    _obscurePassword = !_obscurePassword;
+                  });
+                },
+                textInputAction: TextInputAction.done,
               ),
               const SizedBox(height: 32),
               ElevatedButton(

--- a/lib/presentation/signup/signup.dart
+++ b/lib/presentation/signup/signup.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import '../../application/auth/auth_notifier.dart';
 import '../../utils/auth_error_message.dart';
 import '../../utils/logger.dart';
+import '../widgets/password_text_field.dart';
 
 class SignupPage extends ConsumerStatefulWidget {
   const SignupPage({super.key});
@@ -85,32 +86,6 @@ class _SignupPageState extends ConsumerState<SignupPage> {
     context.pop();
   }
 
-  Widget _buildPasswordField({
-    required TextEditingController controller,
-    required String labelText,
-    required bool obscureText,
-    required VoidCallback onToggleVisibility,
-    required TextInputAction textInputAction,
-  }) {
-    return TextField(
-      controller: controller,
-      decoration: InputDecoration(
-        labelText: labelText,
-        border: const OutlineInputBorder(),
-        suffixIcon: IconButton(
-          tooltip: obscureText ? '$labelTextを表示' : '$labelTextを非表示',
-          icon: Icon(
-            obscureText ? Icons.visibility : Icons.visibility_off,
-          ),
-          onPressed: onToggleVisibility,
-        ),
-      ),
-      obscureText: obscureText,
-      autofillHints: const [AutofillHints.newPassword],
-      textInputAction: textInputAction,
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -152,7 +127,7 @@ class _SignupPageState extends ConsumerState<SignupPage> {
                 textInputAction: TextInputAction.next,
               ),
               const SizedBox(height: 16),
-              _buildPasswordField(
+              PasswordTextField(
                 controller: _passwordController,
                 labelText: 'パスワード',
                 obscureText: _obscurePassword,
@@ -162,9 +137,10 @@ class _SignupPageState extends ConsumerState<SignupPage> {
                   });
                 },
                 textInputAction: TextInputAction.next,
+                autofillHints: const [AutofillHints.newPassword],
               ),
               const SizedBox(height: 16),
-              _buildPasswordField(
+              PasswordTextField(
                 controller: _confirmPasswordController,
                 labelText: 'パスワード再確認',
                 obscureText: _obscureConfirmPassword,
@@ -174,6 +150,7 @@ class _SignupPageState extends ConsumerState<SignupPage> {
                   });
                 },
                 textInputAction: TextInputAction.done,
+                autofillHints: const [AutofillHints.newPassword],
               ),
               const SizedBox(height: 32),
               ElevatedButton(

--- a/lib/presentation/widgets/password_text_field.dart
+++ b/lib/presentation/widgets/password_text_field.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+
+class PasswordTextField extends StatelessWidget {
+  const PasswordTextField({
+    required this.controller,
+    required this.labelText,
+    required this.obscureText,
+    required this.onToggleVisibility,
+    this.textInputAction,
+    this.autofillHints = const [AutofillHints.password],
+    super.key,
+  });
+
+  final TextEditingController controller;
+  final String labelText;
+  final bool obscureText;
+  final VoidCallback onToggleVisibility;
+  final TextInputAction? textInputAction;
+  final Iterable<String>? autofillHints;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      controller: controller,
+      decoration: InputDecoration(
+        labelText: labelText,
+        border: const OutlineInputBorder(),
+        suffixIcon: IconButton(
+          tooltip: obscureText ? '$labelTextを表示' : '$labelTextを非表示',
+          icon: Icon(
+            obscureText ? Icons.visibility : Icons.visibility_off,
+          ),
+          onPressed: onToggleVisibility,
+        ),
+      ),
+      obscureText: obscureText,
+      autofillHints: autofillHints,
+      textInputAction: textInputAction,
+    );
+  }
+}

--- a/test/presentation/auth/login_widget_test.dart
+++ b/test/presentation/auth/login_widget_test.dart
@@ -167,6 +167,24 @@ void main() {
       expect(textField.obscureText, isTrue);
     });
 
+    testWidgets('パスワード表示ボタンで入力内容を表示できる', (tester) async {
+      await tester.pumpWidget(
+        TestUtils.createTestApp(
+          overrides: TestProviders.forLoginForm,
+          child: const LoginPage(),
+        ),
+      );
+
+      final passwordField = find.widgetWithText(TextField, 'パスワード');
+      expect(tester.widget<TextField>(passwordField).obscureText, isTrue);
+
+      await tester.tap(find.byTooltip('パスワードを表示'));
+      await tester.pump();
+
+      expect(tester.widget<TextField>(passwordField).obscureText, isFalse);
+      expect(find.byTooltip('パスワードを非表示'), findsOneWidget);
+    });
+
     testWidgets('フォームバリデーションが動作する', (tester) async {
       await tester.pumpWidget(
         TestUtils.createTestApp(


### PR DESCRIPTION
## Summary
- Add a password visibility toggle to the login password field.
- Extract the shared password text field into `PasswordTextField`.
- Reuse the shared password field on the signup screen.
- Add widget coverage for the login password visibility toggle.

## Why
The signup screen already supports password visibility toggling after the previous change. The login screen should provide the same behavior, and the shared password field keeps both auth screens consistent.

## Test Plan
- `fvm flutter test test/presentation/auth/login_widget_test.dart --dart-define=FLUTTER_TEST=true`
- `fvm flutter test test/presentation/auth/signup_widget_test.dart --dart-define=FLUTTER_TEST=true`
- `fvm flutter analyze lib/presentation/login/login_page.dart lib/presentation/signup/signup.dart lib/presentation/widgets/password_text_field.dart test/presentation/auth/login_widget_test.dart test/presentation/auth/signup_widget_test.dart`