### PR TITLE
[codex] Add display lists for schedule colors

### DIFF
--- a/lib/app/di/providers.dart
+++ b/lib/app/di/providers.dart
@@ -2,6 +2,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lakiite/domain/interfaces/i_friend_list_repository.dart';
+import 'package:lakiite/domain/interfaces/i_display_list_repository.dart';
 import 'package:lakiite/domain/interfaces/i_list_repository.dart';
 import 'package:lakiite/domain/interfaces/i_notification_repository.dart';
 import 'package:lakiite/domain/interfaces/i_schedule_interaction_repository.dart';
@@ -12,6 +13,7 @@ import 'package:lakiite/domain/service/list_manager.dart';
 import 'package:lakiite/domain/service/schedule_manager.dart';
 import 'package:lakiite/domain/service/user_manager.dart';
 import 'package:lakiite/infrastructure/friend_list_repository.dart';
+import 'package:lakiite/infrastructure/display_list_repository.dart';
 import 'package:lakiite/infrastructure/list_repository.dart';
 import 'package:lakiite/infrastructure/notification_repository.dart';
 import 'package:lakiite/infrastructure/repository/reaction_repository_impl.dart';
@@ -58,6 +60,11 @@ final userRepositoryProvider = Provider<IUserRepository>((ref) {
 /// リストリポジトリプロバイダー。
 final listRepositoryProvider = Provider<IListRepository>((ref) {
   return ListRepository();
+});
+
+/// 表示用リストリポジトリプロバイダー。
+final displayListRepositoryProvider = Provider<IDisplayListRepository>((ref) {
+  return DisplayListRepository();
 });
 
 /// スケジュールリポジトリプロバイダー。

--- a/lib/domain/entity/display_list.dart
+++ b/lib/domain/entity/display_list.dart
@@ -1,0 +1,39 @@
+class DisplayList {
+  const DisplayList({
+    required this.id,
+    required this.name,
+    required this.ownerId,
+    required this.colorKey,
+    required this.memberIds,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  final String id;
+  final String name;
+  final String ownerId;
+  final String colorKey;
+  final List<String> memberIds;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  DisplayList copyWith({
+    String? id,
+    String? name,
+    String? ownerId,
+    String? colorKey,
+    List<String>? memberIds,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return DisplayList(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      ownerId: ownerId ?? this.ownerId,
+      colorKey: colorKey ?? this.colorKey,
+      memberIds: memberIds ?? this.memberIds,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+    );
+  }
+}

--- a/lib/domain/interfaces/i_display_list_repository.dart
+++ b/lib/domain/interfaces/i_display_list_repository.dart
@@ -1,0 +1,33 @@
+import 'package:lakiite/domain/entity/display_list.dart';
+
+abstract class IDisplayListRepository {
+  Future<List<DisplayList>> getDisplayLists(String ownerId);
+
+  Stream<List<DisplayList>> watchDisplayLists(String ownerId);
+
+  Future<DisplayList> createDisplayList({
+    required String ownerId,
+    required String name,
+    required String colorKey,
+    required List<String> memberIds,
+  });
+
+  Future<void> updateDisplayList(DisplayList displayList);
+
+  Future<void> deleteDisplayList({
+    required String ownerId,
+    required String displayListId,
+  });
+
+  Future<void> addMember({
+    required String ownerId,
+    required String displayListId,
+    required String userId,
+  });
+
+  Future<void> removeMember({
+    required String ownerId,
+    required String displayListId,
+    required String userId,
+  });
+}

--- a/lib/domain/service/display_list_membership.dart
+++ b/lib/domain/service/display_list_membership.dart
@@ -1,0 +1,33 @@
+import 'package:lakiite/domain/entity/display_list.dart';
+
+class DisplayListMembership {
+  const DisplayListMembership._();
+
+  static DisplayList? findListForUser({
+    required Iterable<DisplayList> displayLists,
+    required String userId,
+  }) {
+    for (final displayList in displayLists) {
+      if (displayList.memberIds.contains(userId)) {
+        return displayList;
+      }
+    }
+    return null;
+  }
+
+  static DisplayList? findConflictingList({
+    required Iterable<DisplayList> displayLists,
+    required String targetListId,
+    required String userId,
+  }) {
+    for (final displayList in displayLists) {
+      if (displayList.id == targetListId) {
+        continue;
+      }
+      if (displayList.memberIds.contains(userId)) {
+        return displayList;
+      }
+    }
+    return null;
+  }
+}

--- a/lib/infrastructure/display_list_repository.dart
+++ b/lib/infrastructure/display_list_repository.dart
@@ -1,0 +1,130 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:lakiite/domain/entity/display_list.dart';
+import 'package:lakiite/domain/interfaces/i_display_list_repository.dart';
+
+class DisplayListRepository implements IDisplayListRepository {
+  DisplayListRepository() : _firestore = FirebaseFirestore.instance;
+
+  final FirebaseFirestore _firestore;
+
+  CollectionReference<Map<String, dynamic>> _collection(String ownerId) {
+    return _firestore
+        .collection('users')
+        .doc(ownerId)
+        .collection('displayLists');
+  }
+
+  static DateTime parseDateTime(Object? value, {DateTime? fallback}) {
+    if (value is Timestamp) {
+      return value.toDate();
+    }
+    if (value is DateTime) {
+      return value;
+    }
+    if (value is String) {
+      return DateTime.tryParse(value) ?? fallback ?? DateTime.now();
+    }
+    return fallback ?? DateTime.now();
+  }
+
+  Map<String, dynamic> _toFirestore(DisplayList displayList) {
+    return {
+      'name': displayList.name,
+      'ownerId': displayList.ownerId,
+      'colorKey': displayList.colorKey,
+      'memberIds': displayList.memberIds,
+      'createdAt': Timestamp.fromDate(displayList.createdAt),
+      'updatedAt': Timestamp.fromDate(displayList.updatedAt),
+    };
+  }
+
+  DisplayList _fromFirestore(DocumentSnapshot<Map<String, dynamic>> doc) {
+    final data = doc.data() ?? const <String, dynamic>{};
+    return DisplayList(
+      id: doc.id,
+      name: data['name'] as String? ?? '',
+      ownerId: data['ownerId'] as String? ?? doc.reference.parent.parent!.id,
+      colorKey: data['colorKey'] as String? ?? 'blue',
+      memberIds: List<String>.from(data['memberIds'] as List? ?? []),
+      createdAt: parseDateTime(data['createdAt']),
+      updatedAt: parseDateTime(data['updatedAt']),
+    );
+  }
+
+  @override
+  Future<List<DisplayList>> getDisplayLists(String ownerId) async {
+    final snapshot = await _collection(ownerId)
+        .orderBy('createdAt', descending: false)
+        .get();
+    return snapshot.docs.map(_fromFirestore).toList();
+  }
+
+  @override
+  Stream<List<DisplayList>> watchDisplayLists(String ownerId) {
+    return _collection(ownerId)
+        .orderBy('createdAt', descending: false)
+        .snapshots()
+        .map((snapshot) => snapshot.docs.map(_fromFirestore).toList());
+  }
+
+  @override
+  Future<DisplayList> createDisplayList({
+    required String ownerId,
+    required String name,
+    required String colorKey,
+    required List<String> memberIds,
+  }) async {
+    final now = DateTime.now();
+    final displayList = DisplayList(
+      id: '',
+      name: name,
+      ownerId: ownerId,
+      colorKey: colorKey,
+      memberIds: memberIds,
+      createdAt: now,
+      updatedAt: now,
+    );
+    final docRef = await _collection(ownerId).add(_toFirestore(displayList));
+    final doc = await docRef.get();
+    return _fromFirestore(doc);
+  }
+
+  @override
+  Future<void> updateDisplayList(DisplayList displayList) async {
+    await _collection(displayList.ownerId).doc(displayList.id).update(
+          _toFirestore(displayList.copyWith(updatedAt: DateTime.now())),
+        );
+  }
+
+  @override
+  Future<void> deleteDisplayList({
+    required String ownerId,
+    required String displayListId,
+  }) async {
+    await _collection(ownerId).doc(displayListId).delete();
+  }
+
+  @override
+  Future<void> addMember({
+    required String ownerId,
+    required String displayListId,
+    required String userId,
+  }) async {
+    await _collection(ownerId).doc(displayListId).update({
+      'memberIds': FieldValue.arrayUnion([userId]),
+      'updatedAt': Timestamp.fromDate(DateTime.now()),
+    });
+  }
+
+  @override
+  Future<void> removeMember({
+    required String ownerId,
+    required String displayListId,
+    required String userId,
+  }) async {
+    await _collection(ownerId).doc(displayListId).update({
+      'memberIds': FieldValue.arrayRemove([userId]),
+      'updatedAt': Timestamp.fromDate(DateTime.now()),
+    });
+  }
+}

--- a/lib/presentation/bottom_navigation/bottom_navigation.dart
+++ b/lib/presentation/bottom_navigation/bottom_navigation.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../home/home_page.dart';
 import '../friend/friend_list_page.dart';
+import '../list/list_page.dart';
 import '../my_page/my_page.dart';
 import '../widgets/auth_dependent_builder.dart';
 import '../../infrastructure/notification_navigation_service.dart';
@@ -42,6 +43,7 @@ class _AuthenticatedBottomNavigationShellState
   final List<Widget> _pages = [
     const HomePage(key: PageStorageKey('home_page')),
     const FriendListPage(key: PageStorageKey('friend_list_page')),
+    const ListPage(key: PageStorageKey('list_page')),
     const MyPage(key: PageStorageKey('my_page')),
   ];
 
@@ -101,6 +103,11 @@ class _AuthenticatedBottomNavigationShellState
               icon: Icon(Icons.groups_3_outlined),
               activeIcon: Icon(Icons.groups_3),
               label: 'フレンド',
+            ),
+            BottomNavigationBarItem(
+              icon: Icon(Icons.format_list_bulleted_outlined),
+              activeIcon: Icon(Icons.format_list_bulleted),
+              label: 'リスト',
             ),
             BottomNavigationBarItem(
               icon: Icon(Icons.person_outline),

--- a/lib/presentation/calendar/widgets/calendar_page_view.dart
+++ b/lib/presentation/calendar/widgets/calendar_page_view.dart
@@ -2,12 +2,14 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:lakiite/application/notification/notification_notifier.dart';
+import 'package:lakiite/domain/entity/display_list.dart';
 import 'package:lakiite/domain/entity/schedule.dart';
 import 'package:lakiite/presentation/calendar/calendar_providers.dart';
 import 'package:lakiite/presentation/calendar/schedule_providers.dart';
 import 'package:lakiite/presentation/calendar/widgets/daily_schedule_list_page.dart';
 import 'package:lakiite/presentation/calendar/widgets/daily_schedule_view.dart';
 import 'package:lakiite/presentation/calendar/widgets/schedule_ownership_style.dart';
+import 'package:lakiite/presentation/list/display_list_providers.dart';
 import 'package:lakiite/presentation/schedule/schedule_display_order.dart';
 import 'package:lakiite/presentation/theme/app_theme.dart';
 import 'package:lakiite/presentation/calendar/create_schedule_page.dart';
@@ -975,6 +977,14 @@ class CalendarPageContent extends HookConsumerWidget {
       return _generateOptimizedScheduleMap(
           currentDates, schedules, visiblePageDate, isOptimized);
     }, [currentDates, schedules, visiblePageDate, isOptimized]);
+    final stableDateSchedulesMap = useRef(dateSchedulesMap);
+    final hasStableSchedules =
+        stableDateSchedulesMap.value.values.any((items) => items.isNotEmpty);
+    if (!isOptimized || !hasStableSchedules) {
+      stableDateSchedulesMap.value = dateSchedulesMap;
+    }
+    final displayDateSchedulesMap =
+        isOptimized ? stableDateSchedulesMap.value : dateSchedulesMap;
 
     // 日付別セルを事前に計算してパフォーマンスを向上（最適化モードではシンプルなセル）
     final dateCells = useMemoized(
@@ -987,18 +997,18 @@ class CalendarPageContent extends HookConsumerWidget {
                 return OptimizedDatesRow(
                   rowIndex: rowIndex,
                   dates: rowDates,
-                  dateSchedulesMap: dateSchedulesMap,
+                  dateSchedulesMap: displayDateSchedulesMap,
                   visibleMonth: visiblePageDate,
                 );
               }
 
               return DatesRow(
                 dates: rowDates,
-                dateSchedulesMap: dateSchedulesMap,
+                dateSchedulesMap: displayDateSchedulesMap,
                 visibleMonth: visiblePageDate,
               );
             }),
-        [currentDates, dateSchedulesMap, visiblePageDate, isOptimized]);
+        [currentDates, displayDateSchedulesMap, visiblePageDate, isOptimized]);
 
     // パフォーマンス最適化のためのコンテナ
     return RepaintBoundary(
@@ -1103,6 +1113,9 @@ class DateCell extends ConsumerWidget {
     final isSaturday = date.weekday == DateTime.saturday;
     final isCurrentMonth = date.month == visibleMonth.month;
     final currentUserId = ref.watch(currentUserIdProvider);
+    final displayLists =
+        ref.watch(userDisplayListsStreamProvider).valueOrNull ??
+            const <DisplayList>[];
 
     // 祝日のチェック（コンテキストからProviderScopeを取得）
     final dateString =
@@ -1141,6 +1154,7 @@ class DateCell extends ConsumerWidget {
             isHoliday: isHolidayFromAsync,
             holidayName: holidays[dateString] ?? '',
             currentUserId: currentUserId,
+            displayLists: displayLists,
           );
         },
         loading: () => OptimizedDateCell(
@@ -1153,6 +1167,7 @@ class DateCell extends ConsumerWidget {
           isHoliday: false,
           holidayName: '',
           currentUserId: currentUserId,
+          displayLists: displayLists,
         ),
         error: (_, __) => OptimizedDateCell(
           date: date,
@@ -1164,6 +1179,7 @@ class DateCell extends ConsumerWidget {
           isHoliday: false,
           holidayName: '',
           currentUserId: currentUserId,
+          displayLists: displayLists,
         ),
       );
     }
@@ -1179,6 +1195,7 @@ class DateCell extends ConsumerWidget {
       isHoliday: isHoliday,
       holidayName: cachedHolidays[dateString] ?? '',
       currentUserId: currentUserId,
+      displayLists: displayLists,
     );
   }
 
@@ -1202,6 +1219,7 @@ class OptimizedDateCell extends StatelessWidget {
     required this.isHoliday,
     required this.holidayName,
     required this.currentUserId,
+    this.displayLists = const [],
     super.key,
   });
 
