### PR TITLE
fix: show edit name save button

### DIFF
--- a/lib/presentation/settings/edit_name_page.dart
+++ b/lib/presentation/settings/edit_name_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../domain/entity/user.dart';
 import '../my_page/my_page_view_model.dart';
 
 class EditNamePage extends ConsumerStatefulWidget {
@@ -34,6 +35,34 @@ class _EditNamePageState extends ConsumerState<EditNamePage> {
     super.dispose();
   }
 
+  Future<void> _saveName(AsyncValue<UserModel?> userState) async {
+    if (!userState.hasValue || userState.value == null) return;
+
+    final scaffoldMessenger = ScaffoldMessenger.of(context);
+    try {
+      final user = userState.value!;
+      final navigator = Navigator.of(context);
+      await ref.read(myPageViewModelProvider.notifier).updateProfile(
+            name: _nameController.text,
+            displayName: _displayNameController.text,
+            searchIdStr: user.searchId.toString(),
+            shortBio: user.publicProfile.shortBio,
+          );
+      if (mounted) {
+        navigator.pop();
+        scaffoldMessenger.showSnackBar(
+          const SnackBar(content: Text('名前を更新しました')),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        scaffoldMessenger.showSnackBar(
+          SnackBar(content: Text('エラー: ${e.toString()}')),
+        );
+      }
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final userState = ref.watch(myPageViewModelProvider);
@@ -43,37 +72,23 @@ class _EditNamePageState extends ConsumerState<EditNamePage> {
         title: const Text('名前の設定'),
         actions: [
           TextButton(
-            onPressed: () async {
-              if (!userState.hasValue || userState.value == null) return;
-
-              final scaffoldMessenger = ScaffoldMessenger.of(context);
-              try {
-                final user = userState.value!;
-                final navigator = Navigator.of(context);
-                await ref.read(myPageViewModelProvider.notifier).updateProfile(
-                      name: _nameController.text,
-                      displayName: _displayNameController.text,
-                      searchIdStr: user.searchId.toString(),
-                      shortBio: user.publicProfile.shortBio,
-                    );
-                if (mounted) {
-                  navigator.pop();
-                  scaffoldMessenger.showSnackBar(
-                    const SnackBar(content: Text('名前を更新しました')),
-                  );
-                }
-              } catch (e) {
-                if (mounted) {
-                  scaffoldMessenger.showSnackBar(
-                    SnackBar(content: Text('エラー: ${e.toString()}')),
-                  );
-                }
-              }
-            },
+            onPressed: () => _saveName(userState),
             child: const Text('保存'),
           ),
         ],
       ),
+      bottomNavigationBar: userState.hasValue && userState.value != null
+          ? SafeArea(
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: FilledButton(
+                  key: const Key('edit-name-bottom-save-button'),
+                  onPressed: () => _saveName(userState),
+                  child: const Text('保存'),
+                ),
+              ),
+            )
+          : null,
       body: userState.when(
         data: (user) {
           if (user == null) {

--- a/test/presentation/settings/edit_name_page_test.dart
+++ b/test/presentation/settings/edit_name_page_test.dart
@@ -1,0 +1,122 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lakiite/domain/entity/user.dart';
+import 'package:lakiite/domain/interfaces/i_image_cropper_service.dart';
+import 'package:lakiite/domain/interfaces/i_image_processor_service.dart';
+import 'package:lakiite/domain/interfaces/i_storage_service.dart';
+import 'package:lakiite/domain/value/user_id.dart';
+import 'package:lakiite/presentation/my_page/my_page_view_model.dart';
+import 'package:lakiite/presentation/settings/edit_name_page.dart';
+
+import '../../mock/repository/mock_schedule_repository.dart';
+import '../../mock/repository/mock_user_repository.dart';
+
+void main() {
+  testWidgets('名前変更画面はフォーム下部に保存ボタンを表示する', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          myPageViewModelProvider.overrideWith(
+            (ref) => _StubMyPageViewModel(
+              UserModel.create(
+                id: 'user-1',
+                name: '山田太郎',
+                displayName: 'やまちゃん',
+              ),
+              ref,
+            ),
+          ),
+        ],
+        child: const MaterialApp(home: EditNamePage()),
+      ),
+    );
+
+    await tester.pump();
+
+    expect(find.text('名前の設定'), findsOneWidget);
+    expect(
+        find.byKey(const Key('edit-name-bottom-save-button')), findsOneWidget);
+  });
+}
+
+class _StubMyPageViewModel extends MyPageViewModel {
+  _StubMyPageViewModel(UserModel user, Ref ref)
+      : super(
+          MockUserRepository(),
+          MockScheduleRepository(),
+          _FakeStorageService(),
+          _FakeImageProcessorService(),
+          _FakeImageCropperService(),
+          ref,
+        ) {
+    state = AsyncValue.data(user);
+  }
+
+  @override
+  Future<void> updateProfile({
+    required String name,
+    required String displayName,
+    required String searchIdStr,
+    String? shortBio,
+    File? imageFile,
+  }) async {
+    state = AsyncValue.data(
+      state.value!.updateProfile(
+        name: name,
+        displayName: displayName,
+        searchId: UserId(searchIdStr),
+        shortBio: shortBio,
+      ),
+    );
+  }
+}
+
+class _FakeStorageService implements IStorageService {
+  @override
+  Future<String> uploadFile({
+    required String path,
+    required File file,
+    required Map<String, String> metadata,
+    String contentType = 'image/jpeg',
+  }) async {
+    return 'https://storage.example.test/profile.jpg';
+  }
+}
+
+class _FakeImageProcessorService implements IImageProcessorService {
+  @override
+  Future<File> compressImage(
+    File imageFile, {
+    int minWidth = 300,
+    int minHeight = 300,
+    int quality = 85,
+  }) async {
+    return imageFile;
+  }
+
+  @override
+  Future<Directory> createTempDirectory() {
+    return Directory.systemTemp.createTemp('lakiite-edit-name-test');
+  }
+
+  @override
+  Future<File> createTempFile(List<int> data, String extension) async {
+    final directory = await createTempDirectory();
+    final file = File('${directory.path}/image.$extension');
+    return file.writeAsBytes(data);
+  }
+}
+
+class _FakeImageCropperService implements IImageCropperService {
+  @override
+  Future<File?> cropImage({
+    required File sourceFile,
+    double? aspectRatioX,
+    double? aspectRatioY,
+  }) async {
+    return sourceFile;
+  }
+}


### PR DESCRIPTION
## Summary
- 名前変更画面の保存処理を共通化
- AppBarに加えて画面下部にも保存ボタンを追加
- 保存ボタン表示のwidget testを追加

Closes #219

## Verification
- fvm flutter test test/presentation/settings/edit_name_page_test.dart --dart-define=FLUTTER_TEST=true
- fvm flutter analyze lib/presentation/settings/edit_name_page.dart test/presentation/settings/edit_name_page_test.dart
- git diff --check
- Galaxy SCG19 / Android 16 で保存ボタン表示を確認