### PR TITLE
feat: add force update gate

### DIFF
--- a/lib/application/force_update/force_update_providers.dart
+++ b/lib/application/force_update/force_update_providers.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+import '../../domain/entity/app_update_settings.dart';
+import '../../domain/interfaces/i_app_update_settings_repository.dart';
+import '../../domain/value/app_version.dart';
+import '../../infrastructure/app_update_settings_repository.dart';
+
+/// 強制アップデート機能の有効/無効を切り替えるプロバイダー。
+final forceUpdateFeatureEnabledProvider = Provider<bool>((ref) => true);
+
+/// 現在のアプリバージョン情報を提供するプロバイダー。
+final packageInfoProvider = FutureProvider<PackageInfo>(
+  (ref) => PackageInfo.fromPlatform(),
+);
+
+/// アプリ更新設定リポジトリを提供するプロバイダー。
+final appUpdateSettingsRepositoryProvider =
+    Provider<IAppUpdateSettingsRepository>(
+  (ref) => AppUpdateSettingsRepository(),
+);
+
+/// Firestore のアプリ更新設定を監視するプロバイダー。
+final appUpdateSettingsStreamProvider = StreamProvider<AppUpdateSettings?>(
+  (ref) => ref.watch(appUpdateSettingsRepositoryProvider).watchSettings(),
+);
+
+/// 強制アップデートが必要かどうかを返すプロバイダー。
+final isForceUpdateRequiredProvider = Provider<bool>((ref) {
+  if (!ref.watch(forceUpdateFeatureEnabledProvider)) {
+    return false;
+  }
+
+  final settings = ref.watch(appUpdateSettingsStreamProvider).asData?.value;
+  if (settings == null || !settings.forceUpdate) {
+    return false;
+  }
+
+  final packageInfo = ref.watch(packageInfoProvider).asData?.value;
+  if (packageInfo == null) {
+    return false;
+  }
+
+  final minRequiredVersion = switch (defaultTargetPlatform) {
+    TargetPlatform.iOS => settings.iOSMinRequiredVersion,
+    TargetPlatform.android => settings.androidMinRequiredVersion,
+    _ => '',
+  };
+
+  return AppVersion.isCurrentVersionLessThanMinRequired(
+    currentVersion: packageInfo.version,
+    minRequiredVersion: minRequiredVersion,
+  );
+});

--- a/lib/domain/entity/app_update_settings.dart
+++ b/lib/domain/entity/app_update_settings.dart
@@ -1,0 +1,39 @@
+/// 強制アップデート判定に使うアプリバージョン設定。
+class AppUpdateSettings {
+  const AppUpdateSettings({
+    required this.title,
+    required this.content,
+    required this.forceUpdate,
+    required this.iOSLatestVersion,
+    required this.androidLatestVersion,
+    required this.iOSMinRequiredVersion,
+    required this.androidMinRequiredVersion,
+    required this.appStoreUrl,
+    required this.googlePlayUrl,
+  });
+
+  factory AppUpdateSettings.fromJson(Map<String, dynamic> json) {
+    return AppUpdateSettings(
+      title: json['title'] as String? ?? '',
+      content: json['content'] as String? ?? '',
+      forceUpdate: json['forceUpdate'] as bool? ?? false,
+      iOSLatestVersion: json['iOSLatestVersion'] as String? ?? '',
+      androidLatestVersion: json['androidLatestVersion'] as String? ?? '',
+      iOSMinRequiredVersion: json['iOSMinRequiredVersion'] as String? ?? '',
+      androidMinRequiredVersion:
+          json['androidMinRequiredVersion'] as String? ?? '',
+      appStoreUrl: json['appStoreUrl'] as String? ?? '',
+      googlePlayUrl: json['googlePlayUrl'] as String? ?? '',
+    );
+  }
+
+  final String title;
+  final String content;
+  final bool forceUpdate;
+  final String iOSLatestVersion;
+  final String androidLatestVersion;
+  final String iOSMinRequiredVersion;
+  final String androidMinRequiredVersion;
+  final String appStoreUrl;
+  final String googlePlayUrl;
+}

--- a/lib/domain/interfaces/i_app_update_settings_repository.dart
+++ b/lib/domain/interfaces/i_app_update_settings_repository.dart
@@ -1,0 +1,6 @@
+import '../entity/app_update_settings.dart';
+
+/// アプリ更新設定のリポジトリ。
+abstract class IAppUpdateSettingsRepository {
+  Stream<AppUpdateSettings?> watchSettings();
+}