@@ -1214,6 +1232,7 @@ class OptimizedDateCell extends StatelessWidget {
   final bool isHoliday;
   final String holidayName;
   final String? currentUserId;
+  final Iterable<DisplayList> displayLists;
 
   @override
   Widget build(BuildContext context) {
@@ -1299,6 +1318,7 @@ class OptimizedDateCell extends StatelessWidget {
                           context,
                           schedule: schedule,
                           currentUserId: currentUserId,
+                          displayLists: displayLists,
                           backgroundAlpha: 0.15,
                           borderAlpha: 0.3,
                           primaryTextAlpha: 0.8,
@@ -1346,6 +1366,7 @@ class OptimizedDateCell extends StatelessWidget {
                                       date: date,
                                       schedules: sortedSchedules,
                                       currentUserId: currentUserId,
+                                      displayLists: displayLists,
                                     ),
                                   ),
                                 );

--- a/lib/presentation/calendar/widgets/daily_schedule_content.dart
+++ b/lib/presentation/calendar/widgets/daily_schedule_content.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:lakiite/domain/entity/display_list.dart';
 import 'package:lakiite/domain/entity/schedule.dart';
 import 'package:lakiite/presentation/calendar/schedule_detail_page.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -8,6 +9,7 @@ import 'package:lakiite/presentation/widgets/default_user_icon.dart';
 import 'package:lakiite/presentation/calendar/widgets/daily_schedule_list_page.dart';
 import 'package:lakiite/presentation/calendar/widgets/schedule_ownership_style.dart';
 import 'package:lakiite/presentation/calendar/widgets/schedule_list_card.dart';
+import 'package:lakiite/presentation/list/display_list_providers.dart';
 import 'package:lakiite/presentation/schedule/schedule_display_order.dart';
 
 class DailyAllDayScheduleList extends StatelessWidget {
@@ -16,6 +18,7 @@ class DailyAllDayScheduleList extends StatelessWidget {
     required this.schedules,
     required this.allSchedules,
     required this.currentUserId,
+    this.displayLists = const [],
     super.key,
   });
 
@@ -23,6 +26,7 @@ class DailyAllDayScheduleList extends StatelessWidget {
   final List<Schedule> schedules;
   final List<Schedule> allSchedules;
   final String? currentUserId;
+  final Iterable<DisplayList> displayLists;
 
   @override
   Widget build(BuildContext context) {
@@ -48,6 +52,7 @@ class DailyAllDayScheduleList extends StatelessWidget {
             (schedule) => ScheduleListCard(
               schedule: schedule,
               currentUserId: currentUserId,
+              displayLists: displayLists,
             ),
           ),
           if (remainingCount > 0)
@@ -65,6 +70,7 @@ class DailyAllDayScheduleList extends StatelessWidget {
                           date: date,
                           schedules: allSchedules,
                           currentUserId: currentUserId,
+                          displayLists: displayLists,
                         ),
                       ),
                     );
@@ -159,6 +165,9 @@ class DailyScheduleContent extends HookConsumerWidget {
     AppLogger.debug('DailyScheduleContent - スケジュール数: ${schedules.length}');
 
     final currentUserId = ref.watch(currentUserIdProvider);
+    final displayLists =
+        ref.watch(userDisplayListsStreamProvider).valueOrNull ??
+            const <DisplayList>[];
     final sortedSchedules = ScheduleDisplayOrder.sortedWithinDay(schedules);
 
     // 重なり合うスケジュールをグループ化
@@ -235,6 +244,7 @@ class DailyScheduleContent extends HookConsumerWidget {
                             context,
                             schedule: schedule,
                             currentUserId: currentUserId,
+                            displayLists: displayLists,
                           );
 
                           final itemWidth = visibleCount == 1
@@ -371,6 +381,7 @@ class DailyScheduleContent extends HookConsumerWidget {
                                         date: date,
                                         schedules: allSchedules,
                                         currentUserId: currentUserId,
+                                        displayLists: displayLists,
                                       ),
                                     ),
                                   );

--- a/lib/presentation/calendar/widgets/daily_schedule_list_page.dart
+++ b/lib/presentation/calendar/widgets/daily_schedule_list_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:lakiite/domain/entity/display_list.dart';
 import 'package:intl/intl.dart';
 import 'package:lakiite/domain/entity/schedule.dart';
 import 'package:lakiite/presentation/calendar/widgets/schedule_list_card.dart';
@@ -9,12 +10,14 @@ class DailyScheduleListPage extends StatelessWidget {
     required this.date,
     required this.schedules,
     required this.currentUserId,
+    this.displayLists = const [],
     super.key,
   });
 
   final DateTime date;
   final List<Schedule> schedules;
   final String? currentUserId;
