### PR TITLE
fix: disable reactions on own schedules

### DIFF
--- a/lib/application/schedule/schedule_interaction_notifier.dart
+++ b/lib/application/schedule/schedule_interaction_notifier.dart
@@ -110,6 +110,11 @@ class ScheduleInteractionNotifier
       if (schedule == null) {
         throw Exception('Schedule not found');
       }
+      if (userId == schedule.ownerId) {
+        AppLogger.debug('Skipping reaction - user is the schedule owner');
+        state = state.copyWith(isLoading: false);
+        return;
+      }
 
       final userDoc = await _ref.read(userRepositoryProvider).getUser(userId);
       if (!mounted) {

--- a/lib/presentation/calendar/schedule_detail_page.dart
+++ b/lib/presentation/calendar/schedule_detail_page.dart
@@ -393,6 +393,10 @@ class ScheduleDetailPage extends HookConsumerWidget {
                                   if (authState.user == null) {
                                     return Container(); // 未ログイン時は表示しない
                                   }
+                                  if (currentSchedule.ownerId ==
+                                      authState.user!.id) {
+                                    return const SizedBox.shrink();
+                                  }
 
                                   // 現在のユーザーのリアクションを取得
                                   final userReaction = interactions

--- a/test/application/schedule/schedule_interaction_notifier_test.dart
+++ b/test/application/schedule/schedule_interaction_notifier_test.dart
@@ -305,6 +305,7 @@ class _FakeScheduleInteractionRepository
   late final StreamController<List<ScheduleComment>> _commentsController;
 
   Completer<String>? addReactionCompleter;
+  int addReactionCallCount = 0;
   int _reactionCancelCount = 0;
   int _commentListenCount = 0;
   int _commentCancelCount = 0;
@@ -350,8 +351,12 @@ class _FakeScheduleInteractionRepository
     String userId,
     ReactionType type,
   ) {
-    addReactionCompleter ??= Completer<String>();
-    return addReactionCompleter!.future;
+    addReactionCallCount++;
+    final completer = addReactionCompleter;
+    if (completer != null) {
+      return completer.future;
+    }
+    return Future.value('reaction-$addReactionCallCount');
   }
 
   @override
@@ -436,8 +441,8 @@ void main() {
           description: 'Desc',
           startDateTime: DateTime(2024, 1, 1, 10),
           endDateTime: DateTime(2024, 1, 1, 12),
-          ownerId: user.id,
-          ownerDisplayName: user.displayName,
+          ownerId: 'owner-1',
+          ownerDisplayName: 'Owner',
           sharedLists: const [],
           visibleTo: const [],
           createdAt: DateTime(2024, 1, 1),
@@ -536,6 +541,99 @@ void main() {
           finalState.reactions.map((r) => r.id),
           containsAll(['reaction-1', 'reaction-2', 'reaction-current-user']),
         );
+      },
+    );
+
+    test(
+      'toggleReaction should ignore reactions from the schedule owner',
+      () async {
+        final user = UserModel(
+          publicProfile: PublicUserModel(
+            id: 'user-1',
+            displayName: 'User One',
+            searchId: UserId('USRTEST1'),
+            iconUrl: null,
+            shortBio: null,
+          ),
+          privateProfile: PrivateUserModel(
+            id: 'user-1',
+            name: 'User One',
+            friends: const [],
+            groups: const [],
+            lists: const [],
+            createdAt: DateTime(2024, 1, 1),
+          ),
+        );
+
+        final schedule = Schedule(
+          id: 'schedule-1',
+          title: 'Sample',
+          description: 'Desc',
+          startDateTime: DateTime(2024, 1, 1, 10),
+          endDateTime: DateTime(2024, 1, 1, 12),
+          ownerId: user.id,
+          ownerDisplayName: user.displayName,
+          sharedLists: const [],
+          visibleTo: const [],
+          createdAt: DateTime(2024, 1, 1),
+          updatedAt: DateTime(2024, 1, 1),
+        );
+
+        final repository = _FakeScheduleInteractionRepository();
+        addTearDown(repository.dispose);
+
+        final container = ProviderContainer(
+          overrides: [
+            auth.authNotifierProvider.overrideWith(
+              () => _StubAuthNotifier(AuthState.authenticated(user)),
+            ),
+            scheduleInteractionRepositoryProvider.overrideWithValue(repository),
+            scheduleInteractionNotifierProvider.overrideWith((ref, scheduleId) {
+              return ScheduleInteractionNotifier(
+                ref.watch(scheduleInteractionRepositoryProvider),
+                scheduleId,
+                ref,
+                enablePushNotifications: false,
+              );
+            }),
+            scheduleRepositoryProvider.overrideWithValue(
+              _FakeScheduleRepository(schedule),
+            ),
+            userRepositoryProvider.overrideWithValue(_FakeUserRepository(user)),
+            notification.notificationRepositoryProvider.overrideWithValue(
+              _FakeNotificationRepository(),
+            ),
+            notification.pushNotificationSenderProvider.overrideWithValue(
+              PushNotificationSender(
+                cloudFunctionUrl: 'https://example.test/push',
+                tokenResolver: (_) async => const [],
+              ),
+            ),
+            notification.notificationNotifierProvider.overrideWith((ref) {
+              return _FakeNotificationNotifier(ref);
+            }),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        final provider = scheduleInteractionNotifierProvider(schedule.id);
+        final subscription = container.listen(
+          provider,
+          (_, __) {},
+          fireImmediately: true,
+        );
+        addTearDown(subscription.close);
+        await repository.waitForReactionListener();
+
+        await container
+            .read(provider.notifier)
+            .toggleReaction(user.id, ReactionType.going);
+
+        final finalState = container.read(provider);
+
+        expect(repository.addReactionCallCount, 0);
+        expect(finalState.isLoading, isFalse);
+        expect(finalState.reactions, isEmpty);
       },
     );
 


### PR DESCRIPTION
## Summary
- 予定作成者本人のtoggleReactionをapplication層でno-op化
- 予定詳細画面では作成者本人にリアクション追加ボタンを表示しない
- 作成者本人のリアクション保存を防ぐ回帰テストを追加

Closes #221

## Verification
- fvm flutter test test/application/schedule/schedule_interaction_notifier_test.dart --dart-define=FLUTTER_TEST=true
- fvm flutter analyze lib/application/schedule/schedule_interaction_notifier.dart lib/presentation/calendar/schedule_detail_page.dart test/application/schedule/schedule_interaction_notifier_test.dart
- git diff --check
- Galaxy SCG19 / Android 16 で一時予定を使い、作成者本人にリアクション追加ボタンが表示されないことを確認
- 確認用の一時予定は削除済み