### PR TITLE
fix: preserve settings legal page back navigation

### DIFF
--- a/lib/presentation/settings/settings_page.dart
+++ b/lib/presentation/settings/settings_page.dart
@@ -69,13 +69,13 @@ class SettingsPage extends ConsumerWidget {
             leading: const Icon(Icons.privacy_tip_outlined),
             title: const Text('プライバシーポリシー'),
             trailing: const Icon(Icons.chevron_right),
-            onTap: () => context.go('/settings/privacy-policy'),
+            onTap: () => context.push('/settings/privacy-policy'),
           ),
           ListTile(
             leading: const Icon(Icons.description_outlined),
             title: const Text('利用規約'),
             trailing: const Icon(Icons.chevron_right),
-            onTap: () => context.go('/settings/terms-of-service'),
+            onTap: () => context.push('/settings/terms-of-service'),
           ),
           const Divider(),
           ListTile(


### PR DESCRIPTION
## Summary
- Change settings legal page navigation from `go` to `push`
- Preserve the settings page in navigation history so the app bar back button appears on privacy policy and terms pages

## Verification
- `fvm flutter analyze`
- `fvm flutter test test/presentation/auth/auth_home_navigation_test.dart`
- Device check on SCG19 Android: Settings -> Terms of Service showed the Back button and returned to Settings when tapped

## Notes
- `lib/firebase_options.dart` was copied locally for device verification with user permission and is not included in this PR.