+  final Iterable<DisplayList> displayLists;
 
   String _formatDate(DateTime date) {
     final weekDays = ['日', '月', '火', '水', '木', '金', '土'];
@@ -46,6 +49,7 @@ class DailyScheduleListPage extends StatelessWidget {
             (schedule) => ScheduleListCard(
               schedule: schedule,
               currentUserId: currentUserId,
+              displayLists: displayLists,
               trailingText:
                   schedule.isAllDay ? null : _formatTimeRange(schedule),
             ),

--- a/lib/presentation/calendar/widgets/daily_schedule_view.dart
+++ b/lib/presentation/calendar/widgets/daily_schedule_view.dart
@@ -9,6 +9,7 @@ import 'package:lakiite/application/notification/notification_notifier.dart';
 import 'package:lakiite/application/schedule/schedule_notifier.dart';
 import 'package:lakiite/application/auth/auth_state.dart';
 import 'package:lakiite/presentation/calendar/calendar_providers.dart';
+import 'package:lakiite/presentation/list/display_list_providers.dart';
 import 'package:lakiite/utils/logger.dart';
 import 'package:lakiite/presentation/calendar/create_schedule_page.dart';
 
@@ -86,6 +87,8 @@ class DailyScheduleView extends HookConsumerWidget {
     // スケジュールの状態を監視
     final scheduleState = ref.watch(scheduleNotifierProvider);
     final currentUserId = ref.watch(currentUserIdProvider);
+    final displayLists =
+        ref.watch(userDisplayListsStreamProvider).valueOrNull ?? const [];
 
     // 初期化時にスケジュールの監視を開始
     useEffect(() {
@@ -260,6 +263,7 @@ class DailyScheduleView extends HookConsumerWidget {
                       schedules: allDaySchedules,
                       allSchedules: dateSchedules,
                       currentUserId: currentUserId,
+                      displayLists: displayLists,
                     ),
                     Expanded(
                       child: SingleChildScrollView(

--- a/lib/presentation/calendar/widgets/schedule_list_card.dart
+++ b/lib/presentation/calendar/widgets/schedule_list_card.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:lakiite/domain/entity/display_list.dart';
 import 'package:lakiite/domain/entity/schedule.dart';
 import 'package:lakiite/presentation/calendar/schedule_detail_page.dart';
 import 'package:lakiite/presentation/calendar/widgets/schedule_ownership_style.dart';
@@ -7,6 +8,7 @@ class ScheduleListCard extends StatelessWidget {
   const ScheduleListCard({
     required this.schedule,
     required this.currentUserId,
+    this.displayLists = const [],
     this.trailingText,
     this.margin = const EdgeInsets.symmetric(vertical: 3),
     super.key,
@@ -14,6 +16,7 @@ class ScheduleListCard extends StatelessWidget {
 
   final Schedule schedule;
   final String? currentUserId;
+  final Iterable<DisplayList> displayLists;
   final String? trailingText;
   final EdgeInsetsGeometry margin;
 
@@ -23,6 +26,7 @@ class ScheduleListCard extends StatelessWidget {
       context,
       schedule: schedule,
       currentUserId: currentUserId,
+      displayLists: displayLists,
     );
 
     return InkWell(

--- a/lib/presentation/calendar/widgets/schedule_ownership_style.dart
+++ b/lib/presentation/calendar/widgets/schedule_ownership_style.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:lakiite/domain/entity/display_list.dart';
 import 'package:lakiite/domain/entity/schedule.dart';
+import 'package:lakiite/domain/service/display_list_membership.dart';
+import 'package:lakiite/presentation/list/display_list_palette.dart';
 
 class ScheduleOwnershipStyle {
   const ScheduleOwnershipStyle({
@@ -12,6 +15,7 @@ class ScheduleOwnershipStyle {
     BuildContext context, {
     required Schedule schedule,
     required String? currentUserId,
+    Iterable<DisplayList> displayLists = const [],
     double backgroundAlpha = 0.1,
     double borderAlpha = 0.8,
     double primaryTextAlpha = 0.85,
@@ -29,7 +33,13 @@ class ScheduleOwnershipStyle {
       );
     }
 
-    final primaryColor = Theme.of(context).primaryColor;
+    final displayList = DisplayListMembership.findListForUser(
+      displayLists: displayLists,
+      userId: schedule.ownerId,
+    );
+    final primaryColor = displayList == null
+        ? Theme.of(context).primaryColor
+        : DisplayListPalette.colorForKey(displayList.colorKey);
     return ScheduleOwnershipStyle(
       backgroundColor: primaryColor.withValues(alpha: backgroundAlpha),
       borderColor: primaryColor.withValues(alpha: borderAlpha),

--- a/lib/presentation/friend/friend_list_page.dart
+++ b/lib/presentation/friend/friend_list_page.dart
@@ -5,9 +5,6 @@ import '../../application/auth/auth_state.dart';
 import '../../application/notification/notification_notifier.dart'
     show sentNotificationsByTypeProvider;
 import '../../domain/entity/notification.dart' as domain;
-import '../list/create_list_page.dart';
-import '../list/list_detail_page.dart';
-import '../list/list_providers.dart';
 import 'friend_providers.dart';
 import '../friend/friend_search_page.dart';
 import '../friend/friend_profile_page.dart';
@@ -15,8 +12,7 @@ import '../widgets/notification_button.dart';
 import '../widgets/banner_ad_widget.dart';
 import '../widgets/default_user_icon.dart';
 
-/// フレンドリストとユーザーリストを表示するページ。
-/// タブで切り替えることができ、それぞれのタブに応じたFloatingActionButtonを表示します。
+/// フレンドリストを表示するページ。
 class FriendListPage extends ConsumerStatefulWidget {
   const FriendListPage({super.key});
 
@@ -24,22 +20,16 @@ class FriendListPage extends ConsumerStatefulWidget {
   ConsumerState<FriendListPage> createState() => _FriendListPageState();
 }
 
-class _FriendListPageState extends ConsumerState<FriendListPage>
-    with SingleTickerProviderStateMixin {
-  late TabController _tabController;
-
+class _FriendListPageState extends ConsumerState<FriendListPage> {
   // フローティングボタンをキャッシュするための変数
   late final Widget _friendTabFAB;
-  late final Widget _listTabFAB;
 
   @override
   void initState() {
     super.initState();
-    _tabController = TabController(length: 2, vsync: this);
-    _tabController.addListener(_handleTabChange);
-
     // フローティングボタンを事前に構築
     _friendTabFAB = FloatingActionButton(
+      heroTag: 'friend_search_fab',
       onPressed: () {
         Navigator.of(context).push(
           MaterialPageRoute(
@@ -49,42 +39,9 @@ class _FriendListPageState extends ConsumerState<FriendListPage>
       },
       child: const Icon(Icons.person_add),
     );
-
-    _listTabFAB = FloatingActionButton(
-      onPressed: () {
-        Navigator.of(context).push(
-          MaterialPageRoute(
-            builder: (context) => const CreateListPage(),
-          ),
-        );
-      },
-      child: const Icon(Icons.post_add_outlined),
-    );
   }
 
-  @override
-  void dispose() {
-    _tabController.removeListener(_handleTabChange);
-    _tabController.dispose();
-    super.dispose();
-  }
-
-  /// タブの変更を処理するメソッド。
-  /// タブの切り替えが完了したときにUIを更新します。
-  void _handleTabChange() {
-    // タブの切り替えが完了したときのみ、FloatingActionButtonの表示を更新
-    if (!_tabController.indexIsChanging) {
-      setState(() {});
-    }
-  }
-
-  /// 現在のタブに応じたFloatingActionButtonを返します。
-  /// 事前に構築されたボタンを返すだけなので、再構築は発生しません。
-  Widget _buildFloatingActionButton() {
-    return _tabController.index == 0 ? _friendTabFAB : _listTabFAB;
-  }
-
-  /// フレンドタブの内容を構築します。
+  // フレンドタブの内容を構築します。
   Widget _buildFriendTabContent() {
     // StreamProviderに変更してリアルタイム更新を実現
     final friendsAsync = ref.watch(userFriendsStreamProvider);
@@ -225,104 +182,9 @@ class _FriendListPageState extends ConsumerState<FriendListPage>
     );
   }
 
-  /// リストタブの内容を構築します。
-  Widget _buildListTabContent() {
-    // キャッシュを使用せず、常に最新のデータを表示
-    final listsAsync = ref.watch(userListsStreamProvider);
-    return listsAsync.when(
-      data: (lists) {
-        if (lists.isEmpty) {
-          return const Center(
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Icon(
-                  Icons.list_alt,
-                  size: 64,
-                  color: Colors.grey,
-                ),
-                SizedBox(height: 16),
-                Text(
-                  'リストがありません',
-                  style: TextStyle(
-                    color: Colors.grey,
-                    fontSize: 16,
-                  ),
-                ),
-              ],
-            ),
-          );
-        }
-        return ListView.builder(
-          key: const PageStorageKey('list_list'), // キーを追加してスクロール位置を保持
-          padding: const EdgeInsets.only(
-            left: 16,
-            right: 16,
-            top: 8,
-            bottom: 58,
-          ),
-          itemCount: lists.length,
-          itemBuilder: (context, index) {
-            final list = lists[index];
-            final currentUser = ref.watch(authNotifierProvider).value?.user;
-            final otherMemberCount = currentUser != null
-                ? list.memberIds.where((id) => id != currentUser.id).length
-                : 0;
-
-            return Card(
-              margin: const EdgeInsets.only(bottom: 4),
-              child: ListTile(
-                contentPadding: const EdgeInsets.symmetric(
-                  horizontal: 16,
-                  vertical: 4,
-                ),
-                leading: CircleAvatar(
-                  radius: 24,
-                  backgroundImage:
-                      list.iconUrl != null ? NetworkImage(list.iconUrl!) : null,
-                  child: list.iconUrl == null
-                      ? const Icon(Icons.list, size: 32)
-                      : null,
-                ),
-                title: Text(
-                  list.listName,
-                  style: const TextStyle(
-                    fontWeight: FontWeight.bold,
-                    fontSize: 16,
-                  ),
-                ),
-                subtitle: Text(
-                  '$otherMemberCount人のメンバー',
-                  style: TextStyle(
-                    color: Colors.grey[600],
-                    fontSize: 14,
-                  ),
-                ),
-                onTap: () {
-                  Navigator.of(context).push(
-                    MaterialPageRoute(
-                      builder: (context) => ListDetailPage(list: list),
-                    ),
-                  );
-                },
-              ),
-            );
-          },
-        );
-      },
-      loading: () => const Center(
-        child: CircularProgressIndicator(),
-      ),
-      error: (error, stack) => Center(
-        child: Text('エラーが発生しました: $error'),
-      ),
-    );
-  }
-
-  /// ウィジェットのUIを構築します。
+  // ウィジェットのUIを構築します。
   ///
-  /// フレンドリストとユーザーリストを含むタブビューを表示し、
-  /// 各タブの状態に応じて適切なコンテンツを表示します。
+  /// フレンドリストを表示します。
   /// また、通知バッジ付きのアプリバーと広告バナーも含まれます。
   ///
   /// [context] - ウィジェットのビルドコンテキスト
@@ -358,62 +220,12 @@ class _FriendListPageState extends ConsumerState<FriendListPage>
           floatingActionButton: Padding(
             key: const ValueKey('friend_list_fab'),
             padding: const EdgeInsets.only(bottom: 58),
-            child: _buildFloatingActionButton(),
+            child: _friendTabFAB,
           ),
           floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
           body: Column(
             children: [
-              Container(
-                decoration: BoxDecoration(
-                  color: Colors.white,
-                  boxShadow: [
-                    BoxShadow(
-                      color: Colors.black.withValues(alpha: 0.05),
-                      blurRadius: 4,
-                      offset: const Offset(0, 2),
-                    ),
-                  ],
-                ),
-                child: TabBar(
-                  controller: _tabController,
-                  labelColor: Theme.of(context).primaryColor,
-                  unselectedLabelColor: Colors.grey[600],
-                  indicatorColor: Theme.of(context).primaryColor,
-                  indicatorWeight: 3,
-                  labelStyle: const TextStyle(
-                    fontWeight: FontWeight.bold,
-                    fontSize: 16,
-                  ),
-                  unselectedLabelStyle: const TextStyle(
-                    fontSize: 16,
-                  ),
-                  tabs: const [
-                    Tab(text: 'フレンド'),
-                    Tab(text: 'リスト'),
-                  ],
-                ),
-              ),
-              Expanded(
-                child: TabBarView(
-                  controller: _tabController,
-                  children: [
-                    IndexedStack(
-                      index: _tabController.index == 0 ? 0 : 1,
-                      children: [
-                        _buildFriendTabContent(),
-                        Container(),
-                      ],
-                    ),
-                    IndexedStack(
-                      index: _tabController.index == 1 ? 0 : 1,
-                      children: [
-                        _buildListTabContent(),
-                        Container(),
-                      ],
-                    ),
-                  ],
-                ),
-              ),
+              Expanded(child: _buildFriendTabContent()),
               const SizedBox(
                 height: 50,
                 child: BannerAdWidget(uniqueId: 'friend_list_page_ad'),

--- a/lib/presentation/home/home_page.dart
+++ b/lib/presentation/home/home_page.dart
@@ -8,6 +8,7 @@ import 'package:lakiite/application/schedule/schedule_notifier.dart';
 import 'package:lakiite/presentation/calendar/calendar_providers.dart';
 import 'package:lakiite/presentation/calendar/create_schedule_page.dart';
 import 'package:lakiite/presentation/calendar/widgets/calendar_page_view.dart';
+import 'package:lakiite/presentation/list/display_list_providers.dart';
 import 'package:lakiite/presentation/schedule/schedule_display_order.dart';
 import 'package:lakiite/presentation/widgets/banner_ad_widget.dart';
 import 'package:lakiite/presentation/widgets/notification_button.dart';
@@ -267,6 +268,11 @@ class HomePage extends HookConsumerWidget {
                               scheduleState.when(
                                 data: (scheduleState) => scheduleState.maybeMap(
                                   loaded: (loaded) {
+                                    final displayLists = ref
+                                            .watch(
+                                                userDisplayListsStreamProvider)
+                                            .valueOrNull ??
+                                        const [];
                                     // 本日以降のスケジュールをフィルタリング
                                     final today =
                                         DateTime.now().toUtc().toLocal();
@@ -396,6 +402,7 @@ class HomePage extends HookConsumerWidget {
                                                           state.user!.id,
                                                   isTimelineView: true,
                                                   showDivider: false,
+                                                  displayLists: displayLists,
                                                 );
                                               },
                                             ),

--- a/lib/presentation/list/create_display_list_page.dart
+++ b/lib/presentation/list/create_display_list_page.dart
@@ -1,0 +1,155 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lakiite/app/di/providers.dart';
+import 'package:lakiite/application/auth/auth_notifier.dart';
+import 'package:lakiite/application/auth/auth_state.dart';
+import 'package:lakiite/presentation/list/display_list_palette.dart';
+
+class CreateDisplayListPage extends ConsumerStatefulWidget {
+  const CreateDisplayListPage({super.key});
+
+  @override
+  ConsumerState<CreateDisplayListPage> createState() =>
+      _CreateDisplayListPageState();
+}
+
+class _CreateDisplayListPageState extends ConsumerState<CreateDisplayListPage> {
+  final _nameController = TextEditingController();
+  String _selectedColorKey = DisplayListPalette.defaultColorKey;
+  bool _isSaving = false;
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _save() async {
+    final authState = ref.read(authNotifierProvider).valueOrNull;
+    final user = authState?.user;
+    if (authState?.status != AuthStatus.authenticated || user == null) {
+      return;
+    }
+
+    final name = _nameController.text.trim();
+    if (name.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('リスト名を入力してください')),
+      );
+      return;
+    }
+
+    setState(() => _isSaving = true);
+    try {
+      await ref.read(displayListRepositoryProvider).createDisplayList(
+        ownerId: user.id,
+        name: name,
+        colorKey: _selectedColorKey,
+        memberIds: const [],
+      );
+      if (mounted) {
+        Navigator.of(context).pop();
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('表示用リストの作成に失敗しました: $e')),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _isSaving = false);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('表示用リストを作成')),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            TextField(
+              controller: _nameController,
+              decoration: const InputDecoration(
+                labelText: 'リスト名',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: 20),
+            const Text(
+              'カラー',
+              style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 8),
+            _ColorPaletteSelector(
+              selectedColorKey: _selectedColorKey,
+              onChanged: (colorKey) {
+                setState(() => _selectedColorKey = colorKey);
+              },
+            ),
+          ],
+        ),
+      ),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: _isSaving ? null : _save,
+        icon: _isSaving
+            ? const SizedBox(
+                width: 18,
+                height: 18,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              )
+            : const Icon(Icons.save),
+        label: const Text('保存'),
+      ),
+    );
+  }
+}
+
+class _ColorPaletteSelector extends StatelessWidget {
+  const _ColorPaletteSelector({
+    required this.selectedColorKey,
+    required this.onChanged,
+  });
+
+  final String selectedColorKey;
+  final ValueChanged<String> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: 10,
+      runSpacing: 10,
+      children: DisplayListPalette.entries.map((entry) {
+        final selected = entry.key == selectedColorKey;
+        return Semantics(
+          label: '${entry.label}を選択',
+          selected: selected,
+          button: true,
+          child: InkWell(
+            borderRadius: BorderRadius.circular(24),
+            onTap: () => onChanged(entry.key),
+            child: Container(
+              width: 44,
+              height: 44,
+              decoration: BoxDecoration(
+                color: entry.color,
+                shape: BoxShape.circle,
+                border: Border.all(
+                  color: selected ? Colors.black87 : Colors.transparent,
+                  width: 3,
+                ),
+              ),
+              child: selected
+                  ? const Icon(Icons.check, color: Colors.white)
+                  : null,
+            ),
+          ),
+        );
+      }).toList(),
+    );
+  }
+}

--- a/lib/presentation/list/display_list_detail_page.dart
+++ b/lib/presentation/list/display_list_detail_page.dart
@@ -1,0 +1,207 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lakiite/app/di/providers.dart';
+import 'package:lakiite/domain/entity/display_list.dart';
+import 'package:lakiite/domain/entity/user.dart';
+import 'package:lakiite/presentation/list/display_list_edit_page.dart';
+import 'package:lakiite/presentation/list/display_list_member_invite_page.dart';
+import 'package:lakiite/presentation/list/display_list_palette.dart';
+import 'package:lakiite/presentation/list/display_list_providers.dart';
+
+class DisplayListDetailPage extends ConsumerWidget {
+  const DisplayListDetailPage({super.key, required this.displayList});
+
+  final DisplayList displayList;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final displayListsAsync = ref.watch(userDisplayListsStreamProvider);
+    final watchedDisplayLists = displayListsAsync.valueOrNull ?? const [];
+    final matchingDisplayLists =
+        watchedDisplayLists.where((item) => item.id == displayList.id).toList();
+    final currentDisplayList =
+        matchingDisplayLists.isEmpty ? displayList : matchingDisplayLists.first;
+    final theme = Theme.of(context);
+    final listColor =
+        DisplayListPalette.colorForKey(currentDisplayList.colorKey);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('表示用リストの詳細'),
+        actions: [
+          PopupMenuButton<String>(
+            onSelected: (value) async {
+              if (value != 'delete') {
+                return;
+              }
+              final navigator = Navigator.of(context);
+              final scaffoldMessenger = ScaffoldMessenger.of(context);
+              final confirmed = await showDialog<bool>(
+                context: context,
+                builder: (context) => AlertDialog(
+                  title: const Text('表示用リストを削除'),
+                  content: const Text('この表示用リストを削除してもよろしいですか？'),
+                  actions: [
+                    TextButton(
+                      onPressed: () => Navigator.of(context).pop(false),
+                      child: const Text('キャンセル'),
+                    ),
+                    TextButton(
+                      onPressed: () => Navigator.of(context).pop(true),
+                      child: const Text('削除'),
+                    ),
+                  ],
+                ),
+              );
+              if (confirmed != true) {
+                return;
+              }
+              try {
+                await ref.read(displayListRepositoryProvider).deleteDisplayList(
+                      ownerId: currentDisplayList.ownerId,
+                      displayListId: currentDisplayList.id,
+                    );
+                navigator.pop();
+              } catch (e) {
+                scaffoldMessenger.showSnackBar(
+                  SnackBar(content: Text('削除に失敗しました: $e')),
+                );
+              }
+            },
+            itemBuilder: (context) => [
+              const PopupMenuItem(value: 'delete', child: Text('削除')),
+            ],
+          ),
+        ],
+      ),
+      body: SingleChildScrollView(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Padding(
+              padding: const EdgeInsets.all(16),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  CircleAvatar(
+                    radius: 40,
+                    backgroundColor: listColor.withValues(alpha: 0.18),
+                    child: Icon(Icons.palette, size: 40, color: listColor),
+                  ),
+                  const SizedBox(width: 16),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          currentDisplayList.name,
+                          style: theme.textTheme.headlineSmall,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                        const SizedBox(height: 8),
+                        OutlinedButton.icon(
+                          onPressed: () {
+                            Navigator.of(context).push(
+                              MaterialPageRoute(
+                                builder: (context) => DisplayListEditPage(
+                                  displayList: currentDisplayList,
+                                ),
+                              ),
+                            );
+                          },
+                          icon: const Icon(Icons.edit),
+                          label: const Text('編集'),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: Row(
+                children: [
+                  Text('メンバー', style: theme.textTheme.titleLarge),
+                  const SizedBox(width: 8),
+                  Text('${currentDisplayList.memberIds.length}人'),
+                  const Spacer(),
+                  OutlinedButton.icon(
+                    onPressed: () {
+                      Navigator.of(context).push(
+                        MaterialPageRoute(
+                          builder: (context) => DisplayListMemberInvitePage(
+                            displayList: currentDisplayList,
+                          ),
+                        ),
+                      );
+                    },
+                    icon: const Icon(Icons.person_add),
+                    label: const Text('友達を追加'),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 8),
+            ListView.builder(
+              shrinkWrap: true,
+              physics: const NeverScrollableScrollPhysics(),
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              itemCount: currentDisplayList.memberIds.length,
+              itemBuilder: (context, index) {
+                final memberId = currentDisplayList.memberIds[index];
+                return FutureBuilder<PublicUserModel?>(
+                  future: ref
+                      .read(userRepositoryProvider)
+                      .getFriendPublicProfile(memberId),
+                  builder: (context, snapshot) {
+                    if (snapshot.connectionState == ConnectionState.waiting) {
+                      return const Card(
+                        margin: EdgeInsets.only(bottom: 8),
+                        child: ListTile(
+                          leading: CircularProgressIndicator(),
+                          title: Text('読み込み中...'),
+                        ),
+                      );
+                    }
+                    final member = snapshot.data;
+                    if (member == null) {
+                      return const SizedBox.shrink();
+                    }
+                    return Card(
+                      margin: const EdgeInsets.only(bottom: 8),
+                      child: ListTile(
+                        leading: CircleAvatar(
+                          backgroundImage: member.iconUrl != null
+                              ? NetworkImage(member.iconUrl!)
+                              : null,
+                          child: member.iconUrl == null
+                              ? const Icon(Icons.person)
+                              : null,
+                        ),
+                        title: Text(member.displayName),
+                        trailing: IconButton(
+                          tooltip: 'メンバーから削除',
+                          icon: const Icon(Icons.remove_circle_outline),
+                          onPressed: () async {
+                            await ref
+                                .read(displayListRepositoryProvider)
+                                .removeMember(
+                                  ownerId: currentDisplayList.ownerId,
+                                  displayListId: currentDisplayList.id,
+                                  userId: memberId,
+                                );
+                          },
+                        ),
+                      ),
+                    );
+                  },
+                );
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/list/display_list_edit_page.dart
+++ b/lib/presentation/list/display_list_edit_page.dart
@@ -1,0 +1,137 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lakiite/app/di/providers.dart';
+import 'package:lakiite/domain/entity/display_list.dart';
+import 'package:lakiite/presentation/list/display_list_palette.dart';
+
+class DisplayListEditPage extends ConsumerStatefulWidget {
+  const DisplayListEditPage({super.key, required this.displayList});
+
+  final DisplayList displayList;
+
+  @override
+  ConsumerState<DisplayListEditPage> createState() =>
+      _DisplayListEditPageState();
+}
+
+class _DisplayListEditPageState extends ConsumerState<DisplayListEditPage> {
+  late final TextEditingController _nameController;
+  late String _selectedColorKey;
+  bool _isSaving = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _nameController = TextEditingController(text: widget.displayList.name);
+    _selectedColorKey = widget.displayList.colorKey;
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _save() async {
+    final name = _nameController.text.trim();
+    if (name.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('リスト名を入力してください')),
+      );
+      return;
+    }
+
+    setState(() => _isSaving = true);
+    try {
+      await ref.read(displayListRepositoryProvider).updateDisplayList(
+            widget.displayList.copyWith(
+              name: name,
+              colorKey: _selectedColorKey,
+            ),
+          );
+      if (mounted) {
+        Navigator.of(context).pop();
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('表示用リストの更新に失敗しました: $e')),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _isSaving = false);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('表示用リストを編集'),
+        actions: [
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: FilledButton(
+              onPressed: _isSaving ? null : _save,
+              child: const Text('保存'),
+            ),
+          ),
+        ],
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            TextField(
+              controller: _nameController,
+              decoration: const InputDecoration(
+                labelText: 'リスト名',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: 20),
+            const Text(
+              'カラー',
+              style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 10,
+              runSpacing: 10,
+              children: DisplayListPalette.entries.map((entry) {
+                final selected = entry.key == _selectedColorKey;
+                return Semantics(
+                  label: '${entry.label}を選択',
+                  selected: selected,
+                  button: true,
+                  child: InkWell(
+                    borderRadius: BorderRadius.circular(24),
+                    onTap: () => setState(() => _selectedColorKey = entry.key),
+                    child: Container(
+                      width: 44,
+                      height: 44,
+                      decoration: BoxDecoration(
+                        color: entry.color,
+                        shape: BoxShape.circle,
+                        border: Border.all(
+                          color: selected ? Colors.black87 : Colors.transparent,
+                          width: 3,
+                        ),
+                      ),
+                      child: selected
+                          ? const Icon(Icons.check, color: Colors.white)
+                          : null,
+                    ),
+                  ),
+                );
+              }).toList(),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/list/display_list_member_invite_page.dart
+++ b/lib/presentation/list/display_list_member_invite_page.dart
@@ -1,0 +1,177 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lakiite/app/di/providers.dart';
+import 'package:lakiite/application/auth/auth_notifier.dart';
+import 'package:lakiite/application/auth/auth_state.dart';
+import 'package:lakiite/domain/entity/display_list.dart';
+import 'package:lakiite/domain/service/display_list_membership.dart';
+import 'package:lakiite/presentation/friend/friend_providers.dart';
+import 'package:lakiite/presentation/list/display_list_providers.dart';
+
+class DisplayListMemberInvitePage extends ConsumerStatefulWidget {
+  const DisplayListMemberInvitePage({super.key, required this.displayList});
+
+  final DisplayList displayList;
+
+  @override
+  ConsumerState<DisplayListMemberInvitePage> createState() =>
+      _DisplayListMemberInvitePageState();
+}
+
+class _DisplayListMemberInvitePageState
+    extends ConsumerState<DisplayListMemberInvitePage> {
+  final Set<String> _selectedFriendIds = {};
+
+  @override
+  Widget build(BuildContext context) {
+    final authStateAsync = ref.watch(authNotifierProvider);
+
+    return authStateAsync.when(
+      data: (state) {
+        if (state.status != AuthStatus.authenticated || state.user == null) {
+          return const Scaffold(body: Center(child: Text('認証が必要です')));
+        }
+
+        final friendsAsync = ref.watch(userFriendsStreamProvider);
+        final displayLists =
+            ref.watch(userDisplayListsStreamProvider).valueOrNull ??
+                const <DisplayList>[];
+        final matchingDisplayLists = displayLists
+            .where((item) => item.id == widget.displayList.id)
+            .toList();
+        final currentDisplayList = matchingDisplayLists.isEmpty
+            ? widget.displayList
+            : matchingDisplayLists.first;
+        final selectedFriendsToAdd = _selectedFriendIds
+            .where((friendId) =>
+                !currentDisplayList.memberIds.contains(friendId) &&
+                DisplayListMembership.findConflictingList(
+                      displayLists: displayLists,
+                      targetListId: currentDisplayList.id,
+                      userId: friendId,
+                    ) ==
+                    null)
+            .toSet();
+
+        return Scaffold(
+          appBar: AppBar(
+            title: Text('${currentDisplayList.name}にメンバーを追加'),
+          ),
+          body: friendsAsync.when(
+            data: (friends) {
+              return ListView.builder(
+                itemCount: friends.length,
+                itemBuilder: (context, index) {
+                  final friend = friends[index];
+                  final friendId = friend.id;
+                  final isInCurrentList =
+                      currentDisplayList.memberIds.contains(friendId);
+                  final conflictingList =
+                      DisplayListMembership.findConflictingList(
+                    displayLists: displayLists,
+                    targetListId: currentDisplayList.id,
+                    userId: friendId,
+                  );
+                  final isUnavailable =
+                      isInCurrentList || conflictingList != null;
+                  final isSelected =
+                      !isUnavailable && selectedFriendsToAdd.contains(friendId);
+                  final subtitle = conflictingList != null
+                      ? '${conflictingList.name}に追加済み'
+                      : isInCurrentList
+                          ? 'このリストに追加済み'
+                          : friend.shortBio;
+
+                  return ListTile(
+                    enabled: !isUnavailable,
+                    tileColor: isUnavailable
+                        ? Colors.grey.withValues(alpha: 0.1)
+                        : null,
+                    leading: CircleAvatar(
+                      backgroundImage: friend.iconUrl != null
+                          ? NetworkImage(friend.iconUrl!)
+                          : null,
+                      child: friend.iconUrl == null
+                          ? const Icon(Icons.person)
+                          : null,
+                    ),
+                    title: Text(friend.displayName),
+                    subtitle: subtitle != null && subtitle.isNotEmpty
+                        ? Text(
+                            subtitle,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: TextStyle(color: Colors.grey[600]),
+                          )
+                        : null,
+                    trailing: Checkbox(
+                      value: isSelected,
+                      onChanged: isUnavailable
+                          ? null
+                          : (value) {
+                              setState(() {
+                                if (value == true) {
+                                  _selectedFriendIds.add(friendId);
+                                } else {
+                                  _selectedFriendIds.remove(friendId);
+                                }
+                              });
+                            },
+                    ),
+                    onTap: isUnavailable
+                        ? null
+                        : () {
+                            setState(() {
+                              if (_selectedFriendIds.contains(friendId)) {
+                                _selectedFriendIds.remove(friendId);
+                              } else {
+                                _selectedFriendIds.add(friendId);
+                              }
+                            });
+                          },
+                  );
+                },
+              );
+            },
+            loading: () => const Center(child: CircularProgressIndicator()),
+            error: (error, _) => Center(child: Text('エラーが発生しました: $error')),
+          ),
+          bottomNavigationBar: SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: ElevatedButton(
+                onPressed: selectedFriendsToAdd.isEmpty
+                    ? null
+                    : () async {
+                        final navigator = Navigator.of(context);
+                        final scaffoldMessenger = ScaffoldMessenger.of(context);
+                        try {
+                          for (final friendId in selectedFriendsToAdd) {
+                            await ref
+                                .read(displayListRepositoryProvider)
+                                .addMember(
+                                  ownerId: currentDisplayList.ownerId,
+                                  displayListId: currentDisplayList.id,
+                                  userId: friendId,
+                                );
+                          }
+                          navigator.pop();
+                        } catch (e) {
+                          scaffoldMessenger.showSnackBar(
+                            SnackBar(content: Text('メンバーの追加に失敗しました: $e')),
+                          );
+                        }
+                      },
+                child: Text('選択したメンバー(${selectedFriendsToAdd.length}名)を追加'),
+              ),
+            ),
+          ),
+        );
+      },
+      loading: () =>
+          const Scaffold(body: Center(child: CircularProgressIndicator())),
+      error: (error, _) =>
+          Scaffold(body: Center(child: Text('エラーが発生しました: $error'))),
+    );
+  }
+}

--- a/lib/presentation/list/display_list_palette.dart
+++ b/lib/presentation/list/display_list_palette.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+
+class DisplayListPalette {
+  const DisplayListPalette._();
+
+  static const defaultColorKey = 'blue';
+
+  static const entries = [
+    DisplayListPaletteEntry(key: 'red', label: 'レッド', color: Colors.red),
+    DisplayListPaletteEntry(
+      key: 'orange',
+      label: 'オレンジ',
+      color: Colors.orange,
+    ),
+    DisplayListPaletteEntry(key: 'amber', label: 'アンバー', color: Colors.amber),
+    DisplayListPaletteEntry(key: 'green', label: 'グリーン', color: Colors.green),
+    DisplayListPaletteEntry(key: 'teal', label: 'ティール', color: Colors.teal),
+    DisplayListPaletteEntry(key: 'cyan', label: 'シアン', color: Colors.cyan),
+    DisplayListPaletteEntry(key: 'blue', label: 'ブルー', color: Colors.blue),
+    DisplayListPaletteEntry(
+      key: 'indigo',
+      label: 'インディゴ',
+      color: Colors.indigo,
+    ),
+    DisplayListPaletteEntry(key: 'purple', label: 'パープル', color: Colors.purple),
+    DisplayListPaletteEntry(key: 'pink', label: 'ピンク', color: Colors.pink),
+  ];
+
+  static Color colorForKey(String colorKey) {
+    for (final entry in entries) {
+      if (entry.key == colorKey) {
+        return entry.color;
+      }
+    }
+    return Colors.blue;
+  }
+}
+
+class DisplayListPaletteEntry {
+  const DisplayListPaletteEntry({
+    required this.key,
+    required this.label,
+    required this.color,
+  });
+
+  final String key;
+  final String label;
+  final Color color;
+}

--- a/lib/presentation/list/display_list_palette.dart
+++ b/lib/presentation/list/display_list_palette.dart
@@ -7,12 +7,6 @@ class DisplayListPalette {
 
   static const entries = [
     DisplayListPaletteEntry(key: 'red', label: 'レッド', color: Colors.red),
-    DisplayListPaletteEntry(
-      key: 'orange',
-      label: 'オレンジ',
-      color: Colors.orange,
-    ),
-    DisplayListPaletteEntry(key: 'amber', label: 'アンバー', color: Colors.amber),
     DisplayListPaletteEntry(key: 'green', label: 'グリーン', color: Colors.green),
     DisplayListPaletteEntry(key: 'teal', label: 'ティール', color: Colors.teal),
     DisplayListPaletteEntry(key: 'cyan', label: 'シアン', color: Colors.cyan),

--- a/lib/presentation/list/display_list_providers.dart
+++ b/lib/presentation/list/display_list_providers.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lakiite/app/di/providers.dart';
+import 'package:lakiite/application/auth/auth_notifier.dart';
+import 'package:lakiite/application/auth/auth_state.dart';
+import 'package:lakiite/domain/entity/display_list.dart';
+
+final userDisplayListsStreamProvider =
+    StreamProvider.autoDispose<List<DisplayList>>((ref) {
+  final authState = ref.watch(authNotifierProvider);
+
+  return authState.when(
+    data: (state) {
+      if (state.status != AuthStatus.authenticated || state.user == null) {
+        return Stream.value([]);
+      }
+
+      return ref
+          .watch(displayListRepositoryProvider)
+          .watchDisplayLists(state.user!.id);
+    },
+    loading: () => Stream.value([]),
+    error: (_, __) => Stream.value([]),
+  );
+});

--- a/lib/presentation/list/list_page.dart
+++ b/lib/presentation/list/list_page.dart
@@ -1,6 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'create_list_page.dart';
+import 'create_display_list_page.dart';
+import 'display_list_detail_page.dart';
+import 'display_list_palette.dart';
+import 'display_list_providers.dart';
 import 'list_detail_page.dart';
 import 'list_providers.dart';
 
@@ -10,60 +14,118 @@ import 'list_providers.dart';
 /// - ユーザーのプライベートリスト一覧の表示
 /// - リストの作成
 /// - リストの詳細表示
-class ListPage extends ConsumerWidget {
+class ListPage extends ConsumerStatefulWidget {
   const ListPage({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final listsAsync = ref.watch(userListsStreamProvider);
+  ConsumerState<ListPage> createState() => _ListPageState();
+}
 
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('リスト'),
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.add),
-            onPressed: () {
+class _ListPageState extends ConsumerState<ListPage> {
+  int _tabIndex = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    final listsAsync = ref.watch(userListsStreamProvider);
+    final displayListsAsync = ref.watch(userDisplayListsStreamProvider);
+
+    return DefaultTabController(
+      length: 2,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('リスト'),
+          bottom: TabBar(
+            onTap: (index) => setState(() => _tabIndex = index),
+            tabs: const [
+              Tab(text: '公開用'),
+              Tab(text: '表示用'),
+            ],
+          ),
+        ),
+        body: TabBarView(
+          children: [
+            listsAsync.when(
+              data: (lists) {
+                if (lists.isEmpty) {
+                  return const Center(child: Text('公開用リストがありません'));
+                }
+
+                return ListView.builder(
+                  itemCount: lists.length,
+                  itemBuilder: (context, index) {
+                    final list = lists[index];
+                    return ListTile(
+                      leading: const Icon(Icons.list),
+                      title: Text(list.listName),
+                      subtitle: Text('${list.memberIds.length}人のメンバー'),
+                      onTap: () {
+                        Navigator.of(context).push(
+                          MaterialPageRoute(
+                            builder: (context) => ListDetailPage(list: list),
+                          ),
+                        );
+                      },
+                    );
+                  },
+                );
+              },
+              loading: () => const Center(child: CircularProgressIndicator()),
+              error: (error, _) => Center(child: Text('エラーが発生しました: $error')),
+            ),
+            displayListsAsync.when(
+              data: (displayLists) {
+                if (displayLists.isEmpty) {
+                  return const Center(child: Text('表示用リストがありません'));
+                }
+
+                return ListView.builder(
+                  itemCount: displayLists.length,
+                  itemBuilder: (context, index) {
+                    final displayList = displayLists[index];
+                    final color =
+                        DisplayListPalette.colorForKey(displayList.colorKey);
+                    return ListTile(
+                      leading: CircleAvatar(
+                        backgroundColor: color.withValues(alpha: 0.18),
+                        child: Icon(Icons.palette, color: color),
+                      ),
+                      title: Text(displayList.name),
+                      subtitle: Text('${displayList.memberIds.length}人のメンバー'),
+                      onTap: () {
+                        Navigator.of(context).push(
+                          MaterialPageRoute(
+                            builder: (context) => DisplayListDetailPage(
+                              displayList: displayList,
+                            ),
+                          ),
+                        );
+                      },
+                    );
+                  },
+                );
+              },
+              loading: () => const Center(child: CircularProgressIndicator()),
+              error: (error, _) => Center(child: Text('エラーが発生しました: $error')),
+            ),
+          ],
+        ),
+        floatingActionButton: FloatingActionButton(
+          onPressed: () {
+            if (_tabIndex == 0) {
               Navigator.of(context).push(
                 MaterialPageRoute(
                   builder: (context) => const CreateListPage(),
                 ),
               );
-            },
-          ),
-        ],
-      ),
-      body: listsAsync.when(
-        data: (lists) {
-          if (lists.isEmpty) {
-            return const Center(
-              child: Text('リストがありません'),
+              return;
+            }
+            Navigator.of(context).push(
+              MaterialPageRoute(
+                builder: (context) => const CreateDisplayListPage(),
+              ),
             );
-          }
-
-          return ListView.builder(
-            itemCount: lists.length,
-            itemBuilder: (context, index) {
-              final list = lists[index];
-              return ListTile(
-                title: Text(list.listName),
-                subtitle: Text('${list.memberIds.length}人のメンバー'),
-                onTap: () {
-                  Navigator.of(context).push(
-                    MaterialPageRoute(
-                      builder: (context) => ListDetailPage(list: list),
-                    ),
-                  );
-                },
-              );
-            },
-          );
-        },
-        loading: () => const Center(
-          child: CircularProgressIndicator(),
-        ),
-        error: (error, stackTrace) => Center(
-          child: Text('エラーが発生しました: $error'),
+          },
+          child: const Icon(Icons.add),
         ),
       ),
     );

--- a/lib/presentation/list/list_page.dart
+++ b/lib/presentation/list/list_page.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lakiite/domain/entity/display_list.dart';
+import 'package:lakiite/domain/entity/list.dart';
 import 'create_list_page.dart';
 import 'create_display_list_page.dart';
 import 'display_list_detail_page.dart';
@@ -7,6 +9,7 @@ import 'display_list_palette.dart';
 import 'display_list_providers.dart';
 import 'list_detail_page.dart';
 import 'list_providers.dart';
+import '../widgets/banner_ad_widget.dart';
 
 /// プライベートリスト一覧を表示するウィジェット
 ///
@@ -15,7 +18,9 @@ import 'list_providers.dart';
 /// - リストの作成
 /// - リストの詳細表示
 class ListPage extends ConsumerStatefulWidget {
-  const ListPage({super.key});
+  const ListPage({super.key, this.embedded = false});
+
+  final bool embedded;
 
   @override
   ConsumerState<ListPage> createState() => _ListPageState();
@@ -26,108 +31,200 @@ class _ListPageState extends ConsumerState<ListPage> {
 
   @override
   Widget build(BuildContext context) {
+    final content = _ListContent(
+      selectedTabIndex: _tabIndex,
+      onTabChanged: (index) => setState(() => _tabIndex = index),
+    );
+
+    if (widget.embedded) {
+      return content;
+    }
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const SizedBox(
+          width: double.infinity,
+          child: Text(
+            'リスト',
+            textAlign: TextAlign.center,
+          ),
+        ),
+        centerTitle: true,
+        titleSpacing: 0,
+      ),
+      body: Column(
+        children: [
+          Expanded(child: content),
+          const SizedBox(
+            height: 50,
+            child: BannerAdWidget(uniqueId: 'list_page_ad'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ListContent extends ConsumerWidget {
+  const _ListContent({
+    required this.selectedTabIndex,
+    required this.onTabChanged,
+  });
+
+  final int selectedTabIndex;
+  final ValueChanged<int> onTabChanged;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
     final listsAsync = ref.watch(userListsStreamProvider);
     final displayListsAsync = ref.watch(userDisplayListsStreamProvider);
 
     return DefaultTabController(
       length: 2,
-      child: Scaffold(
-        appBar: AppBar(
-          title: const Text('リスト'),
-          bottom: TabBar(
-            onTap: (index) => setState(() => _tabIndex = index),
-            tabs: const [
-              Tab(text: '公開用'),
-              Tab(text: '表示用'),
+      initialIndex: selectedTabIndex,
+      child: Stack(
+        children: [
+          Column(
+            children: [
+              Material(
+                color: Colors.white,
+                elevation: 1,
+                child: TabBar(
+                  onTap: onTabChanged,
+                  labelColor: Theme.of(context).primaryColor,
+                  unselectedLabelColor: Colors.grey[600],
+                  indicatorColor: Theme.of(context).primaryColor,
+                  indicatorWeight: 3,
+                  labelStyle: const TextStyle(
+                    fontWeight: FontWeight.bold,
+                    fontSize: 16,
+                  ),
+                  unselectedLabelStyle: const TextStyle(fontSize: 16),
+                  tabs: const [
+                    Tab(text: '公開用'),
+                    Tab(text: '表示用'),
+                  ],
+                ),
+              ),
+              Expanded(
+                child: TabBarView(
+                  children: [
+                    _PublicListsView(listsAsync: listsAsync),
+                    _DisplayListsView(displayListsAsync: displayListsAsync),
+                  ],
+                ),
+              ),
             ],
           ),
-        ),
-        body: TabBarView(
-          children: [
-            listsAsync.when(
-              data: (lists) {
-                if (lists.isEmpty) {
-                  return const Center(child: Text('公開用リストがありません'));
+          Positioned(
+            right: 16,
+            bottom: 16,
+            child: FloatingActionButton(
+              heroTag: 'list_create_fab',
+              onPressed: () {
+                if (selectedTabIndex == 0) {
+                  Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (context) => const CreateListPage(),
+                    ),
+                  );
+                  return;
                 }
-
-                return ListView.builder(
-                  itemCount: lists.length,
-                  itemBuilder: (context, index) {
-                    final list = lists[index];
-                    return ListTile(
-                      leading: const Icon(Icons.list),
-                      title: Text(list.listName),
-                      subtitle: Text('${list.memberIds.length}人のメンバー'),
-                      onTap: () {
-                        Navigator.of(context).push(
-                          MaterialPageRoute(
-                            builder: (context) => ListDetailPage(list: list),
-                          ),
-                        );
-                      },
-                    );
-                  },
+                Navigator.of(context).push(
+                  MaterialPageRoute(
+                    builder: (context) => const CreateDisplayListPage(),
+                  ),
                 );
               },
-              loading: () => const Center(child: CircularProgressIndicator()),
-              error: (error, _) => Center(child: Text('エラーが発生しました: $error')),
+              child: const Icon(Icons.add),
             ),
-            displayListsAsync.when(
-              data: (displayLists) {
-                if (displayLists.isEmpty) {
-                  return const Center(child: Text('表示用リストがありません'));
-                }
+          ),
+        ],
+      ),
+    );
+  }
+}
 
-                return ListView.builder(
-                  itemCount: displayLists.length,
-                  itemBuilder: (context, index) {
-                    final displayList = displayLists[index];
-                    final color =
-                        DisplayListPalette.colorForKey(displayList.colorKey);
-                    return ListTile(
-                      leading: CircleAvatar(
-                        backgroundColor: color.withValues(alpha: 0.18),
-                        child: Icon(Icons.palette, color: color),
-                      ),
-                      title: Text(displayList.name),
-                      subtitle: Text('${displayList.memberIds.length}人のメンバー'),
-                      onTap: () {
-                        Navigator.of(context).push(
-                          MaterialPageRoute(
-                            builder: (context) => DisplayListDetailPage(
-                              displayList: displayList,
-                            ),
-                          ),
-                        );
-                      },
-                    );
-                  },
+class _PublicListsView extends StatelessWidget {
+  const _PublicListsView({required this.listsAsync});
+
+  final AsyncValue<List<UserList>> listsAsync;
+
+  @override
+  Widget build(BuildContext context) {
+    return listsAsync.when(
+      data: (lists) {
+        if (lists.isEmpty) {
+          return const Center(child: Text('公開用リストがありません'));
+        }
+
+        return ListView.builder(
+          padding: const EdgeInsets.only(bottom: 88),
+          itemCount: lists.length,
+          itemBuilder: (context, index) {
+            final list = lists[index];
+            return ListTile(
+              leading: const Icon(Icons.list),
+              title: Text(list.listName),
+              subtitle: Text('${list.memberIds.length}人のメンバー'),
+              onTap: () {
+                Navigator.of(context).push(
+                  MaterialPageRoute(
+                    builder: (context) => ListDetailPage(list: list),
+                  ),
                 );
               },
-              loading: () => const Center(child: CircularProgressIndicator()),
-              error: (error, _) => Center(child: Text('エラーが発生しました: $error')),
-            ),
-          ],
-        ),
-        floatingActionButton: FloatingActionButton(
-          onPressed: () {
-            if (_tabIndex == 0) {
-              Navigator.of(context).push(
-                MaterialPageRoute(
-                  builder: (context) => const CreateListPage(),
-                ),
-              );
-              return;
-            }
-            Navigator.of(context).push(
-              MaterialPageRoute(
-                builder: (context) => const CreateDisplayListPage(),
-              ),
             );
           },
-          child: const Icon(Icons.add),
-        ),
-      ),
+        );
+      },
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (error, _) => Center(child: Text('エラーが発生しました: $error')),
+    );
+  }
+}
+
+class _DisplayListsView extends StatelessWidget {
+  const _DisplayListsView({required this.displayListsAsync});
+
+  final AsyncValue<List<DisplayList>> displayListsAsync;
+
+  @override
+  Widget build(BuildContext context) {
+    return displayListsAsync.when(
+      data: (displayLists) {
+        if (displayLists.isEmpty) {
+          return const Center(child: Text('表示用リストがありません'));
+        }
+
+        return ListView.builder(
+          padding: const EdgeInsets.only(bottom: 88),
+          itemCount: displayLists.length,
+          itemBuilder: (context, index) {
+            final displayList = displayLists[index];
+            final color = DisplayListPalette.colorForKey(displayList.colorKey);
+            return ListTile(
+              leading: CircleAvatar(
+                backgroundColor: color.withValues(alpha: 0.18),
+                child: Icon(Icons.palette, color: color),
+              ),
+              title: Text(displayList.name),
+              subtitle: Text('${displayList.memberIds.length}人のメンバー'),
+              onTap: () {
+                Navigator.of(context).push(
+                  MaterialPageRoute(
+                    builder: (context) => DisplayListDetailPage(
+                      displayList: displayList,
+                    ),
+                  ),
+                );
+              },
+            );
+          },
+        );
+      },
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (error, _) => Center(child: Text('エラーが発生しました: $error')),
     );
   }
 }

--- a/lib/presentation/widgets/schedule_tile.dart
+++ b/lib/presentation/widgets/schedule_tile.dart
@@ -3,10 +3,12 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:intl/intl.dart';
 import 'package:lakiite/app/di/providers.dart';
 import 'package:lakiite/application/schedule/schedule_notifier.dart';
+import 'package:lakiite/domain/entity/display_list.dart';
 import 'package:lakiite/domain/entity/schedule.dart';
 import 'package:lakiite/domain/entity/user.dart';
 import 'package:lakiite/presentation/calendar/edit_schedule_page.dart';
 import 'package:lakiite/presentation/calendar/schedule_detail_page.dart';
+import 'package:lakiite/presentation/calendar/widgets/schedule_ownership_style.dart';
 import 'package:lakiite/application/schedule/schedule_interaction_notifier.dart';
 import 'package:lakiite/presentation/widgets/reaction_icon_widget.dart';
 
@@ -44,6 +46,7 @@ class ScheduleTile extends ConsumerWidget {
     this.onDeletePressed,
     this.onReactionTap,
     this.margin,
+    this.displayLists = const [],
   });
 
   /// 表示する予定のデータ
@@ -79,29 +82,36 @@ class ScheduleTile extends ConsumerWidget {
   /// カードのマージン
   final EdgeInsetsGeometry? margin;
 
+  /// 予定作成者の色分けに使う表示用リスト
+  final Iterable<DisplayList> displayLists;
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final isOwnSchedule = schedule.ownerId == currentUserId;
+    final ownershipStyle = ScheduleOwnershipStyle.resolve(
+      context,
+      schedule: schedule,
+      currentUserId: currentUserId,
+      displayLists: displayLists,
+      backgroundAlpha: isTimelineView ? 0.08 : 0.1,
+      borderAlpha: isTimelineView ? 0.7 : 0.8,
+      primaryTextAlpha: 0.85,
+      ownerBackgroundColor: Colors.grey[100],
+      ownerBorderColor: Colors.grey[400],
+    );
 
     return Card(
       margin: margin ?? const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
       elevation: isTimelineView && !isOwnSchedule ? 0 : 1,
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(8),
-        side: isTimelineView && !isOwnSchedule
-            ? BorderSide.none
-            : BorderSide(
-                color: isTimelineView
-                    ? (isOwnSchedule
-                        ? Colors.grey[400]!
-                        : Theme.of(context).primaryColor.withAlpha(77))
-                    : Colors.grey[300]!,
-                width: 1,
-              ),
+        side: BorderSide(
+          color:
+              isTimelineView ? ownershipStyle.borderColor : Colors.grey[300]!,
+          width: 1,
+        ),
       ),
-      color: isTimelineView
-          ? (isOwnSchedule ? Colors.grey[100] : Colors.white)
-          : Colors.grey[50],
+      color: isTimelineView ? ownershipStyle.backgroundColor : Colors.grey[50],
       child: InkWell(
         onTap: () {
           Navigator.of(context).push(

--- a/test/domain/service/display_list_membership_test.dart
+++ b/test/domain/service/display_list_membership_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lakiite/domain/entity/display_list.dart';
+import 'package:lakiite/domain/service/display_list_membership.dart';
+
+void main() {
+  group('DisplayListMembership', () {
+    test('finds the display list containing a schedule owner', () {
+      final displayLists = [
+        _displayList(id: 'family', colorKey: 'red', memberIds: ['friend-1']),
+        _displayList(id: 'work', colorKey: 'blue', memberIds: ['friend-2']),
+      ];
+
+      final result = DisplayListMembership.findListForUser(
+        displayLists: displayLists,
+        userId: 'friend-2',
+      );
+
+      expect(result?.id, 'work');
+      expect(result?.colorKey, 'blue');
+    });
+
+    test('returns null when the user is not in any display list', () {
+      final displayLists = [
+        _displayList(id: 'family', colorKey: 'red', memberIds: ['friend-1']),
+      ];
+
+      final result = DisplayListMembership.findListForUser(
+        displayLists: displayLists,
+        userId: 'friend-2',
+      );
+
+      expect(result, isNull);
+    });
+
+    test('detects membership in another display list', () {
+      final displayLists = [
+        _displayList(id: 'family', colorKey: 'red', memberIds: ['friend-1']),
+        _displayList(id: 'work', colorKey: 'blue', memberIds: ['friend-2']),
+      ];
+
+      final result = DisplayListMembership.findConflictingList(
+        displayLists: displayLists,
+        targetListId: 'family',
+        userId: 'friend-2',
+      );
+
+      expect(result?.id, 'work');
+    });
+  });
+}
+
+DisplayList _displayList({
+  required String id,
+  required String colorKey,
+  required List<String> memberIds,
+}) {
+  final now = DateTime(2026, 6, 3);
+  return DisplayList(
+    id: id,
+    name: id,
+    ownerId: 'owner',
+    colorKey: colorKey,
+    memberIds: memberIds,
+    createdAt: now,
+    updatedAt: now,
+  );
+}

--- a/test/presentation/auth/auth_home_navigation_test.dart
+++ b/test/presentation/auth/auth_home_navigation_test.dart
@@ -5,6 +5,9 @@ import 'package:intl/date_symbol_data_local.dart';
 import 'package:lakiite/config/admob_config.dart';
 import 'package:lakiite/config/app_config.dart';
 import 'package:lakiite/main.dart';
+import 'package:lakiite/presentation/bottom_navigation/bottom_navigation.dart';
+import 'package:lakiite/presentation/list/display_list_providers.dart';
+import 'package:lakiite/presentation/list/list_providers.dart';
 
 import '../../../mock/providers/test_providers.dart';
 import '../../utils/test_utils.dart';
@@ -143,6 +146,45 @@ void main() {
       ),
       findsOneWidget,
     );
+  });
+
+  testWidgets('認証済みボトムナビはリストを独立タブとして表示する', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          ...TestProviders.authenticated,
+          userListsStreamProvider.overrideWith((ref) => Stream.value([])),
+          userDisplayListsStreamProvider.overrideWith(
+            (ref) => Stream.value([]),
+          ),
+        ],
+        child: const MaterialApp(home: BottomNavigationPage()),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 2));
+    await tester.pump(const Duration(milliseconds: 300));
+
+    final bottomNavigationBar = tester.widget<BottomNavigationBar>(
+      find.byType(BottomNavigationBar),
+    );
+    expect(
+      bottomNavigationBar.items.map((item) => item.label),
+      ['ホーム', 'フレンド', 'リスト', 'マイページ'],
+    );
+
+    await tester.tap(find.text('リスト'));
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(
+      find.descendant(
+        of: find.byType(AppBar),
+        matching: find.text('リスト'),
+      ),
+      findsOneWidget,
+    );
+    expect(find.text('公開用'), findsOneWidget);
+    expect(find.text('表示用'), findsOneWidget);
   });
 }
 

--- a/test/presentation/calendar/schedule_ownership_style_test.dart
+++ b/test/presentation/calendar/schedule_ownership_style_test.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lakiite/domain/entity/display_list.dart';
+import 'package:lakiite/domain/entity/schedule.dart';
+import 'package:lakiite/presentation/calendar/widgets/schedule_ownership_style.dart';
+import 'package:lakiite/presentation/list/display_list_palette.dart';
+
+void main() {
+  group('ScheduleOwnershipStyle', () {
+    testWidgets('uses gray for the current user schedule', (tester) async {
+      late ScheduleOwnershipStyle style;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              style = ScheduleOwnershipStyle.resolve(
+                context,
+                schedule: _schedule(ownerId: 'current-user'),
+                currentUserId: 'current-user',
+                displayLists: const [],
+              );
+              return const SizedBox();
+            },
+          ),
+        ),
+      );
+
+      expect(style.borderColor, Colors.grey.withValues(alpha: 0.8));
+    });
+
+    testWidgets('uses display list color for a listed friend schedule',
+        (tester) async {
+      late ScheduleOwnershipStyle style;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              style = ScheduleOwnershipStyle.resolve(
+                context,
+                schedule: _schedule(ownerId: 'friend-1'),
+                currentUserId: 'current-user',
+                displayLists: [
+                  _displayList(colorKey: 'teal', memberIds: ['friend-1']),
+                ],
+              );
+              return const SizedBox();
+            },
+          ),
+        ),
+      );
+
+      expect(
+        style.borderColor,
+        DisplayListPalette.colorForKey('teal').withValues(alpha: 0.8),
+      );
+    });
+
+    testWidgets('uses primary color for an unlisted friend schedule',
+        (tester) async {
+      const primaryColor = Colors.deepOrange;
+      late ScheduleOwnershipStyle style;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(primaryColor: primaryColor),
+          home: Builder(
+            builder: (context) {
+              style = ScheduleOwnershipStyle.resolve(
+                context,
+                schedule: _schedule(ownerId: 'friend-2'),
+                currentUserId: 'current-user',
+                displayLists: [
+                  _displayList(colorKey: 'teal', memberIds: ['friend-1']),
+                ],
+              );
+              return const SizedBox();
+            },
+          ),
+        ),
+      );
+
+      expect(style.borderColor, primaryColor.withValues(alpha: 0.8));
+    });
+  });
+}
+
+DisplayList _displayList({
+  required String colorKey,
+  required List<String> memberIds,
+}) {
+  final now = DateTime(2026, 6, 3);
+  return DisplayList(
+    id: 'display-list',
+    name: '表示用リスト',
+    ownerId: 'current-user',
+    colorKey: colorKey,
+    memberIds: memberIds,
+    createdAt: now,
+    updatedAt: now,
+  );
+}
+
+Schedule _schedule({required String ownerId}) {
+  final now = DateTime(2026, 6, 3, 10);
+  return Schedule(
+    id: 'schedule',
+    title: '予定',
+    description: '',
+    startDateTime: now,
+    endDateTime: now.add(const Duration(hours: 1)),
+    ownerId: ownerId,
+    ownerDisplayName: 'Owner',
+    sharedLists: const [],
+    visibleTo: const [],
+    createdAt: now,
+    updatedAt: now,
+  );
+}

--- a/test/presentation/friend/friend_list_page_test.dart
+++ b/test/presentation/friend/friend_list_page_test.dart
@@ -125,5 +125,46 @@ void main() {
       expect(find.text('拒否済みユーザー'), findsNothing);
       expect(find.text('承認待ち'), findsNothing);
     });
+
+    testWidgets('フレンド画面はリストタブを表示しない', (tester) async {
+      final currentUser = UserModel.create(
+        id: 'current-user-id',
+        name: '現在ユーザー',
+        displayName: '現在ユーザー',
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            auth.authNotifierProvider.overrideWith(
+              () => _StubAuthNotifier(AuthState.authenticated(currentUser)),
+            ),
+            userFriendsStreamProvider.overrideWith(
+              (ref) => Stream.value([]),
+            ),
+            notification.sentNotificationsByTypeProvider.overrideWith(
+              (ref, type) => Stream.value([]),
+            ),
+            notification.unreadNotificationCountProvider.overrideWith(
+              (ref) => Stream.value(0),
+            ),
+            notification.unreadNotificationCountByTypeProvider.overrideWith(
+              (ref, type) => Stream.value(0),
+            ),
+          ],
+          child: const MaterialApp(home: FriendListPage()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        find.descendant(
+          of: find.byType(AppBar),
+          matching: find.text('フレンド'),
+        ),
+        findsOneWidget,
+      );
+      expect(find.text('リスト'), findsNothing);
+    });
   });
 }


### PR DESCRIPTION
## Summary
- Add user-owned display lists with a fixed 10-color palette
- Apply display-list colors to home calendar and timeline schedule surfaces
- Keep current user schedules gray and unlisted friends on the primary color
- Disable friends already assigned to any display list when adding display-list members

## Validation
- fvm flutter analyze
- fvm flutter test --coverage --dart-define=FLUTTER_TEST=true --exclude-tags=integration test/domain/ test/utils/ test/application/
- fvm flutter test test/presentation/ --dart-define=FLUTTER_TEST=true
- fvm flutter run -d cf545991 --flavor dev --dart-define-from-file=dart_define/dev_dart_define.json

Closes #223