### PR TITLE
[codex] Improve profile image quality

### DIFF
--- a/lib/presentation/my_page/my_page_view_model.dart
+++ b/lib/presentation/my_page/my_page_view_model.dart
@@ -118,9 +118,9 @@ class MyPageViewModel extends StateNotifier<AsyncValue<UserModel?>> {
         AppLogger.debug('画像圧縮を開始します');
         final compressedImageFile = await _imageProcessorService.compressImage(
           croppedImageFile,
-          minWidth: 300,
-          minHeight: 300,
-          quality: 85,
+          minWidth: 1024,
+          minHeight: 1024,
+          quality: 90,
         );
         AppLogger.debug('圧縮後の画像パス: ${compressedImageFile.path}');
         AppLogger.debug(

--- a/lib/presentation/widgets/expandable_user_avatar.dart
+++ b/lib/presentation/widgets/expandable_user_avatar.dart
@@ -5,11 +5,7 @@ import 'package:photo_view/photo_view.dart';
 import 'default_user_icon.dart';
 
 class ExpandableUserAvatar extends StatefulWidget {
-  const ExpandableUserAvatar({
-    super.key,
-    this.imageUrl,
-    this.size = 80,
-  });
+  const ExpandableUserAvatar({super.key, this.imageUrl, this.size = 80});
 
   final String? imageUrl;
   final double size;
@@ -19,9 +15,6 @@ class ExpandableUserAvatar extends StatefulWidget {
 }
 
 class _ExpandableUserAvatarState extends State<ExpandableUserAvatar> {
-  static var _heroTagSeed = 0;
-  late final String _heroTag = 'expandable-user-avatar-${_heroTagSeed++}';
-
   @override
   Widget build(BuildContext context) {
     final normalizedImageUrl = widget.imageUrl?.trim();
@@ -32,12 +25,9 @@ class _ExpandableUserAvatarState extends State<ExpandableUserAvatar> {
       return DefaultUserIcon(size: widget.size);
     }
 
-    final avatar = Hero(
-      tag: _heroTag,
-      child: _AvatarImage(
-        imageUrl: normalizedImageUrl,
-        size: widget.size,
-      ),
+    final avatar = _AvatarImage(
+      imageUrl: normalizedImageUrl,
+      size: widget.size,
     );
 
     return Semantics(
@@ -46,40 +36,28 @@ class _ExpandableUserAvatarState extends State<ExpandableUserAvatar> {
       child: InkWell(
         key: const Key('expandable-user-avatar-button'),
         customBorder: const CircleBorder(),
-        onTap: () => _showExpandedAvatar(
-          context,
-          imageUrl: normalizedImageUrl,
-          heroTag: _heroTag,
-        ),
+        onTap: () => _showExpandedAvatar(context, imageUrl: normalizedImageUrl),
         child: avatar,
       ),
     );
   }
 
-  void _showExpandedAvatar(
-    BuildContext context, {
-    required String imageUrl,
-    required String heroTag,
-  }) {
+  void _showExpandedAvatar(BuildContext context, {required String imageUrl}) {
     Navigator.of(context).push<void>(
-      MaterialPageRoute<void>(
-        builder: (context) => _ExpandedUserAvatarPage(
-          imageUrl: imageUrl,
-          heroTag: heroTag,
-        ),
+      PageRouteBuilder<void>(
+        transitionDuration: Duration.zero,
+        reverseTransitionDuration: Duration.zero,
+        pageBuilder: (context, animation, secondaryAnimation) =>
+            _ExpandedUserAvatarPage(imageUrl: imageUrl),
       ),
     );
   }
 }
 
 class _ExpandedUserAvatarPage extends StatelessWidget {
-  const _ExpandedUserAvatarPage({
-    required this.imageUrl,
-    required this.heroTag,
-  });
+  const _ExpandedUserAvatarPage({required this.imageUrl});
 
   final String imageUrl;
-  final String heroTag;
 
   @override
   Widget build(BuildContext context) {
@@ -99,12 +77,9 @@ class _ExpandedUserAvatarPage extends StatelessWidget {
         key: const Key('expanded-user-avatar-image'),
         imageProvider: NetworkImage(imageUrl),
         minScale: PhotoViewComputedScale.contained,
-        heroAttributes: PhotoViewHeroAttributes(tag: heroTag),
         backgroundDecoration: const BoxDecoration(color: Colors.black),
         errorBuilder: (context, error, stackTrace) {
-          return const Center(
-            child: DefaultUserIcon(size: 160),
-          );
+          return const Center(child: DefaultUserIcon(size: 160));
         },
       ),
     );
@@ -112,10 +87,7 @@ class _ExpandedUserAvatarPage extends StatelessWidget {
 }
 
 class _AvatarImage extends StatelessWidget {
-  const _AvatarImage({
-    required this.imageUrl,
-    required this.size,
-  });
+  const _AvatarImage({required this.imageUrl, required this.size});
 
   final String imageUrl;
   final double size;

--- a/test/application/flows/primary_user_flows_test.dart
+++ b/test/application/flows/primary_user_flows_test.dart
@@ -274,6 +274,9 @@ void main() {
         imageProcessorService.compressedSourceFile?.path,
         croppedImageFile.path,
       );
+      expect(imageProcessorService.minWidth, 1024);
+      expect(imageProcessorService.minHeight, 1024);
+      expect(imageProcessorService.quality, 90);
       expect(
         container.read(selectedImageProvider)?.path,
         croppedImageFile.path,
@@ -402,6 +405,9 @@ class _FakeStorageService implements IStorageService {
 
 class _FakeImageProcessorService implements IImageProcessorService {
   File? compressedSourceFile;
+  int? minWidth;
+  int? minHeight;
+  int? quality;
 
   @override
   Future<File> compressImage(
@@ -411,6 +417,9 @@ class _FakeImageProcessorService implements IImageProcessorService {
     int quality = 85,
   }) async {
     compressedSourceFile = imageFile;
+    this.minWidth = minWidth;
+    this.minHeight = minHeight;
+    this.quality = quality;
     return imageFile;
   }
 


### PR DESCRIPTION
## Summary
- Increase profile image compression target from 300px / quality 85 to 1024px / quality 90
- Remove the Hero/page transition animation from expanded profile image open/close
- Add test coverage for the updated profile image compression parameters

## Validation
- `git diff --check`
- `fvm flutter test test/presentation/widgets/expandable_user_avatar_test.dart test/application/flows/primary_user_flows_test.dart`
- `fvm flutter analyze`