### PR TITLE
feat: expand user icon images

### DIFF
--- a/lib/application/auth/auth_notifier.dart
+++ b/lib/application/auth/auth_notifier.dart
@@ -1,5 +1,6 @@
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/painting.dart';
 import 'package:flutter/services.dart';
 import 'dart:io';
 import '../../domain/interfaces/i_auth_repository.dart';
@@ -40,6 +41,14 @@ final authStateStreamProvider = StreamProvider.autoDispose<AuthState>((ref) {
     }
     return AuthState.unauthenticated();
   });
+});
+
+final authImageCacheClearerProvider = Provider<void Function()>((ref) {
+  return () {
+    PaintingBinding.instance.imageCache
+      ..clear()
+      ..clearLiveImages();
+  };
 });
 
 /// 認証状態を管理するNotifierクラス
@@ -241,7 +250,15 @@ class AuthNotifier extends _$AuthNotifier {
         await _authRepository.signOut();
         AppLogger.debug('認証サインアウトが完了しました');
 
-        // 3. WebView 関連の強制クリーンアップ
+        // 3. 前ユーザーのアイコン画像がメモリキャッシュに残らないようにする
+        try {
+          ref.read(authImageCacheClearerProvider)();
+          AppLogger.debug('画像キャッシュをクリアしました');
+        } catch (e) {
+          AppLogger.warning('画像キャッシュクリアエラー（無視して続行）: $e');
+        }
+
+        // 4. WebView 関連の強制クリーンアップ
         try {
           // WebView インスタンスの状態を確認
           WebViewMonitor.printStatus();

--- a/lib/presentation/friend/friend_profile_page.dart
+++ b/lib/presentation/friend/friend_profile_page.dart
@@ -7,6 +7,7 @@ import '../../domain/entity/schedule.dart';
 import '../../domain/entity/user.dart';
 import '../calendar/schedule_providers.dart';
 import '../schedule/schedule_display_order.dart';
+import '../widgets/expandable_user_avatar.dart';
 import '../widgets/schedule_tile.dart';
 import '../../utils/logger.dart';
 
@@ -74,18 +75,9 @@ class FriendProfilePage extends ConsumerWidget {
                       child: Row(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
-                          CircleAvatar(
-                            radius: 40,
-                            backgroundColor: Theme.of(context)
-                                .primaryColor
-                                .withValues(alpha: 0.1),
-                            backgroundImage: user.iconUrl != null
-                                ? NetworkImage(user.iconUrl!)
-                                : null,
-                            child: user.iconUrl == null
-                                ? const Icon(Icons.person,
-                                    size: 40, color: Colors.grey)
-                                : null,
+                          ExpandableUserAvatar(
+                            imageUrl: user.iconUrl,
+                            size: 80,
                           ),
                           const SizedBox(width: 16),
                           Expanded(

--- a/lib/presentation/my_page/widgets/profile_card.dart
+++ b/lib/presentation/my_page/widgets/profile_card.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import '../../../domain/entity/user.dart';
-import '../../widgets/default_user_icon.dart';
+import '../../widgets/expandable_user_avatar.dart';
 import 'search_id_display.dart';
 
 /// ユーザープロフィールカードを表示するウィジェット
@@ -62,34 +62,11 @@ class ProfileCard extends StatelessWidget {
   }
 
   /// ユーザーアバターを構築
-  /// nullチェックを行い、適切なフォールバックを提供
+  /// 画像URLがある場合はタップで拡大表示する。
   Widget _buildUserAvatar(BuildContext context) {
-    // iconUrlがnullまたは空文字列の場合はデフォルトアイコンを使用
-    if (user.iconUrl == null || user.iconUrl!.isEmpty) {
-      return const DefaultUserIcon(size: 80);
-    }
-
-    // NetworkImageでエラーが発生した場合のフォールバックも含める
-    return CircleAvatar(
-      radius: 40,
-      backgroundColor: Theme.of(context).primaryColor.withValues(alpha: 0.1),
-      child: ClipRRect(
-        borderRadius: BorderRadius.circular(40),
-        child: Image.network(
-          user.iconUrl!,
-          width: 80,
-          height: 80,
-          fit: BoxFit.cover,
-          loadingBuilder: (context, child, loadingProgress) {
-            if (loadingProgress == null) return child;
-            return const DefaultUserIcon(size: 80);
-          },
-          errorBuilder: (context, error, stackTrace) {
-            // ネットワークエラーや画像読み込みエラーの場合
-            return const DefaultUserIcon(size: 80);
-          },
-        ),
-      ),
+    return ExpandableUserAvatar(
+      imageUrl: user.iconUrl,
+      size: 80,
     );
   }
 }

--- a/lib/presentation/widgets/expandable_user_avatar.dart
+++ b/lib/presentation/widgets/expandable_user_avatar.dart
@@ -1,0 +1,147 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:photo_view/photo_view.dart';
+
+import 'default_user_icon.dart';
+
+class ExpandableUserAvatar extends StatefulWidget {
+  const ExpandableUserAvatar({
+    super.key,
+    this.imageUrl,
+    this.size = 80,
+  });
+
+  final String? imageUrl;
+  final double size;
+
+  @override
+  State<ExpandableUserAvatar> createState() => _ExpandableUserAvatarState();
+}
+
+class _ExpandableUserAvatarState extends State<ExpandableUserAvatar> {
+  static var _heroTagSeed = 0;
+  late final String _heroTag = 'expandable-user-avatar-${_heroTagSeed++}';
+
+  @override
+  Widget build(BuildContext context) {
+    final normalizedImageUrl = widget.imageUrl?.trim();
+    final hasImage =
+        normalizedImageUrl != null && normalizedImageUrl.isNotEmpty;
+
+    if (!hasImage) {
+      return DefaultUserIcon(size: widget.size);
+    }
+
+    final avatar = Hero(
+      tag: _heroTag,
+      child: _AvatarImage(
+        imageUrl: normalizedImageUrl,
+        size: widget.size,
+      ),
+    );
+
+    return Semantics(
+      button: true,
+      label: 'アイコン画像を拡大',
+      child: InkWell(
+        key: const Key('expandable-user-avatar-button'),
+        customBorder: const CircleBorder(),
+        onTap: () => _showExpandedAvatar(
+          context,
+          imageUrl: normalizedImageUrl,
+          heroTag: _heroTag,
+        ),
+        child: avatar,
+      ),
+    );
+  }
+
+  void _showExpandedAvatar(
+    BuildContext context, {
+    required String imageUrl,
+    required String heroTag,
+  }) {
+    Navigator.of(context).push<void>(
+      MaterialPageRoute<void>(
+        builder: (context) => _ExpandedUserAvatarPage(
+          imageUrl: imageUrl,
+          heroTag: heroTag,
+        ),
+      ),
+    );
+  }
+}
+
+class _ExpandedUserAvatarPage extends StatelessWidget {
+  const _ExpandedUserAvatarPage({
+    required this.imageUrl,
+    required this.heroTag,
+  });
+
+  final String imageUrl;
+  final String heroTag;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.black,
+      appBar: AppBar(
+        backgroundColor: Colors.black,
+        elevation: 0,
+        systemOverlayStyle: SystemUiOverlayStyle.light,
+        leading: IconButton(
+          tooltip: '閉じる',
+          onPressed: () => Navigator.of(context).pop(),
+          icon: const Icon(Icons.close, color: Colors.white),
+        ),
+      ),
+      body: PhotoView(
+        key: const Key('expanded-user-avatar-image'),
+        imageProvider: NetworkImage(imageUrl),
+        minScale: PhotoViewComputedScale.contained,
+        heroAttributes: PhotoViewHeroAttributes(tag: heroTag),
+        backgroundDecoration: const BoxDecoration(color: Colors.black),
+        errorBuilder: (context, error, stackTrace) {
+          return const Center(
+            child: DefaultUserIcon(size: 160),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _AvatarImage extends StatelessWidget {
+  const _AvatarImage({
+    required this.imageUrl,
+    required this.size,
+  });
+
+  final String imageUrl;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    return CircleAvatar(
+      radius: size / 2,
+      backgroundColor: Theme.of(context).primaryColor.withValues(alpha: 0.1),
+      child: ClipOval(
+        child: Image.network(
+          imageUrl,
+          width: size,
+          height: size,
+          fit: BoxFit.cover,
+          loadingBuilder: (context, child, loadingProgress) {
+            if (loadingProgress == null) {
+              return child;
+            }
+            return DefaultUserIcon(size: size);
+          },
+          errorBuilder: (context, error, stackTrace) {
+            return DefaultUserIcon(size: size);
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1039,6 +1039,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.2"
+  photo_view:
+    dependency: "direct main"
+    description:
+      name: photo_view
+      sha256: "1fc3d970a91295fbd1364296575f854c9863f225505c28c46e0a03e48960c75e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.15.0"
   platform:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -60,6 +60,7 @@ dependencies:
   webview_flutter: ^4.10.0
   url_launcher: ^6.2.5
   package_info_plus: ^9.0.1
+  photo_view: ^0.15.0
 
 dev_dependencies:
   flutter_test:

--- a/test/application/auth/auth_notifier_test.dart
+++ b/test/application/auth/auth_notifier_test.dart
@@ -101,6 +101,53 @@ void main() {
       }
     });
 
+    test('ログアウト時に画像キャッシュをクリアする', () async {
+      var didClearImageCache = false;
+      final testUser = MockAuthRepository.createTestUser(
+        name: 'テストユーザー',
+        displayName: 'テスト表示名',
+      );
+      mockAuthRepository.setCurrentUser(testUser);
+
+      final isolatedContainer = createTestProviderContainer(
+        overrides: [
+          notifier.authRepositoryProvider.overrideWithValue(mockAuthRepository),
+          notifier.authStateStreamProvider.overrideWith((ref) {
+            return Stream.value(AuthState.authenticated(testUser));
+          }),
+          notifier.authImageCacheClearerProvider.overrideWithValue(() {
+            didClearImageCache = true;
+          }),
+        ],
+      );
+
+      final subscription = isolatedContainer.listen(
+        notifier.authNotifierProvider,
+        (_, __) {},
+        fireImmediately: true,
+      );
+
+      try {
+        for (var i = 0; i < 10; i++) {
+          if (isolatedContainer.read(notifier.authNotifierProvider).hasValue) {
+            break;
+          }
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+        }
+        expect(isolatedContainer.read(notifier.authNotifierProvider).hasValue,
+            isTrue);
+
+        await isolatedContainer
+            .read(notifier.authNotifierProvider.notifier)
+            .signOut();
+
+        expect(didClearImageCache, isTrue);
+      } finally {
+        subscription.close();
+        isolatedContainer.dispose();
+      }
+    });
+
     test('再認証が必要な場合のエラーハンドリング', () async {
       // 準備: ユーザーがログイン済みだが、削除時に再認証が必要な状態
       final testUser = MockAuthRepository.createTestUser(

--- a/test/presentation/widgets/expandable_user_avatar_test.dart
+++ b/test/presentation/widgets/expandable_user_avatar_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:photo_view/photo_view.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lakiite/presentation/widgets/expandable_user_avatar.dart';
+
+void main() {
+  group('ExpandableUserAvatar', () {
+    testWidgets('画像URLありのアイコンをタップすると全画面で拡大表示する', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: ExpandableUserAvatar(
+              imageUrl: 'https://example.com/avatar.jpg',
+              size: 80,
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byKey(const Key('expandable-user-avatar-button')));
+      await tester.pumpAndSettle();
+
+      final scaffold = tester.widget<Scaffold>(find.byType(Scaffold).last);
+      expect(scaffold.backgroundColor, Colors.black);
+      expect(find.byType(PhotoView), findsOneWidget);
+      expect(
+          find.byKey(const Key('expanded-user-avatar-image')), findsOneWidget);
+      expect(find.byTooltip('閉じる'), findsOneWidget);
+    });
+
+    testWidgets('画像URLがない場合はタップ対象にしない', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: ExpandableUserAvatar(size: 80),
+          ),
+        ),
+      );
+
+      expect(
+          find.byKey(const Key('expandable-user-avatar-button')), findsNothing);
+      expect(find.byType(PhotoView), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- ユーザーアイコン画像をタップすると黒背景の全画面ビューで拡大表示できる共通ウィジェットを追加
- ZEN側の実装を確認し、画像拡大は `photo_view` を使う方針に合わせた
- ZENでは `cached_network_image` も使っていたが、ログアウト後のキャッシュ残存を避けるためLaKiiteでは導入しない
- マイページのプロフィールカードとフレンドプロフィール画面のアイコンに拡大表示を適用
- 画像URLがない場合は従来どおりデフォルトアイコンを表示し、タップ対象にしない
- ログアウト時にFlutterの画像メモリキャッシュをクリアする

Closes #226

## Verification
- fvm flutter test test/presentation/widgets/expandable_user_avatar_test.dart --dart-define=FLUTTER_TEST=true
- fvm flutter test test/application/auth/auth_notifier_test.dart --plain-name 'ログアウト時に画像キャッシュをクリアする' --dart-define=FLUTTER_TEST=true
- fvm flutter test test/application/auth/auth_notifier_test.dart --dart-define=FLUTTER_TEST=true
- fvm flutter analyze lib/presentation/widgets/expandable_user_avatar.dart lib/application/auth/auth_notifier.dart test/presentation/widgets/expandable_user_avatar_test.dart test/application/auth/auth_notifier_test.dart
- git diff --check

## Notes
- OPPO実機の起動・ログイン確認はユーザー側で継続予定のため、このPR更新では未実施