--- a/lib/domain/value/app_version.dart
+++ b/lib/domain/value/app_version.dart
@@ -1,0 +1,58 @@
+/// アプリバージョンの比較ロジック。
+class AppVersion implements Comparable<AppVersion> {
+  const AppVersion._(this._segments);
+
+  /// [version] を `major.minor.patch` として解釈する。
+  ///
+  /// `1.2.3+4` のようなビルド番号は比較対象から除外する。
+  factory AppVersion.parse(String version) {
+    final normalized = version.trim().split('+').first.split('-').first;
+    if (normalized.isEmpty) {
+      throw const FormatException('Version is empty');
+    }
+
+    final segments = normalized.split('.').map((segment) {
+      if (segment.isEmpty) {
+        throw FormatException('Version segment is empty: $version');
+      }
+      return int.parse(segment);
+    }).toList();
+
+    while (segments.length < 3) {
+      segments.add(0);
+    }
+
+    return AppVersion._(segments.take(3).toList());
+  }
+
+  final List<int> _segments;
+
+  /// 現在のバージョンが最低必須バージョン未満かどうかを返す。
+  static bool isCurrentVersionLessThanMinRequired({
+    required String currentVersion,
+    required String minRequiredVersion,
+  }) {
+    if (currentVersion.trim().isEmpty || minRequiredVersion.trim().isEmpty) {
+      return false;
+    }
+
+    try {
+      return AppVersion.parse(currentVersion)
+              .compareTo(AppVersion.parse(minRequiredVersion)) <
+          0;
+    } on FormatException {
+      return false;
+    }
+  }
+
+  @override
+  int compareTo(AppVersion other) {
+    for (var index = 0; index < _segments.length; index++) {
+      final result = _segments[index].compareTo(other._segments[index]);
+      if (result != 0) {
+        return result;
+      }
+    }
+    return 0;
+  }
+}

