### PR TITLE
fix: handle missing schedule digest settings

### DIFF
--- a/lib/domain/entity/schedule_digest_settings.dart
+++ b/lib/domain/entity/schedule_digest_settings.dart
@@ -24,6 +24,14 @@ class ScheduleDigestSettings {
     );
   }
 
+  factory ScheduleDigestSettings.missingDocumentFallback(String userId) {
+    return ScheduleDigestSettings(
+      userId: userId,
+      enabled: false,
+      notifyHour: 8,
+    );
+  }
+
   factory ScheduleDigestSettings.fromFirestore({
     required String userId,
     required Map<String, dynamic>? data,

--- a/lib/infrastructure/schedule_digest_settings_repository.dart
+++ b/lib/infrastructure/schedule_digest_settings_repository.dart
@@ -25,6 +25,10 @@ class ScheduleDigestSettingsRepository
         .doc(userId)
         .snapshots()
         .map((snapshot) {
+      if (!snapshot.exists) {
+        return ScheduleDigestSettings.missingDocumentFallback(userId);
+      }
+
       return ScheduleDigestSettings.fromFirestore(
         userId: userId,
         data: snapshot.data(),

--- a/lib/presentation/settings/schedule_digest_settings_page.dart
+++ b/lib/presentation/settings/schedule_digest_settings_page.dart
@@ -30,40 +30,90 @@ class ScheduleDigestSettingsPage extends ConsumerWidget {
   }
 }
 
-class _ScheduleDigestSettingsContent extends ConsumerWidget {
+class _ScheduleDigestSettingsContent extends ConsumerStatefulWidget {
   const _ScheduleDigestSettingsContent({required this.settings});
 
   final ScheduleDigestSettings settings;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final repository = ref.watch(scheduleDigestSettingsRepositoryProvider);
+  ConsumerState<_ScheduleDigestSettingsContent> createState() =>
+      _ScheduleDigestSettingsContentState();
+}
 
-    Future<void> save(ScheduleDigestSettings nextSettings) async {
-      try {
-        await repository.saveCurrentUserSettings(nextSettings);
-      } catch (error) {
-        if (!context.mounted) return;
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('通知設定の保存に失敗しました: $error')),
-        );
+class _ScheduleDigestSettingsContentState
+    extends ConsumerState<_ScheduleDigestSettingsContent> {
+  late ScheduleDigestSettings _draftSettings;
+  var _isSaving = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _draftSettings = widget.settings;
+  }
+
+  @override
+  void didUpdateWidget(_ScheduleDigestSettingsContent oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.settings.userId != widget.settings.userId ||
+        oldWidget.settings.enabled != widget.settings.enabled ||
+        oldWidget.settings.notifyHour != widget.settings.notifyHour ||
+        oldWidget.settings.lastSentDate != widget.settings.lastSentDate) {
+      _draftSettings = widget.settings;
+    }
+  }
+
+  Future<void> _save() async {
+    setState(() {
+      _isSaving = true;
+    });
+
+    try {
+      final repository = ref.read(scheduleDigestSettingsRepositoryProvider);
+      await repository.saveCurrentUserSettings(_draftSettings);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('通知設定を保存しました')),
+      );
+    } catch (error) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('通知設定の保存に失敗しました: $error')),
+      );
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isSaving = false;
+        });
       }
     }
+  }
 
