### PR TITLE
Fix list createdAt parsing

### DIFF
--- a/lib/infrastructure/list_repository.dart
+++ b/lib/infrastructure/list_repository.dart
@@ -6,6 +6,19 @@ class ListRepository implements IListRepository {
   ListRepository() : _firestore = FirebaseFirestore.instance;
   final FirebaseFirestore _firestore;
 
+  static DateTime parseCreatedAt(Object? value, {DateTime? fallback}) {
+    if (value is Timestamp) {
+      return value.toDate();
+    }
+    if (value is DateTime) {
+      return value;
+    }
+    if (value is String) {
+      return DateTime.tryParse(value) ?? fallback ?? DateTime.now();
+    }
+    return fallback ?? DateTime.now();
+  }
+
   Map<String, dynamic> _toFirestore(UserList list) {
     final data = list.toJson();
     if (data['createdAt'] != null) {
@@ -16,11 +29,10 @@ class ListRepository implements IListRepository {
 
   UserList _fromFirestore(DocumentSnapshot doc) {
     final data = doc.data() as Map<String, dynamic>;
-    final timestamp = data['createdAt'] as Timestamp?;
     final modifiedData = Map<String, dynamic>.from(data);
     modifiedData['id'] = doc.id;
-    modifiedData['createdAt'] = timestamp?.toDate().toIso8601String() ??
-        DateTime.now().toIso8601String();
+    modifiedData['createdAt'] =
+        parseCreatedAt(data['createdAt']).toIso8601String();
     return UserList.fromJson(modifiedData);
   }
 

--- a/test/infrastructure/list_repository_test.dart
+++ b/test/infrastructure/list_repository_test.dart
@@ -1,0 +1,43 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lakiite/infrastructure/list_repository.dart';
+
+void main() {
+  group('ListRepository', () {
+    group('parseCreatedAt', () {
+      test('TimestampをDateTimeに変換する', () {
+        final createdAt = DateTime(2026, 6, 3, 9);
+
+        final result =
+            ListRepository.parseCreatedAt(Timestamp.fromDate(createdAt));
+
+        expect(result, createdAt);
+      });
+
+      test('ISO文字列をDateTimeに変換する', () {
+        final createdAt = DateTime(2026, 6, 3, 9);
+
+        final result =
+            ListRepository.parseCreatedAt(createdAt.toIso8601String());
+
+        expect(result, createdAt);
+      });
+
+      test('DateTimeはそのまま返す', () {
+        final createdAt = DateTime(2026, 6, 3, 9);
+
+        final result = ListRepository.parseCreatedAt(createdAt);
+
+        expect(result, createdAt);
+      });
+
+      test('nullはfallbackを返す', () {
+        final fallback = DateTime(2026, 6, 3, 9);
+
+        final result = ListRepository.parseCreatedAt(null, fallback: fallback);
+
+        expect(result, fallback);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Accept Timestamp, ISO string, DateTime, and null values when parsing list createdAt
- Prevent schedule creation list loading from failing on legacy/review-account list data
- Add unit coverage for createdAt parsing variants

## Verification
- fvm flutter test test/infrastructure/list_repository_test.dart
- fvm flutter analyze
- Galaxy physical device prod debug: logged in with review account, confirmed the schedule create screen shows the list instead of the createdAt cast error, and saved a test schedule successfully