--- a/lib/infrastructure/app_update_settings_repository.dart
+++ b/lib/infrastructure/app_update_settings_repository.dart
@@ -1,0 +1,31 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import '../domain/entity/app_update_settings.dart';
+import '../domain/interfaces/i_app_update_settings_repository.dart';
+
+/// Firestore からアプリ更新設定を読み取るリポジトリ。
+class AppUpdateSettingsRepository implements IAppUpdateSettingsRepository {
+  AppUpdateSettingsRepository({
+    FirebaseFirestore? firestore,
+  }) : _firestore = firestore ?? FirebaseFirestore.instance;
+
+  static const settingsCollection = 'settings';
+  static const appVersionDocumentId = 'appVersion';
+
+  final FirebaseFirestore _firestore;
+
+  @override
+  Stream<AppUpdateSettings?> watchSettings() {
+    return _firestore
+        .collection(settingsCollection)
+        .doc(appVersionDocumentId)
+        .snapshots()
+        .map((snapshot) {
+      final data = snapshot.data();
+      if (!snapshot.exists || data == null) {
+        return null;
+      }
+      return AppUpdateSettings.fromJson(data);
+    });
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:intl/date_symbol_data_local.dart';
+import 'application/force_update/force_update_providers.dart';
 import 'config/app_config.dart';
 import 'config/admob_config.dart';
 import 'config/firebase_emulator_config.dart';
@@ -11,6 +12,7 @@ import 'config/router/app_router.dart';
 import 'infrastructure/admob_service.dart';
 import 'infrastructure/firebase/push_notification_service.dart';
 import 'infrastructure/notification_navigation_service.dart';
+import 'presentation/force_update/force_update_gate.dart';
 import 'presentation/notification/notification_list_page.dart';
 import 'presentation/theme/app_theme.dart';
 import 'application/app_lifecycle/app_lifecycle_notifier.dart';
@@ -120,8 +122,14 @@ Future<void> startApp([
     }
   }
 
+  final effectiveOverrides = [
+    if (skipFirebaseInit)
+      forceUpdateFeatureEnabledProvider.overrideWithValue(false),
+    ...overrides,
+  ];
+
   // アプリケーションの起動
-  runApp(ProviderScope(overrides: overrides, child: const MyApp()));
+  runApp(ProviderScope(overrides: effectiveOverrides, child: const MyApp()));
 }
 
 /// iOS でのプラットフォームビューリセット処理
@@ -180,6 +188,9 @@ class MyApp extends ConsumerWidget {
       title: 'LaKiite',
       theme: AppTheme.theme,
       routerConfig: router,
+      builder: (context, child) => ForceUpdateGate(
+        child: child ?? const SizedBox.shrink(),
+      ),
       // 環境名をデバッグモードで表示
       debugShowCheckedModeBanner: AppConfig.instance.isDevelopment,
     );

--- a/lib/presentation/force_update/force_update_gate.dart
+++ b/lib/presentation/force_update/force_update_gate.dart
@@ -1,0 +1,87 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../../application/force_update/force_update_providers.dart';
+
+/// 強制アップデートが必要な場合に、通常操作をブロックするゲート。
+class ForceUpdateGate extends ConsumerWidget {
+  const ForceUpdateGate({
+    super.key,
+    required this.child,
+  });
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final isForceUpdateRequired = ref.watch(isForceUpdateRequiredProvider);
+
+    return Stack(
+      children: [
+        child,
+        if (isForceUpdateRequired)
+          const Positioned.fill(
+            child: _ForceUpdateOverlay(),
+          ),
+      ],
+    );
+  }
+}
+
+class _ForceUpdateOverlay extends ConsumerWidget {
+  const _ForceUpdateOverlay();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final settings = ref.watch(appUpdateSettingsStreamProvider).asData?.value;
+    final title =
+        settings?.title.trim().isNotEmpty == true ? settings!.title : 'アプリの更新';
+    final content = settings?.content.trim().isNotEmpty == true
+        ? settings!.content
+        : '最新バージョンのアプリがご利用可能です。ストアから最新バージョンをダウンロードしてください。';
+    final storeUrl =
+        Platform.isIOS ? settings?.appStoreUrl : settings?.googlePlayUrl;
+    final storeName = Platform.isIOS ? 'App Store' : 'Google Play';
+
+    return ColoredBox(
+      color: Colors.black54,
+      child: SafeArea(
+        child: Center(
+          child: AlertDialog(
+            title: Text(title),
+            content: Text(content),
+            actionsAlignment: MainAxisAlignment.center,
+            actions: [
+              ElevatedButton.icon(
+                onPressed: storeUrl == null || storeUrl.trim().isEmpty
+                    ? null
+                    : () => _launchStore(context, storeUrl),
+                icon: const Icon(Icons.open_in_new),
+                label: Text('$storeName へ'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _launchStore(BuildContext context, String storeUrl) async {
+    final uri = Uri.parse(storeUrl);
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+      return;
+    }
+
+    if (!context.mounted) {
+      return;
+    }
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('ストアを開けませんでした')),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -983,6 +983,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  package_info_plus:
+    dependency: "direct main"
+    description:
+      name: package_info_plus
+      sha256: "468c26b4254ab01979fa5e4a98cb343ea3631b9acee6f21028997419a80e1a20"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.0.1"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
   path:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,6 +59,7 @@ dependencies:
   flutter_native_splash: ^2.3.10
   webview_flutter: ^4.10.0
   url_launcher: ^6.2.5
+  package_info_plus: ^9.0.1
 
 dev_dependencies:
   flutter_test:

--- a/test/application/force_update/force_update_providers_test.dart
+++ b/test/application/force_update/force_update_providers_test.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lakiite/application/force_update/force_update_providers.dart';
+import 'package:lakiite/domain/entity/app_update_settings.dart';
+import 'package:lakiite/domain/interfaces/i_app_update_settings_repository.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+void main() {
+  tearDown(() {
+    debugDefaultTargetPlatformOverride = null;
+  });
+
+  group('isForceUpdateRequiredProvider', () {
+    test('機能が無効な場合は更新設定を読まずfalseを返す', () {
+      final container = ProviderContainer(
+        overrides: [
+          forceUpdateFeatureEnabledProvider.overrideWithValue(false),
+          appUpdateSettingsRepositoryProvider.overrideWithValue(
+            _ThrowingAppUpdateSettingsRepository(),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      expect(container.read(isForceUpdateRequiredProvider), isFalse);
+    });
+
+    test('Androidの現在バージョンが最低必須バージョン未満の場合はtrueを返す', () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      final container = _createContainer(
+        currentVersion: '1.2.9',
+        settings: _settings(
+          forceUpdate: true,
+          androidMinRequiredVersion: '1.3.0',
+        ),
+      );
+      addTearDown(container.dispose);
+
+      await container.read(appUpdateSettingsStreamProvider.future);
+      await container.read(packageInfoProvider.future);
+
+      expect(container.read(isForceUpdateRequiredProvider), isTrue);
+    });
+
+    test('appVersion設定が存在しない場合はfalseを返す', () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      final container = _createContainer(
+        currentVersion: '1.0.0',
+        settings: null,
+      );
+      addTearDown(container.dispose);
+
+      await container.read(appUpdateSettingsStreamProvider.future);
+      await container.read(packageInfoProvider.future);
+
+      expect(container.read(isForceUpdateRequiredProvider), isFalse);
+    });
+
+    test('forceUpdateがfalseの場合は最低必須バージョン未満でもfalseを返す', () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      final container = _createContainer(
+        currentVersion: '1.0.0',
+        settings: _settings(
+          forceUpdate: false,
+          iOSMinRequiredVersion: '2.0.0',
+        ),
+      );
+      addTearDown(container.dispose);
+
+      await container.read(appUpdateSettingsStreamProvider.future);
+      await container.read(packageInfoProvider.future);
+
+      expect(container.read(isForceUpdateRequiredProvider), isFalse);
+    });
+  });
+}
+
+ProviderContainer _createContainer({
+  required String currentVersion,
+  required AppUpdateSettings? settings,
+}) {
+  return ProviderContainer(
+    overrides: [
+      forceUpdateFeatureEnabledProvider.overrideWithValue(true),
+      appUpdateSettingsRepositoryProvider.overrideWithValue(
+        _FakeAppUpdateSettingsRepository(settings),
+      ),
+      packageInfoProvider.overrideWith(
+        (ref) async => PackageInfo(
+          appName: 'LaKiite',
+          packageName: 'com.inoworl.lakiite',
+          version: currentVersion,
+          buildNumber: '1',
+        ),
+      ),
+    ],
+  );
+}
+
+AppUpdateSettings _settings({
+  required bool forceUpdate,
+  String iOSMinRequiredVersion = '',
+  String androidMinRequiredVersion = '',
+}) {
+  return AppUpdateSettings(
+    title: 'アプリの更新',
+    content: '最新バージョンへ更新してください。',
+    forceUpdate: forceUpdate,
+    iOSLatestVersion: '',
+    androidLatestVersion: '',
+    iOSMinRequiredVersion: iOSMinRequiredVersion,
+    androidMinRequiredVersion: androidMinRequiredVersion,
+    appStoreUrl: 'https://apps.apple.com/app/example',
+    googlePlayUrl: 'https://play.google.com/store/apps/details?id=example',
+  );
+}
+
+class _FakeAppUpdateSettingsRepository implements IAppUpdateSettingsRepository {
+  _FakeAppUpdateSettingsRepository(this.settings);
+
+  final AppUpdateSettings? settings;
+
+  @override
+  Stream<AppUpdateSettings?> watchSettings() => Stream.value(settings);
+}
+
+class _ThrowingAppUpdateSettingsRepository
+    implements IAppUpdateSettingsRepository {
+  @override
+  Stream<AppUpdateSettings?> watchSettings() {
+    throw StateError('Settings repository must not be read.');
+  }
+}

--- a/test/domain/value/app_version_test.dart
+++ b/test/domain/value/app_version_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lakiite/domain/value/app_version.dart';
+
+void main() {
+  group('AppVersion', () {
+    test('現在バージョンが最低必須バージョン未満の場合はtrueを返す', () {
+      expect(
+        AppVersion.isCurrentVersionLessThanMinRequired(
+          currentVersion: '1.2.9',
+          minRequiredVersion: '1.3.0',
+        ),
+        isTrue,
+      );
+    });
+
+    test('二桁のminor/patchを数値として比較する', () {
+      expect(
+        AppVersion.isCurrentVersionLessThanMinRequired(
+          currentVersion: '1.10.0',
+          minRequiredVersion: '1.2.0',
+        ),
+        isFalse,
+      );
+
+      expect(
+        AppVersion.isCurrentVersionLessThanMinRequired(
+          currentVersion: '1.0.10',
+          minRequiredVersion: '1.0.2',
+        ),
+        isFalse,
+      );
+    });
+
+    test('ビルド番号付きバージョンはビルド番号を除外して比較する', () {
+      expect(
+        AppVersion.isCurrentVersionLessThanMinRequired(
+          currentVersion: '1.2.3+4',
+          minRequiredVersion: '1.2.3',
+        ),
+        isFalse,
+      );
+    });
+
+    test('最低必須バージョンが空の場合は強制アップデート不要として扱う', () {
+      expect(
+        AppVersion.isCurrentVersionLessThanMinRequired(
+          currentVersion: '1.2.3',
+          minRequiredVersion: '',
+        ),
+        isFalse,
+      );
+    });
+  });
+}

--- a/test/mock/providers/test_providers.dart
+++ b/test/mock/providers/test_providers.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lakiite/app/di/providers.dart';
 import 'package:lakiite/application/auth/auth_notifier.dart';
+import 'package:lakiite/application/force_update/force_update_providers.dart';
 import 'package:lakiite/domain/entity/list.dart';
 import 'package:lakiite/domain/entity/notification.dart';
 import '../repository/mock_auth_repository.dart';
@@ -26,6 +27,7 @@ class TestProviders {
           mockNotificationRepository,
         ),
         userRepositoryProvider.overrideWithValue(mockUserRepository),
+        forceUpdateFeatureEnabledProvider.overrideWithValue(false),
       ];
 
   /// 認証済み状態のモックプロバイダー


### PR DESCRIPTION
## Summary
- Add a force update gate that reads settings/appVersion from Firestore
- Add app version comparison and force update providers
- Add tests for version comparison, force update decisions, and missing appVersion settings

## Test Plan
- fvm flutter test test/domain/value/app_version_test.dart test/application/force_update/force_update_providers_test.dart

## Notes
- fvm flutter analyze currently fails in this worktree because lib/firebase_options.dart is not present on the checked out dev branch.