+  @override
+  Widget build(BuildContext context) {
     return ListView(
       children: [
+        const Padding(
+          padding: EdgeInsets.fromLTRB(16, 16, 16, 8),
+          child: Text(
+            '今日あなたに共有されている予定がある場合に、指定した時刻に通知を受け取れます。',
+          ),
+        ),
         SwitchListTile(
           secondary: const Icon(Icons.notifications_outlined),
           title: const Text('通知する'),
-          value: settings.enabled,
-          onChanged: (enabled) => save(settings.copyWith(enabled: enabled)),
+          value: _draftSettings.enabled,
+          onChanged: (enabled) {
+            setState(() {
+              _draftSettings = _draftSettings.copyWith(enabled: enabled);
+            });
+          },
         ),
         const Divider(),
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
           child: DropdownButtonFormField<int>(
             key: const Key('schedule-digest-notify-hour-dropdown'),
-            initialValue: settings.notifyHour,
+            initialValue: _draftSettings.notifyHour,
             decoration: const InputDecoration(
               icon: Icon(Icons.schedule),
               labelText: '通知時刻',
@@ -77,12 +127,24 @@ class _ScheduleDigestSettingsContent extends ConsumerWidget {
                   child: Text('$hour時'),
                 ),
             ],
-            onChanged: settings.enabled
+            onChanged: _draftSettings.enabled
                 ? (value) {
                     if (value == null) return;
-                    save(settings.copyWith(notifyHour: value));
+                    setState(() {
+                      _draftSettings = _draftSettings.copyWith(
+                        notifyHour: value,
+                      );
+                    });
                   }
                 : null,
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
+          child: FilledButton(
+            key: const Key('schedule-digest-save-button'),
+            onPressed: _isSaving ? null : _save,
+            child: Text(_isSaving ? '保存中...' : '保存'),
           ),
         ),
       ],

--- a/test/domain/entity/schedule_digest_settings_test.dart
+++ b/test/domain/entity/schedule_digest_settings_test.dart
@@ -13,6 +13,15 @@ void main() {
       expect(settings.lastSentDate, isNull);
     });
 
+    test('missing document fallback defaults to disabled at 8', () {
+      final settings = ScheduleDigestSettings.missingDocumentFallback('user-1');
+
+      expect(settings.userId, 'user-1');
+      expect(settings.enabled, isFalse);
+      expect(settings.notifyHour, 8);
+      expect(settings.lastSentDate, isNull);
+    });
+
     test('serializes notifyHour and enabled fields for Firestore', () {
       final settings = ScheduleDigestSettings(
         userId: 'user-1',

--- a/test/presentation/settings/schedule_digest_settings_page_test.dart
+++ b/test/presentation/settings/schedule_digest_settings_page_test.dart
@@ -43,6 +43,41 @@ void main() {
     expect(repository.saved?.notifyHour, 7);
     expect(repository.saved?.enabled, isTrue);
   });
+
+  testWidgets('設定が未作成の場合はオフ表示でオンにすると作成される', (tester) async {
+    final repository = _FakeScheduleDigestSettingsRepository(
+      ScheduleDigestSettings.missingDocumentFallback('user-1'),
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          scheduleDigestSettingsRepositoryProvider.overrideWithValue(
+            repository,
+          ),
+          scheduleDigestSettingsProvider.overrideWith(
+            (ref) => Stream.value(repository.current),
+          ),
+        ],
+        child: const MaterialApp(home: ScheduleDigestSettingsPage()),
+      ),
+    );
+
+    await tester.pump();
+
+    expect(find.text('通知する'), findsOneWidget);
+    expect(find.text('8時'), findsOneWidget);
+    expect(repository.saved, isNull);
+
+    final notificationSwitch = tester.widget<Switch>(find.byType(Switch));
+    expect(notificationSwitch.value, isFalse);
+
+    await tester.tap(find.byType(Switch));
+    await tester.pumpAndSettle();
+
+    expect(repository.saved?.enabled, isTrue);
+    expect(repository.saved?.notifyHour, 8);
+  });
 }
 
 class _FakeScheduleDigestSettingsRepository

--- a/test/presentation/settings/schedule_digest_settings_page_test.dart
+++ b/test/presentation/settings/schedule_digest_settings_page_test.dart
@@ -30,6 +30,11 @@ void main() {
 
     expect(find.text('朝の共有予定通知'), findsOneWidget);
     expect(find.text('通知する'), findsOneWidget);
+    expect(
+      find.text('今日あなたに共有されている予定がある場合に、指定した時刻に通知を受け取れます。'),
+      findsOneWidget,
+    );
+    expect(find.text('保存'), findsOneWidget);
 
     expect(find.text('8時'), findsOneWidget);
 
@@ -40,11 +45,16 @@ void main() {
     await tester.tap(find.text('7時').last);
     await tester.pumpAndSettle();
 
+    expect(repository.saved, isNull);
+
+    await tester.tap(find.byKey(const Key('schedule-digest-save-button')));
+    await tester.pumpAndSettle();
+
     expect(repository.saved?.notifyHour, 7);
     expect(repository.saved?.enabled, isTrue);
   });
 
-  testWidgets('設定が未作成の場合はオフ表示でオンにすると作成される', (tester) async {
+  testWidgets('設定が未作成の場合はオフ表示でオンにして保存すると作成される', (tester) async {
     final repository = _FakeScheduleDigestSettingsRepository(
       ScheduleDigestSettings.missingDocumentFallback('user-1'),
     );
@@ -73,6 +83,11 @@ void main() {
     expect(notificationSwitch.value, isFalse);
 
     await tester.tap(find.byType(Switch));
+    await tester.pumpAndSettle();
+
+    expect(repository.saved, isNull);
+
+    await tester.tap(find.byKey(const Key('schedule-digest-save-button')));
     await tester.pumpAndSettle();
 
     expect(repository.saved?.enabled, isTrue);


### PR DESCRIPTION
## Summary
- Show schedule digest settings as disabled at 8:00 when the Firestore settings document does not exist.
- Keep existing/default created documents enabled, including backfill and new-user creation behavior from Firebase Functions.
- Add an explanation for the morning digest behavior.
- Change the settings UI to edit locally and persist only when the user taps 保存, creating `scheduleDigestSettings/{uid}` through the existing repository `set(..., merge: true)`.

## Test Plan
- `fvm flutter test test/domain/entity/schedule_digest_settings_test.dart test/presentation/settings/schedule_digest_settings_page_test.dart`
- `fvm dart analyze lib/presentation/settings/schedule_digest_settings_page.dart test/presentation/settings/schedule_digest_settings_page_test.dart`
- `git diff --check`
- Hot reloaded on Galaxy SCG19 dev flavor

## Related Issues
- Follow-up to #225