### PR TITLE
[codex] iOS bundle languageを日本語に設定

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -270,10 +270,10 @@
 			};
 			buildConfigurationList = 97C146E91CF9000F007C117D /* Build configuration list for PBXProject "Runner" */;
 			compatibilityVersion = "Xcode 9.3";
-			developmentRegion = en;
+			developmentRegion = ja;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				en,
+				ja,
 				Base,
 			);
 			mainGroup = 97C146E51CF9000F007C117D;

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -6,6 +6,10 @@
 	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleLocalizations</key>
+	<array>
+		<string>ja</string>
+	</array>
 	<key>CFBundleDisplayName</key>
 	<string>LaKiite</string>
 	<key>CFBundleExecutable</key>


### PR DESCRIPTION
## Summary
- Set the iOS project development region to Japanese.
- Add `CFBundleLocalizations` with `ja` so the app binary declares Japanese support.

## Why
The App Store page metadata is Japanese, but the public App Store app information showed the supported language as English. The iOS project still declared English as the development/known region, so the binary could be interpreted as English-only.

## Validation
- `plutil -lint ios/Runner/Info.plist`
- `git diff --check`
- `xcodebuild -project ios/Runner.xcodeproj -list`

## Notes
- `fvm flutter analyze` was attempted, but this fresh worktree does not include `lib/firebase_options.dart`, which is intentionally not copied because it can contain sensitive Firebase configuration. The resulting analyzer errors were limited to missing `DefaultFirebaseOptions` imports/usages.