### PR TITLE
[codex] Add how-to-use guide WebView

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
     <!-- インターネット接続の権限 -->
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
@@ -18,8 +19,12 @@
         android:label="${appName}"
         android:name="${applicationName}"
         android:icon="@mipmap/launcher_icon"
+        android:allowBackup="false"
+        android:fullBackupContent="false"
+        android:dataExtractionRules="@xml/data_extraction_rules"
         android:usesCleartextTraffic="false"
-        android:networkSecurityConfig="@xml/network_security_config">
+        android:networkSecurityConfig="@xml/network_security_config"
+        tools:replace="android:allowBackup,android:fullBackupContent,android:dataExtractionRules">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/android/app/src/main/res/xml/data_extraction_rules.xml
+++ b/android/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="root" path="." />
+        <exclude domain="device_root" path="." />
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="root" path="." />
+        <exclude domain="device_root" path="." />
+    </device-transfer>
+</data-extraction-rules>

--- a/lib/config/router/app_router.dart
+++ b/lib/config/router/app_router.dart
@@ -115,6 +115,13 @@ final routerProvider = Provider<GoRouter>((ref) {
             builder: (context, state) => const ScheduleDigestSettingsPage(),
           ),
           GoRoute(
+            path: 'how-to-use',
+            builder: (context, state) => const LegalInfoPage(
+              title: '使い方',
+              urlPath: 'how-to-use',
+            ),
+          ),
+          GoRoute(
             path: 'privacy-policy',
             builder: (context, state) => const LegalInfoPage(
               title: 'プライバシーポリシー',

--- a/lib/infrastructure/how_to_use_prompt_preferences.dart
+++ b/lib/infrastructure/how_to_use_prompt_preferences.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+final howToUsePromptPreferencesProvider = Provider<HowToUsePromptPreferences>(
+  (ref) => const HowToUsePromptPreferences(),
+);
+
+class HowToUsePromptPreferences {
+  const HowToUsePromptPreferences();
+
+  static const _hasSeenPromptKey = 'has_seen_how_to_use_prompt';
+
+  Future<bool> shouldShowPrompt() async {
+    final preferences = await SharedPreferences.getInstance();
+    return !(preferences.getBool(_hasSeenPromptKey) ?? false);
+  }
+
+  Future<void> markPromptSeen() async {
+    final preferences = await SharedPreferences.getInstance();
+    await preferences.setBool(_hasSeenPromptKey, true);
+  }
+}

--- a/lib/presentation/bottom_navigation/bottom_navigation.dart
+++ b/lib/presentation/bottom_navigation/bottom_navigation.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import '../home/home_page.dart';
 import '../friend/friend_list_page.dart';
 import '../list/list_page.dart';
 import '../my_page/my_page.dart';
 import '../widgets/auth_dependent_builder.dart';
+import '../../infrastructure/how_to_use_prompt_preferences.dart';
 import '../../infrastructure/notification_navigation_service.dart';
 
 class BottomNavigationPage extends ConsumerStatefulWidget {
@@ -28,16 +30,16 @@ class _BottomNavigationPageState extends ConsumerState<BottomNavigationPage> {
   }
 }
 
-class _AuthenticatedBottomNavigationShell extends StatefulWidget {
+class _AuthenticatedBottomNavigationShell extends ConsumerStatefulWidget {
   const _AuthenticatedBottomNavigationShell();
 
   @override
-  State<_AuthenticatedBottomNavigationShell> createState() =>
+  ConsumerState<_AuthenticatedBottomNavigationShell> createState() =>
       _AuthenticatedBottomNavigationShellState();
 }
 
 class _AuthenticatedBottomNavigationShellState
-    extends State<_AuthenticatedBottomNavigationShell> {
+    extends ConsumerState<_AuthenticatedBottomNavigationShell> {
   int _selectedIndex = 0;
 
   final List<Widget> _pages = [
@@ -59,7 +61,42 @@ class _AuthenticatedBottomNavigationShellState
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       NotificationNavigationService.instance.markNavigationReady();
+      _showHowToUsePromptIfNeeded();
     });
+  }
+
+  Future<void> _showHowToUsePromptIfNeeded() async {
+    final preferences = ref.read(howToUsePromptPreferencesProvider);
+    final shouldShowPrompt = await preferences.shouldShowPrompt();
+
+    if (!shouldShowPrompt || !mounted) {
+      return;
+    }
+
+    final openGuide = await showDialog<bool>(
+      context: context,
+      barrierDismissible: false,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('LaKiiteの使い方'),
+        content: const Text('はじめに、予定の共有やフレンド追加の流れを確認しますか？'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: const Text('閉じる'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: const Text('使い方を見る'),
+          ),
+        ],
+      ),
+    );
+
+    await preferences.markPromptSeen();
+
+    if (openGuide == true && mounted) {
+      context.push('/settings/how-to-use');
+    }
   }
 
   @override

--- a/lib/presentation/settings/legal_info_page.dart
+++ b/lib/presentation/settings/legal_info_page.dart
@@ -1,9 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
+import '../../config/app_config.dart';
 import '../../utils/logger.dart';
 
-/// 法的情報（プライバシーポリシーや利用規約）を表示するページ
+/// Firebase Hosting上の静的HTMLをWebViewで表示するページ
 class LegalInfoPage extends StatefulWidget {
   const LegalInfoPage({
     super.key,
@@ -118,8 +119,7 @@ class _LegalInfoPageState extends State<LegalInfoPage> {
       // マウント状態を確認してからURLをロード
       if (mounted && !_isDisposed) {
         _controller.loadRequest(
-          Uri.parse(
-              'https://keishimizu26629.github.io/LaKiite-flutter-app/${widget.urlPath}.html'),
+          Uri.parse('${_hostingBaseUrl()}/${widget.urlPath}.html'),
         );
       }
     } catch (e) {
@@ -133,6 +133,18 @@ class _LegalInfoPageState extends State<LegalInfoPage> {
         });
       }
     }
+  }
+
+  String _hostingBaseUrl() {
+    try {
+      if (AppConfig.instance.isProduction) {
+        return 'https://lakiite-flutter-app-prod.web.app';
+      }
+    } catch (_) {
+      return 'https://lakiite-flutter-app-dev.web.app';
+    }
+
+    return 'https://lakiite-flutter-app-dev.web.app';
   }
 
   @override

--- a/lib/presentation/settings/settings_page.dart
+++ b/lib/presentation/settings/settings_page.dart
@@ -76,6 +76,12 @@ class SettingsPage extends ConsumerWidget {
           */
 
           ListTile(
+            leading: const Icon(Icons.help_outline),
+            title: const Text('使い方'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () => context.push('/settings/how-to-use'),
+          ),
+          ListTile(
             leading: const Icon(Icons.privacy_tip_outlined),
             title: const Text('プライバシーポリシー'),
             trailing: const Icon(Icons.chevron_right),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1007,6 +1007,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      sha256: bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
   patrol:
     dependency: "direct dev"
     description:
@@ -1159,6 +1183,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.6.4"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: c3025c5534b01739267eb7d76959bbc25a6d10f6988e1c2a3036940133dd10bf
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.5"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: e8d4762b1e2e8578fc4d0fd548cebf24afd24f49719c08974df92834565e2c53
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.23"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "4e7eaffc2b17ba398759f1151415869a34771ba11ebbccd1b0145472a619a64f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.6"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "649dc798a33931919ea356c4305c2d1f81619ea6e92244070b520187b5140ef9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   shelf:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -61,6 +61,7 @@ dependencies:
   url_launcher: ^6.2.5
   package_info_plus: ^9.0.1
   photo_view: ^0.15.0
+  shared_preferences: ^2.5.5
 
 dev_dependencies:
   flutter_test:

--- a/test/infrastructure/how_to_use_prompt_preferences_test.dart
+++ b/test/infrastructure/how_to_use_prompt_preferences_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lakiite/infrastructure/how_to_use_prompt_preferences.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  test('使い方案内を未表示の場合は表示対象になる', () async {
+    SharedPreferences.setMockInitialValues({});
+
+    const preferences = HowToUsePromptPreferences();
+
+    expect(await preferences.shouldShowPrompt(), isTrue);
+  });
+
+  test('使い方案内を表示済みにすると次回以降は表示対象外になる', () async {
+    SharedPreferences.setMockInitialValues({});
+
+    const preferences = HowToUsePromptPreferences();
+
+    await preferences.markPromptSeen();
+
+    expect(await preferences.shouldShowPrompt(), isFalse);
+  });
+}

--- a/test/mock/providers/test_providers.dart
+++ b/test/mock/providers/test_providers.dart
@@ -4,6 +4,7 @@ import 'package:lakiite/application/auth/auth_notifier.dart';
 import 'package:lakiite/application/force_update/force_update_providers.dart';
 import 'package:lakiite/domain/entity/list.dart';
 import 'package:lakiite/domain/entity/notification.dart';
+import 'package:lakiite/infrastructure/how_to_use_prompt_preferences.dart';
 import '../repository/mock_auth_repository.dart';
 import '../repository/mock_schedule_repository.dart';
 import '../repository/mock_list_repository.dart';
@@ -28,6 +29,9 @@ class TestProviders {
         ),
         userRepositoryProvider.overrideWithValue(mockUserRepository),
         forceUpdateFeatureEnabledProvider.overrideWithValue(false),
+        howToUsePromptPreferencesProvider.overrideWithValue(
+          const _SeenHowToUsePromptPreferences(),
+        ),
       ];
 
   /// 認証済み状態のモックプロバイダー
@@ -179,4 +183,14 @@ class TestProviders {
     _mockNotificationRepository = null;
     _mockUserRepository = null;
   }
+}
+
+class _SeenHowToUsePromptPreferences extends HowToUsePromptPreferences {
+  const _SeenHowToUsePromptPreferences();
+
+  @override
+  Future<bool> shouldShowPrompt() async => false;
+
+  @override
+  Future<void> markPromptSeen() async {}
 }

--- a/test/presentation/auth/auth_home_navigation_test.dart
+++ b/test/presentation/auth/auth_home_navigation_test.dart
@@ -131,6 +131,12 @@ void main() {
       findsOneWidget,
     );
 
+    await tester.scrollUntilVisible(
+      find.widgetWithText(ListTile, 'ログアウト'),
+      200,
+    );
+    await tester.pump();
+
     await tester.tap(find.widgetWithText(ListTile, 'ログアウト'));
     await tester.pump(const Duration(milliseconds: 300));
 

--- a/test/presentation/settings/settings_page_test.dart
+++ b/test/presentation/settings/settings_page_test.dart
@@ -1,0 +1,13 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('設定画面に使い方リンクを表示する', () {
+    final source =
+        File('lib/presentation/settings/settings_page.dart').readAsStringSync();
+
+    expect(source, contains("title: const Text('使い方')"));
+    expect(source, contains("context.push('/settings/how-to-use')"));
+  });
+}

--- a/web/README.md
+++ b/web/README.md
@@ -7,6 +7,7 @@
 - `index.html` - メインランディングページ
 - `privacy-policy.html` - プライバシーポリシー
 - `terms-of-service.html` - 利用規約
+- `how-to-use.html` - アプリの使い方
 - `support.html` - サポートページ
 - `account-deletion.html` - アカウント削除ページ（一般向け）
 - `account-deletion-webview.html` - アカウント削除ページ（WebView用）
@@ -31,6 +32,7 @@
 - メインページ: `https://keishimizu26629.github.io/LaKiite-flutter-app/`
 - プライバシーポリシー: `https://keishimizu26629.github.io/LaKiite-flutter-app/privacy-policy.html`
 - 利用規約: `https://keishimizu26629.github.io/LaKiite-flutter-app/terms-of-service.html`
+- 使い方: `https://keishimizu26629.github.io/LaKiite-flutter-app/how-to-use.html`
 - サポート: `https://keishimizu26629.github.io/LaKiite-flutter-app/support.html`
 - アカウント削除: `https://keishimizu26629.github.io/LaKiite-flutter-app/account-deletion.html`
 
@@ -42,6 +44,8 @@
 
 - Dev: `https://lakiite-flutter-app-dev.web.app/support.html`
 - Prod: `https://lakiite-flutter-app-prod.web.app/support.html`
+- 使い方 Dev: `https://lakiite-flutter-app-dev.web.app/how-to-use.html`
+- 使い方 Prod: `https://lakiite-flutter-app-prod.web.app/how-to-use.html`
 
 ### 🔧 設定変更が必要
 GitHub Repository Settings → Pages → Source を以下に変更してください：
@@ -57,6 +61,7 @@ App Store Connect や Google Play Console でのアプリ申請時に上記URL�
 - **データセーフティー** → **アカウント削除**: `https://keishimizu26629.github.io/LaKiite-flutter-app/account-deletion.html`
 
 ### アプリ内WebView での使用
+- **使い方**: `https://lakiite-flutter-app-dev.web.app/how-to-use.html` / `https://lakiite-flutter-app-prod.web.app/how-to-use.html`
 - **WebView削除機能**: `https://keishimizu26629.github.io/LaKiite-flutter-app/account-deletion-webview.html`
 - JavaScript連携でアプリ内削除処理と連動
 

--- a/web/how-to-use.html
+++ b/web/how-to-use.html
@@ -1,0 +1,302 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>LaKiiteの使い方</title>
+    <style>
+        :root {
+            color-scheme: light;
+            --accent: #f59e0b;
+            --accent-strong: #d97706;
+            --text: #1f2937;
+            --muted: #6b7280;
+            --line: #e5e7eb;
+            --surface: #ffffff;
+            --surface-soft: #f9fafb;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            background: var(--surface);
+            color: var(--text);
+            font-family: 'Noto Sans JP', 'Hiragino Sans', 'Yu Gothic', 'YuGothic', 'Meiryo', sans-serif;
+            line-height: 1.75;
+            -webkit-text-size-adjust: 100%;
+        }
+
+        .page {
+            width: min(100%, 780px);
+            margin: 0 auto;
+            padding: 20px 16px 32px;
+        }
+
+        header {
+            padding: 8px 0 18px;
+        }
+
+        h1 {
+            margin: 0 0 8px;
+            font-size: 1.65rem;
+            line-height: 1.35;
+            letter-spacing: 0;
+        }
+
+        .lead {
+            margin: 0;
+            color: var(--muted);
+            font-size: 0.98rem;
+        }
+
+        .tabs {
+            position: sticky;
+            top: 0;
+            z-index: 1;
+            display: flex;
+            gap: 8px;
+            overflow-x: auto;
+            margin: 0 -16px 22px;
+            padding: 10px 16px;
+            background: rgba(255, 255, 255, 0.96);
+            border-top: 1px solid var(--line);
+            border-bottom: 1px solid var(--line);
+            scrollbar-width: none;
+        }
+
+        .tabs::-webkit-scrollbar {
+            display: none;
+        }
+
+        .tab {
+            flex: 0 0 auto;
+            min-height: 40px;
+            padding: 8px 12px;
+            border: 1px solid var(--line);
+            border-radius: 999px;
+            background: var(--surface);
+            color: var(--text);
+            font: inherit;
+            font-size: 0.92rem;
+            white-space: nowrap;
+        }
+
+        .tab[aria-selected="true"] {
+            border-color: var(--accent);
+            background: #fffbeb;
+            color: #92400e;
+            font-weight: 700;
+        }
+
+        .tab:focus-visible {
+            outline: 3px solid rgba(245, 158, 11, 0.35);
+            outline-offset: 2px;
+        }
+
+        .panel {
+            display: none;
+        }
+
+        .panel.active {
+            display: block;
+        }
+
+        h2 {
+            margin: 0 0 10px;
+            font-size: 1.35rem;
+            line-height: 1.4;
+            letter-spacing: 0;
+        }
+
+        .summary {
+            margin: 0 0 22px;
+            color: var(--muted);
+        }
+
+        h3 {
+            margin: 24px 0 8px;
+            font-size: 1.05rem;
+            line-height: 1.5;
+        }
+
+        p {
+            margin: 10px 0;
+        }
+
+        ol,
+        ul {
+            margin: 10px 0 0;
+            padding-left: 22px;
+        }
+
+        li {
+            margin: 8px 0;
+        }
+
+        .tip {
+            margin-top: 24px;
+            padding: 14px 16px;
+            border: 1px solid #fde68a;
+            border-radius: 8px;
+            background: #fffbeb;
+            color: #78350f;
+            font-size: 0.95rem;
+        }
+
+        @media (min-width: 640px) {
+            .page {
+                padding: 32px 24px 48px;
+            }
+
+            header {
+                padding-bottom: 24px;
+            }
+
+            h1 {
+                font-size: 2rem;
+            }
+
+            .tabs {
+                margin-right: -24px;
+                margin-left: -24px;
+                padding-right: 24px;
+                padding-left: 24px;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="page">
+        <header>
+            <h1>LaKiiteの使い方</h1>
+            <p class="lead">フレンドやリストに予定を共有し、相手の反応を確認するまでの基本操作をまとめています。</p>
+        </header>
+
+        <nav class="tabs" aria-label="使い方カテゴリ">
+            <button class="tab" type="button" role="tab" aria-selected="true" aria-controls="friends" id="tab-friends">フレンド追加</button>
+            <button class="tab" type="button" role="tab" aria-selected="false" aria-controls="lists" id="tab-lists">リストの使い方</button>
+            <button class="tab" type="button" role="tab" aria-selected="false" aria-controls="create" id="tab-create">予定作成</button>
+            <button class="tab" type="button" role="tab" aria-selected="false" aria-controls="check" id="tab-check">予定の確認</button>
+            <button class="tab" type="button" role="tab" aria-selected="false" aria-controls="notifications" id="tab-notifications">通知設定</button>
+        </nav>
+
+        <main>
+            <section class="panel active" id="friends" role="tabpanel" aria-labelledby="tab-friends">
+                <h2>フレンド追加</h2>
+                <p class="summary">予定を共有するには、まず相手とフレンドになる必要があります。検索IDを使って相手を探し、申請を送ります。</p>
+
+                <h3>追加の流れ</h3>
+                <ol>
+                    <li>「フレンド」タブを開きます。</li>
+                    <li>相手の検索IDを入力してユーザーを検索します。</li>
+                    <li>表示された相手を確認し、フレンド申請を送ります。</li>
+                    <li>相手が承認すると、予定の共有先として選べるようになります。</li>
+                </ol>
+
+                <h3>検索IDについて</h3>
+                <p>検索IDは、相手を探すためのIDです。名前が同じユーザーがいても、検索IDを使うことで目的の相手を見つけやすくなります。</p>
+
+                <p class="tip">相手が見つからない場合は、検索IDの入力間違いや、相手が設定しているIDをもう一度確認してください。</p>
+            </section>
+
+            <section class="panel" id="lists" role="tabpanel" aria-labelledby="tab-lists">
+                <h2>リストの使い方</h2>
+                <p class="summary">リストは、複数のフレンドへまとめて予定を共有したいときに使います。家族、仕事、友人グループなどの単位で作ると便利です。</p>
+
+                <h3>リストでできること</h3>
+                <ul>
+                    <li>よく共有する相手をひとつのグループにまとめられます。</li>
+                    <li>予定作成時にリストを選ぶだけで、複数人へ一度に共有できます。</li>
+                    <li>リストのメンバーを変更すると、次に共有する予定から新しいメンバー構成を使えます。</li>
+                </ul>
+
+                <h3>使いどころ</h3>
+                <p>毎回同じ相手に予定を共有する場合は、個別にフレンドを選ぶよりもリストを使う方が手間を減らせます。</p>
+
+                <p class="tip">「家族」「チーム」「週末メンバー」のように、あとから見ても分かりやすい名前にしておくと管理しやすくなります。</p>
+            </section>
+
+            <section class="panel" id="create" role="tabpanel" aria-labelledby="tab-create">
+                <h2>予定作成</h2>
+                <p class="summary">予定にはタイトル、日時、メモ、共有先を設定できます。共有先を選ばない場合は、自分だけの予定として保存されます。</p>
+
+                <h3>作成の流れ</h3>
+                <ol>
+                    <li>予定作成画面を開きます。</li>
+                    <li>予定のタイトルを入力します。</li>
+                    <li>開始日時と終了日時を設定します。</li>
+                    <li>必要に応じてメモを入力します。</li>
+                    <li>共有したいフレンドまたはリストを選びます。</li>
+                    <li>内容を確認して保存します。</li>
+                </ol>
+
+                <h3>共有先の考え方</h3>
+                <p>個別の相手にだけ伝えたい予定はフレンドを選び、複数人へまとめて伝えたい予定はリストを選びます。</p>
+
+                <p class="tip">まだ共有先を決めていない予定は、共有先を選ばずに保存しておき、あとから編集で追加できます。</p>
+            </section>
+
+            <section class="panel" id="check" role="tabpanel" aria-labelledby="tab-check">
+                <h2>予定の確認</h2>
+                <p class="summary">作成した予定や共有された予定は、ホームやカレンダーから確認できます。共有予定では、相手のリアクションやコメントも確認できます。</p>
+
+                <h3>予定を見る</h3>
+                <ul>
+                    <li>今日の予定はホームで確認できます。</li>
+                    <li>日付をまたいで確認したい場合は、カレンダーから目的の日を開きます。</li>
+                    <li>予定を開くと、日時やメモなどの詳細を確認できます。</li>
+                </ul>
+
+                <h3>リアクション・コメント</h3>
+                <p>共有された予定には、相手がリアクションやコメントを追加できます。参加できるか、確認したか、補足したいことがあるかをやり取りするために使います。</p>
+
+                <p class="tip">予定の内容を変更した場合は、共有相手にも更新後の内容が表示されます。重要な変更をしたときは、コメントでも補足しておくと伝わりやすくなります。</p>
+            </section>
+
+            <section class="panel" id="notifications" role="tabpanel" aria-labelledby="tab-notifications">
+                <h2>通知設定</h2>
+                <p class="summary">通知を使うと、共有されている予定に気づきやすくなります。朝の共有予定通知では、その日に共有されている予定を指定した時刻に受け取れます。</p>
+
+                <h3>設定できること</h3>
+                <ul>
+                    <li>朝の共有予定通知をオン・オフできます。</li>
+                    <li>通知を受け取る時刻を変更できます。</li>
+                    <li>共有予定がある日だけ通知を受け取れます。</li>
+                </ul>
+
+                <h3>変更方法</h3>
+                <ol>
+                    <li>設定画面を開きます。</li>
+                    <li>「朝の共有予定通知」を選びます。</li>
+                    <li>通知のオン・オフや時刻を変更します。</li>
+                    <li>保存して設定を反映します。</li>
+                </ol>
+
+                <p class="tip">端末側で通知が許可されていない場合、アプリ内で通知をオンにしていても通知が届かないことがあります。</p>
+            </section>
+        </main>
+    </div>
+
+    <script>
+        const tabs = Array.from(document.querySelectorAll('.tab'));
+        const panels = Array.from(document.querySelectorAll('.panel'));
+
+        function activateTab(tab) {
+            tabs.forEach((item) => {
+                item.setAttribute('aria-selected', item === tab ? 'true' : 'false');
+            });
+
+            panels.forEach((panel) => {
+                panel.classList.toggle('active', panel.id === tab.getAttribute('aria-controls'));
+            });
+        }
+
+        tabs.forEach((tab) => {
+            tab.addEventListener('click', () => activateTab(tab));
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add a hosted how-to-use HTML page and settings link for opening it in WebView
- Show a first-use guide prompt after authenticated users enter the main app, tracked locally with SharedPreferences
- Disable Android app data backup/transfer so local first-use flags are not restored after reinstall

## Details
- The how-to page is served from the existing Firebase Hosting `web/` public directory.
- The WebView URL switches between dev/prod Hosting based on `AppConfig.instance`.
- The prompt is marked seen when the user taps either `閉じる` or `使い方を見る`.
- `firebase-commons` has no changes because this flow does not require Firestore fields or Security Rules.

## Validation
- `git diff --check`
- `fvm flutter test test/infrastructure/how_to_use_prompt_preferences_test.dart test/presentation/settings/settings_page_test.dart`
- `fvm flutter analyze`
- `fvm flutter build apk --debug --flavor dev --dart-define-from-file=dart_define/dev_dart_define.json`
- Android real device reinstall check on `cf545991` confirmed `has_seen_how_to_use_prompt` was absent after uninstall/reinstall

## Hosting
Merging this into `dev` will trigger `[Release] Firebase Hosting` because `web/how-to-use.html` changes match the workflow path filter `web/**`.
