### PR TITLE
feat: add morning schedule digest settings

### DIFF
--- a/lib/config/router/app_router.dart
+++ b/lib/config/router/app_router.dart
@@ -9,6 +9,7 @@ import '../../presentation/settings/edit_email_page.dart';
 import '../../presentation/settings/edit_name_page.dart';
 import '../../presentation/settings/edit_search_id_page.dart';
 import '../../presentation/settings/legal_info_page.dart';
+import '../../presentation/settings/schedule_digest_settings_page.dart';
 import '../../presentation/settings/settings_page.dart';
 import '../../presentation/settings/account_deletion_webview_page.dart';
 import '../../presentation/signup/signup.dart';
@@ -108,6 +109,10 @@ final routerProvider = Provider<GoRouter>((ref) {
           GoRoute(
             path: EditSearchIdPage.path,
             builder: (context, state) => const EditSearchIdPage(),
+          ),
+          GoRoute(
+            path: ScheduleDigestSettingsPage.path,
+            builder: (context, state) => const ScheduleDigestSettingsPage(),
           ),
           GoRoute(
             path: 'privacy-policy',

--- a/lib/domain/entity/schedule_digest_settings.dart
+++ b/lib/domain/entity/schedule_digest_settings.dart
@@ -1,0 +1,72 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class ScheduleDigestSettings {
+  ScheduleDigestSettings({
+    required this.userId,
+    required this.enabled,
+    required this.notifyHour,
+    this.lastSentDate,
+  }) {
+    if (notifyHour < 0 || notifyHour > 9) {
+      throw ArgumentError.value(
+        notifyHour,
+        'notifyHour',
+        'notifyHour must be between 0 and 9',
+      );
+    }
+  }
+
+  factory ScheduleDigestSettings.defaults(String userId) {
+    return ScheduleDigestSettings(
+      userId: userId,
+      enabled: true,
+      notifyHour: 8,
+    );
+  }
+
+  factory ScheduleDigestSettings.fromFirestore({
+    required String userId,
+    required Map<String, dynamic>? data,
+  }) {
+    if (data == null) {
+      return ScheduleDigestSettings.defaults(userId);
+    }
+
+    final rawNotifyHour = data['notifyHour'];
+    final notifyHour = rawNotifyHour is int ? rawNotifyHour : 8;
+
+    return ScheduleDigestSettings(
+      userId: userId,
+      enabled: data['enabled'] as bool? ?? true,
+      notifyHour: notifyHour >= 0 && notifyHour <= 9 ? notifyHour : 8,
+      lastSentDate: data['lastSentDate'] as String?,
+    );
+  }
+
+  final String userId;
+  final bool enabled;
+  final int notifyHour;
+  final String? lastSentDate;
+
+  ScheduleDigestSettings copyWith({
+    bool? enabled,
+    int? notifyHour,
+    String? lastSentDate,
+  }) {
+    return ScheduleDigestSettings(
+      userId: userId,
+      enabled: enabled ?? this.enabled,
+      notifyHour: notifyHour ?? this.notifyHour,
+      lastSentDate: lastSentDate ?? this.lastSentDate,
+    );
+  }
+
+  Map<String, dynamic> toFirestore() {
+    return {
+      'enabled': enabled,
+      'notifyHour': notifyHour,
+      'lastSentDate': lastSentDate,
+      'updatedAt': FieldValue.serverTimestamp(),
+    };
+  }
+}

--- a/lib/domain/interfaces/i_schedule_digest_settings_repository.dart
+++ b/lib/domain/interfaces/i_schedule_digest_settings_repository.dart
@@ -1,0 +1,7 @@
+import '../entity/schedule_digest_settings.dart';
+
+abstract class IScheduleDigestSettingsRepository {
+  Stream<ScheduleDigestSettings> watchCurrentUserSettings();
+
+  Future<void> saveCurrentUserSettings(ScheduleDigestSettings settings);
+}

--- a/lib/infrastructure/firebase/push_notification_service.dart
+++ b/lib/infrastructure/firebase/push_notification_service.dart
@@ -626,10 +626,13 @@ class PushNotificationService {
         case 'comment':
           _handleComment(data);
           break;
+        case 'schedule_digest':
+          _handleScheduleDigest(data);
+          break;
         default:
           AppLogger.warning('⚠️ 未知の通知タイプ: $notificationType');
           AppLogger.info(
-              '💡 サポートされている通知タイプ: friend_request, group_invitation, reaction, comment');
+              '💡 サポートされている通知タイプ: friend_request, group_invitation, reaction, comment, schedule_digest');
       }
     } catch (e) {
       AppLogger.error('メッセージ処理エラー: $e');
@@ -641,6 +644,12 @@ class PushNotificationService {
     AppLogger.info('👥 送信元ユーザーID: ${data['fromUserId']}');
     AppLogger.info('👥 送信元ユーザー名: ${data['fromUserName']}');
     AppLogger.info('👥 データ詳細: $data');
+  }
+
+  void _handleScheduleDigest(Map<String, dynamic> data) {
+    AppLogger.info('📅 朝の共有予定通知を処理中');
+    AppLogger.info('📅 日付: ${data['date']}');
+    AppLogger.info('📅 予定件数: ${data['scheduleCount']}');
   }
 
   void _handleGroupInvitation(Map<String, dynamic> data) {

--- a/lib/infrastructure/schedule_digest_settings_repository.dart
+++ b/lib/infrastructure/schedule_digest_settings_repository.dart
@@ -1,0 +1,53 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+import '../domain/entity/schedule_digest_settings.dart';
+import '../domain/interfaces/i_schedule_digest_settings_repository.dart';
+
+class ScheduleDigestSettingsRepository
+    implements IScheduleDigestSettingsRepository {
+  ScheduleDigestSettingsRepository({
+    FirebaseFirestore? firestore,
+    FirebaseAuth? auth,
+  })  : _firestore = firestore ?? FirebaseFirestore.instance,
+        _auth = auth ?? FirebaseAuth.instance;
+
+  final FirebaseFirestore _firestore;
+  final FirebaseAuth _auth;
+
+  static const String collectionPath = 'scheduleDigestSettings';
+
+  @override
+  Stream<ScheduleDigestSettings> watchCurrentUserSettings() {
+    final userId = _currentUserId();
+    return _firestore
+        .collection(collectionPath)
+        .doc(userId)
+        .snapshots()
+        .map((snapshot) {
+      return ScheduleDigestSettings.fromFirestore(
+        userId: userId,
+        data: snapshot.data(),
+      );
+    });
+  }
+
+  @override
+  Future<void> saveCurrentUserSettings(
+    ScheduleDigestSettings settings,
+  ) async {
+    final userId = _currentUserId();
+    await _firestore.collection(collectionPath).doc(userId).set(
+          settings.toFirestore(),
+          SetOptions(merge: true),
+        );
+  }
+
+  String _currentUserId() {
+    final user = _auth.currentUser;
+    if (user == null) {
+      throw StateError('User not authenticated');
+    }
+    return user.uid;
+  }
+}

--- a/lib/presentation/settings/schedule_digest_settings_page.dart
+++ b/lib/presentation/settings/schedule_digest_settings_page.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../domain/entity/schedule_digest_settings.dart';
+import 'schedule_digest_settings_providers.dart';
+
+class ScheduleDigestSettingsPage extends ConsumerWidget {
+  const ScheduleDigestSettingsPage({super.key});
+
+  static const String path = 'schedule-digest';
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final settingsAsync = ref.watch(scheduleDigestSettingsProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('朝の共有予定通知'),
+      ),
+      body: settingsAsync.when(
+        data: (settings) => _ScheduleDigestSettingsContent(
+          settings: settings,
+        ),
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (error, _) => Center(
+          child: Text('通知設定の取得に失敗しました: $error'),
+        ),
+      ),
+    );
+  }
+}
+
+class _ScheduleDigestSettingsContent extends ConsumerWidget {
+  const _ScheduleDigestSettingsContent({required this.settings});
+
+  final ScheduleDigestSettings settings;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final repository = ref.watch(scheduleDigestSettingsRepositoryProvider);
+
+    Future<void> save(ScheduleDigestSettings nextSettings) async {
+      try {
+        await repository.saveCurrentUserSettings(nextSettings);
+      } catch (error) {
+        if (!context.mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('通知設定の保存に失敗しました: $error')),
+        );
+      }
+    }
+
+    return ListView(
+      children: [
+        SwitchListTile(
+          secondary: const Icon(Icons.notifications_outlined),
+          title: const Text('通知する'),
+          value: settings.enabled,
+          onChanged: (enabled) => save(settings.copyWith(enabled: enabled)),
+        ),
+        const Divider(),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+          child: DropdownButtonFormField<int>(
+            key: const Key('schedule-digest-notify-hour-dropdown'),
+            initialValue: settings.notifyHour,
+            decoration: const InputDecoration(
+              icon: Icon(Icons.schedule),
+              labelText: '通知時刻',
+              helperText: '0時から9時まで選択できます',
+              border: OutlineInputBorder(),
+            ),
+            items: [
+              for (var hour = 0; hour <= 9; hour++)
+                DropdownMenuItem<int>(
+                  value: hour,
+                  child: Text('$hour時'),
+                ),
+            ],
+            onChanged: settings.enabled
+                ? (value) {
+                    if (value == null) return;
+                    save(settings.copyWith(notifyHour: value));
+                  }
+                : null,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/presentation/settings/schedule_digest_settings_providers.dart
+++ b/lib/presentation/settings/schedule_digest_settings_providers.dart
@@ -1,0 +1,17 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../domain/entity/schedule_digest_settings.dart';
+import '../../domain/interfaces/i_schedule_digest_settings_repository.dart';
+import '../../infrastructure/schedule_digest_settings_repository.dart';
+
+final scheduleDigestSettingsRepositoryProvider =
+    Provider<IScheduleDigestSettingsRepository>((ref) {
+  return ScheduleDigestSettingsRepository();
+});
+
+final scheduleDigestSettingsProvider =
+    StreamProvider<ScheduleDigestSettings>((ref) {
+  return ref
+      .watch(scheduleDigestSettingsRepositoryProvider)
+      .watchCurrentUserSettings();
+});

--- a/lib/presentation/settings/settings_page.dart
+++ b/lib/presentation/settings/settings_page.dart
@@ -6,6 +6,7 @@ import 'edit_name_page.dart';
 import 'edit_email_page.dart';
 import 'edit_search_id_page.dart';
 import 'account_deletion_webview_page.dart';
+import 'schedule_digest_settings_page.dart';
 
 class SettingsPage extends ConsumerWidget {
   const SettingsPage({super.key});
@@ -41,6 +42,15 @@ class SettingsPage extends ConsumerWidget {
             trailing: const Icon(Icons.chevron_right),
             onTap: () {
               context.push('/settings/${EditSearchIdPage.path}');
+            },
+          ),
+          ListTile(
+            leading: const Icon(Icons.notifications_outlined),
+            title: const Text('朝の共有予定通知'),
+            subtitle: const Text('今日共有されている予定を朝に通知'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () {
+              context.push('/settings/${ScheduleDigestSettingsPage.path}');
             },
           ),
           const Divider(),

--- a/test/domain/entity/schedule_digest_settings_test.dart
+++ b/test/domain/entity/schedule_digest_settings_test.dart
@@ -1,0 +1,43 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lakiite/domain/entity/schedule_digest_settings.dart';
+
+void main() {
+  group('ScheduleDigestSettings', () {
+    test('missing document defaults to enabled at 8', () {
+      final settings = ScheduleDigestSettings.defaults('user-1');
+
+      expect(settings.userId, 'user-1');
+      expect(settings.enabled, isTrue);
+      expect(settings.notifyHour, 8);
+      expect(settings.lastSentDate, isNull);
+    });
+
+    test('serializes notifyHour and enabled fields for Firestore', () {
+      final settings = ScheduleDigestSettings(
+        userId: 'user-1',
+        enabled: false,
+        notifyHour: 7,
+        lastSentDate: '2026-06-03',
+      );
+
+      final data = settings.toFirestore();
+
+      expect(data['enabled'], isFalse);
+      expect(data['notifyHour'], 7);
+      expect(data['lastSentDate'], '2026-06-03');
+      expect(data['updatedAt'], isA<FieldValue>());
+    });
+
+    test('rejects notifyHour outside morning range', () {
+      expect(
+        () => ScheduleDigestSettings(
+          userId: 'user-1',
+          enabled: true,
+          notifyHour: 10,
+        ),
+        throwsArgumentError,
+      );
+    });
+  });
+}

--- a/test/presentation/settings/schedule_digest_settings_page_test.dart
+++ b/test/presentation/settings/schedule_digest_settings_page_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lakiite/domain/entity/schedule_digest_settings.dart';
+import 'package:lakiite/domain/interfaces/i_schedule_digest_settings_repository.dart';
+import 'package:lakiite/presentation/settings/schedule_digest_settings_page.dart';
+import 'package:lakiite/presentation/settings/schedule_digest_settings_providers.dart';
+
+void main() {
+  testWidgets('朝の共有予定通知設定を表示して保存できる', (tester) async {
+    final repository = _FakeScheduleDigestSettingsRepository(
+      ScheduleDigestSettings.defaults('user-1'),
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          scheduleDigestSettingsRepositoryProvider.overrideWithValue(
+            repository,
+          ),
+          scheduleDigestSettingsProvider.overrideWith(
+            (ref) => Stream.value(repository.current),
+          ),
+        ],
+        child: const MaterialApp(home: ScheduleDigestSettingsPage()),
+      ),
+    );
+
+    await tester.pump();
+
+    expect(find.text('朝の共有予定通知'), findsOneWidget);
+    expect(find.text('通知する'), findsOneWidget);
+
+    expect(find.text('8時'), findsOneWidget);
+
+    await tester.tap(
+      find.byKey(const Key('schedule-digest-notify-hour-dropdown')),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('7時').last);
+    await tester.pumpAndSettle();
+
+    expect(repository.saved?.notifyHour, 7);
+    expect(repository.saved?.enabled, isTrue);
+  });
+}
+
+class _FakeScheduleDigestSettingsRepository
+    implements IScheduleDigestSettingsRepository {
+  _FakeScheduleDigestSettingsRepository(this.current);
+
+  ScheduleDigestSettings current;
+  ScheduleDigestSettings? saved;
+
+  @override
+  Stream<ScheduleDigestSettings> watchCurrentUserSettings() {
+    return Stream.value(current);
+  }
+
+  @override
+  Future<void> saveCurrentUserSettings(ScheduleDigestSettings settings) async {
+    saved = settings;
+    current = settings;
+  }
+}


### PR DESCRIPTION
## Summary
- Add schedule digest settings domain model, repository, providers, route, and settings page.
- Add settings entry for morning shared-schedule notifications with 0-9 hour selection and default 8:00.
- Handle `schedule_digest` push notification data type explicitly.

## Test Plan
- `fvm flutter test test/domain/entity/schedule_digest_settings_test.dart test/presentation/settings/schedule_digest_settings_page_test.dart`
- `fvm dart analyze lib/domain/entity/schedule_digest_settings.dart lib/domain/interfaces/i_schedule_digest_settings_repository.dart lib/infrastructure/schedule_digest_settings_repository.dart lib/presentation/settings/schedule_digest_settings_providers.dart lib/presentation/settings/schedule_digest_settings_page.dart`
- `fvm flutter analyze` currently reports existing generated Firebase options are missing: `lib/firebase_options.dart`.

## Related Issues
- Closes #225
- Follow-up: #233