### PR TITLE
[codex] Fix friend list display and schedule form save action

### DIFF
--- a/lib/domain/service/user_manager.dart
+++ b/lib/domain/service/user_manager.dart
@@ -46,7 +46,7 @@ class UserManager implements IUserManager {
     }
 
     final profiles = await _userRepository.getPublicProfiles(user.friends);
-    return profiles;
+    return _sortByDisplayName(profiles);
   }
 
   @override
@@ -57,7 +57,21 @@ class UserManager implements IUserManager {
       }
 
       final profiles = await _userRepository.getPublicProfiles(user.friends);
-      return profiles;
+      return _sortByDisplayName(profiles);
     });
+  }
+
+  List<PublicUserModel> _sortByDisplayName(List<PublicUserModel> profiles) {
+    final sortedProfiles = [...profiles];
+    sortedProfiles.sort((a, b) {
+      final nameComparison =
+          a.displayName.toLowerCase().compareTo(b.displayName.toLowerCase());
+      if (nameComparison != 0) {
+        return nameComparison;
+      }
+
+      return a.id.compareTo(b.id);
+    });
+    return sortedProfiles;
   }
 }

--- a/lib/presentation/calendar/schedule_detail_page.dart
+++ b/lib/presentation/calendar/schedule_detail_page.dart
@@ -18,6 +18,7 @@ import 'package:lakiite/presentation/calendar/widgets/delete_confirmation_dialog
 import 'package:lakiite/presentation/calendar/widgets/reaction_users_sheet.dart';
 import 'package:lakiite/presentation/theme/app_theme.dart';
 import 'package:lakiite/presentation/calendar/edit_schedule_page.dart';
+import 'package:lakiite/presentation/calendar/schedule_shared_lists_page.dart';
 import 'package:lakiite/presentation/widgets/default_user_icon.dart';
 import 'package:lakiite/domain/entity/notification.dart' as domain;
 import 'package:lakiite/application/notification/notification_notifier.dart';
@@ -60,7 +61,7 @@ class ScheduleDetailPage extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    ref.watch(authNotifierProvider);
+    final authStateAsync = ref.watch(authNotifierProvider);
     final interactions = ref.watch(
       scheduleInteractionNotifierProvider(schedule.id),
     );
@@ -79,6 +80,8 @@ class ScheduleDetailPage extends HookConsumerWidget {
       loading: () => schedule,
       error: (_, __) => schedule,
     );
+    final currentUserId = authStateAsync.value?.user?.id;
+    final isOwnSchedule = currentSchedule.ownerId == currentUserId;
 
     // コメント入力用のテキストコントローラー
     final commentController = useTextEditingController();
@@ -169,8 +172,7 @@ class ScheduleDetailPage extends HookConsumerWidget {
       appBar: AppBar(
         title: const Text('予定の詳細'),
         actions: [
-          if (currentSchedule.ownerId ==
-              ref.watch(authNotifierProvider).value?.user?.id) ...[
+          if (currentSchedule.ownerId == authStateAsync.value?.user?.id) ...[
             Padding(
               padding: const EdgeInsets.only(right: 8),
               child: IconButton(
@@ -291,6 +293,24 @@ class ScheduleDetailPage extends HookConsumerWidget {
                               ),
                             ],
                           ),
+                          if (isOwnSchedule) ...[
+                            const SizedBox(height: 12),
+                            OutlinedButton.icon(
+                              key: const Key('schedule_shared_lists_button'),
+                              onPressed: () {
+                                Navigator.of(context).push(
+                                  MaterialPageRoute(
+                                    builder: (context) =>
+                                        ScheduleSharedListsPage(
+                                      schedule: currentSchedule,
+                                    ),
+                                  ),
+                                );
+                              },
+                              icon: const Icon(Icons.groups),
+                              label: const Text('公開先リスト'),
+                            ),
+                          ],
                           const SizedBox(height: 16),
                           // インタラクション情報（リアクション数・コメント数）
                           Container(

--- a/lib/presentation/calendar/schedule_form_page.dart
+++ b/lib/presentation/calendar/schedule_form_page.dart
@@ -809,6 +809,10 @@ class ScheduleFormPage extends HookConsumerWidget {
               loading: () => const Center(child: CircularProgressIndicator()),
               error: (error, stack) => Center(child: Text('エラー: $error')),
             ),
+            const SizedBox(
+              key: Key('schedule_form_bottom_spacer'),
+              height: 96,
+            ),
           ],
         ),
       ),

--- a/lib/presentation/calendar/schedule_form_page.dart
+++ b/lib/presentation/calendar/schedule_form_page.dart
@@ -7,6 +7,7 @@ import 'package:lakiite/domain/entity/list.dart';
 import 'package:lakiite/domain/entity/schedule.dart';
 import 'package:lakiite/presentation/calendar/schedule_form_logic.dart';
 import 'package:lakiite/presentation/list/list_providers.dart';
+import 'package:lakiite/presentation/list/user_list_icon.dart';
 import 'package:lakiite/utils/logger.dart';
 import 'package:lakiite/presentation/list/list_detail_page.dart';
 
@@ -759,6 +760,11 @@ class ScheduleFormPage extends HookConsumerWidget {
                                 },
                               ),
                               const SizedBox(width: 8),
+                              UserListIcon(
+                                key: Key('schedule_form_list_icon_${list.id}'),
+                                iconUrl: list.iconUrl,
+                              ),
+                              const SizedBox(width: 12),
                               Expanded(
                                 child: Row(
                                   children: [

--- a/lib/presentation/calendar/schedule_form_page.dart
+++ b/lib/presentation/calendar/schedule_form_page.dart
@@ -358,8 +358,27 @@ class ScheduleFormPage extends HookConsumerWidget {
       }
     }
 
+    final appBarForegroundColor =
+        Theme.of(context).appBarTheme.foregroundColor ??
+            Theme.of(context).colorScheme.onSurface;
+
     return Scaffold(
-      appBar: AppBar(title: Text(schedule != null ? '予定編集' : '予定作成')),
+      appBar: AppBar(
+        title: Text(schedule != null ? '予定編集' : '予定作成'),
+        actions: [
+          TextButton.icon(
+            key: const Key('schedule_form_save_action'),
+            onPressed: formValidationResult.value.canSave ? handleSave : null,
+            style: TextButton.styleFrom(
+              foregroundColor: appBarForegroundColor,
+              disabledForegroundColor:
+                  appBarForegroundColor.withValues(alpha: 0.45),
+            ),
+            icon: const Icon(Icons.save),
+            label: const Text('保存'),
+          ),
+        ],
+      ),
       body: SingleChildScrollView(
         padding: const EdgeInsets.all(16),
         child: Column(
@@ -809,19 +828,8 @@ class ScheduleFormPage extends HookConsumerWidget {
               loading: () => const Center(child: CircularProgressIndicator()),
               error: (error, stack) => Center(child: Text('エラー: $error')),
             ),
-            const SizedBox(
-              key: Key('schedule_form_bottom_spacer'),
-              height: 96,
-            ),
           ],
         ),
-      ),
-      floatingActionButton: FloatingActionButton.extended(
-        onPressed: formValidationResult.value.canSave ? handleSave : null,
-        icon: const Icon(Icons.save),
-        label: const Text('保存'),
-        backgroundColor:
-            formValidationResult.value.canSave ? null : Colors.grey,
       ),
     );
   }

--- a/lib/presentation/calendar/schedule_shared_lists_page.dart
+++ b/lib/presentation/calendar/schedule_shared_lists_page.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lakiite/domain/entity/list.dart';
+import 'package:lakiite/domain/entity/schedule.dart';
+import 'package:lakiite/presentation/list/list_member_profile_tile.dart';
+import 'package:lakiite/presentation/list/list_providers.dart';
+import 'package:lakiite/presentation/list/user_list_icon.dart';
+
+class ScheduleSharedListsPage extends ConsumerWidget {
+  const ScheduleSharedListsPage({super.key, required this.schedule});
+
+  final Schedule schedule;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final listsAsync = ref.watch(userListsStreamProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('公開先リスト')),
+      body: listsAsync.when(
+        data: (lists) {
+          final listById = {for (final list in lists) list.id: list};
+          final orderedLists = schedule.sharedLists
+              .map((listId) => listById[listId])
+              .whereType<UserList>()
+              .toList();
+
+          if (orderedLists.isEmpty) {
+            return const Center(child: Text('公開先リストがありません'));
+          }
+
+          return ListView.separated(
+            padding: const EdgeInsets.all(16),
+            itemCount: orderedLists.length,
+            separatorBuilder: (_, __) => const SizedBox(height: 20),
+            itemBuilder: (context, index) {
+              final list = orderedLists[index];
+              return _SharedListSection(list: list);
+            },
+          );
+        },
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (error, _) => Center(child: Text('エラーが発生しました: $error')),
+      ),
+    );
+  }
+}
+
+class _SharedListSection extends StatelessWidget {
+  const _SharedListSection({required this.list});
+
+  final UserList list;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            UserListIcon(iconUrl: list.iconUrl),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Text(
+                list.listName,
+                style: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+            Text(
+              '${list.memberIds.length}人',
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: Colors.grey[600],
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        if (list.memberIds.isEmpty)
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 12),
+            child: Text(
+              'メンバーがいません',
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: Colors.grey[600],
+              ),
+            ),
+          )
+        else
+          ...list.memberIds.map(
+            (memberId) => ListMemberProfileTile(memberId: memberId),
+          ),
+      ],
+    );
+  }
+}

--- a/lib/presentation/friend/friend_list_page.dart
+++ b/lib/presentation/friend/friend_list_page.dart
@@ -10,6 +10,7 @@ import '../friend/friend_search_page.dart';
 import '../friend/friend_profile_page.dart';
 import '../widgets/notification_button.dart';
 import '../widgets/banner_ad_widget.dart';
+import '../user/user_providers.dart';
 import '../widgets/default_user_icon.dart';
 
 /// フレンドリストを表示するページ。
@@ -142,34 +143,9 @@ class _FriendListPageState extends ConsumerState<FriendListPage> {
                     style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
                   ),
                 ),
-                ...pendingRequests.map((request) {
-                  final displayName =
-                      request.receiveUserDisplayName ?? request.receiveUserId;
-                  return Card(
-                    margin: const EdgeInsets.only(bottom: 4),
-                    child: ListTile(
-                      contentPadding: const EdgeInsets.symmetric(
-                        horizontal: 16,
-                        vertical: 4,
-                      ),
-                      leading: const CircleAvatar(
-                        radius: 24,
-                        child: Icon(Icons.hourglass_empty),
-                      ),
-                      title: Text(
-                        displayName,
-                        style: const TextStyle(
-                          fontWeight: FontWeight.bold,
-                          fontSize: 16,
-                        ),
-                      ),
-                      subtitle: Text(
-                        '承認待ち',
-                        style: TextStyle(color: Colors.grey[600], fontSize: 14),
-                      ),
-                    ),
-                  );
-                }),
+                ...pendingRequests.map(
+                  (request) => _PendingFriendRequestTile(request: request),
+                ),
               ],
             ],
           ),
@@ -229,6 +205,50 @@ class _FriendListPageState extends ConsumerState<FriendListPage> {
           const Scaffold(body: Center(child: CircularProgressIndicator())),
       error: (error, stack) =>
           Scaffold(body: Center(child: Text('エラーが発生しました: $error'))),
+    );
+  }
+}
+
+class _PendingFriendRequestTile extends ConsumerWidget {
+  const _PendingFriendRequestTile({required this.request});
+
+  final domain.Notification request;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final pendingUserAsync =
+        ref.watch(userStreamProvider(request.receiveUserId));
+    final pendingUser = pendingUserAsync.valueOrNull?.publicProfile;
+    final displayName = pendingUser?.displayName ??
+        request.receiveUserDisplayName ??
+        request.receiveUserId;
+    final iconUrl = pendingUser?.iconUrl;
+
+    return Card(
+      margin: const EdgeInsets.only(bottom: 4),
+      child: ListTile(
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: 16,
+          vertical: 4,
+        ),
+        leading: iconUrl != null && iconUrl.isNotEmpty
+            ? CircleAvatar(
+                radius: 24,
+                backgroundImage: NetworkImage(iconUrl),
+              )
+            : const DefaultUserIcon(size: 48),
+        title: Text(
+          displayName,
+          style: const TextStyle(
+            fontWeight: FontWeight.bold,
+            fontSize: 16,
+          ),
+        ),
+        subtitle: Text(
+          '承認待ち',
+          style: TextStyle(color: Colors.grey[600], fontSize: 14),
+        ),
+      ),
     );
   }
 }

--- a/lib/presentation/friend/friend_list_page.dart
+++ b/lib/presentation/friend/friend_list_page.dart
@@ -217,8 +217,8 @@ class _PendingFriendRequestTile extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final pendingUserAsync =
-        ref.watch(userStreamProvider(request.receiveUserId));
-    final pendingUser = pendingUserAsync.valueOrNull?.publicProfile;
+        ref.watch(publicUserProvider(request.receiveUserId));
+    final pendingUser = pendingUserAsync.valueOrNull;
     final displayName = pendingUser?.displayName ??
         request.receiveUserDisplayName ??
         request.receiveUserId;

--- a/lib/presentation/friend/friend_search_view_model.dart
+++ b/lib/presentation/friend/friend_search_view_model.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../app/di/providers.dart';
 import '../../domain/entity/notification.dart' as domain;
+import '../../domain/entity/user.dart' as domain_user;
 import '../../domain/interfaces/i_notification_repository.dart';
 import '../../domain/interfaces/i_user_repository.dart';
 import '../../application/auth/auth_notifier.dart' as auth;
@@ -30,13 +31,11 @@ final friendSearchViewModelProvider =
         (ref) {
   final userRepository = ref.watch(userRepositoryProvider);
   final notificationRepository = ref.watch(notificationRepositoryProvider);
-  final currentUser = ref.watch(auth.authNotifierProvider).value?.user;
+  final currentUserId = ref.watch(auth.authNotifierProvider).value?.user?.id;
   return FriendSearchViewModel(
     userRepository,
     notificationRepository,
-    currentUser?.id ?? '',
-    currentUser?.publicProfile.displayName ?? '',
-    currentUser?.friends ?? const [],
+    currentUserId ?? '',
   );
 });
 
@@ -46,16 +45,12 @@ class FriendSearchViewModel
     this._userRepository,
     this._notificationRepository,
     this._currentUserId,
-    this._currentUserDisplayName,
-    this._currentUserFriendIds,
   ) : super(const AsyncValue.data(null));
   String? _message;
   String? get message => _message;
   final IUserRepository _userRepository;
   final INotificationRepository _notificationRepository;
   final String _currentUserId;
-  final String _currentUserDisplayName;
-  final List<String> _currentUserFriendIds;
 
   Future<void> searchUser(String searchId) async {
     try {
@@ -75,6 +70,8 @@ class FriendSearchViewModel
       if (user.id == _currentUserId) {
         throw Exception('自分自身は友達に追加できません');
       }
+
+      final currentUser = await _getCurrentUser();
 
       // 友達申請の状態を確認(送信済みまたは受信済み)
       bool hasPending = false;
@@ -106,7 +103,7 @@ class FriendSearchViewModel
         iconUrl: user.iconUrl ?? '',
         shortBio: user.shortBio,
         hasPendingRequest: hasPending,
-        isFriend: _currentUserFriendIds.contains(user.id),
+        isFriend: currentUser.friends.contains(user.id),
       );
 
       state = AsyncValue.data(searchUser);
@@ -125,12 +122,14 @@ class FriendSearchViewModel
         throw Exception('ユーザー情報が見つかりません');
       }
 
+      final currentUser = await _getCurrentUser();
+
       AppLogger.info('👥 友達申請を送信開始: $_currentUserId → $toUserId');
 
       final notification = domain.Notification.createFriendRequest(
         fromUserId: _currentUserId,
         toUserId: toUserId,
-        fromUserDisplayName: _currentUserDisplayName,
+        fromUserDisplayName: currentUser.publicProfile.displayName,
         toUserDisplayName: state.value!.displayName,
       );
 
@@ -146,6 +145,14 @@ class FriendSearchViewModel
       AppLogger.error('❌ 友達申請送信エラー: $e');
       state = AsyncValue.error(e, StackTrace.current);
     }
+  }
+
+  Future<domain_user.UserModel> _getCurrentUser() async {
+    final currentUser = await _userRepository.getUser(_currentUserId);
+    if (currentUser == null) {
+      throw Exception('ログインユーザー情報が見つかりません');
+    }
+    return currentUser;
   }
 
   // 状態をリセットするメソッド

--- a/lib/presentation/list/display_list_detail_page.dart
+++ b/lib/presentation/list/display_list_detail_page.dart
@@ -2,11 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lakiite/app/di/providers.dart';
 import 'package:lakiite/domain/entity/display_list.dart';
-import 'package:lakiite/domain/entity/user.dart';
 import 'package:lakiite/presentation/list/display_list_edit_page.dart';
 import 'package:lakiite/presentation/list/display_list_member_invite_page.dart';
 import 'package:lakiite/presentation/list/display_list_palette.dart';
 import 'package:lakiite/presentation/list/display_list_providers.dart';
+import 'package:lakiite/presentation/user/user_providers.dart';
 
 class DisplayListDetailPage extends ConsumerWidget {
   const DisplayListDetailPage({super.key, required this.displayList});
@@ -150,56 +150,73 @@ class DisplayListDetailPage extends ConsumerWidget {
               itemCount: currentDisplayList.memberIds.length,
               itemBuilder: (context, index) {
                 final memberId = currentDisplayList.memberIds[index];
-                return FutureBuilder<PublicUserModel?>(
-                  future: ref
-                      .read(userRepositoryProvider)
-                      .getFriendPublicProfile(memberId),
-                  builder: (context, snapshot) {
-                    if (snapshot.connectionState == ConnectionState.waiting) {
-                      return const Card(
-                        margin: EdgeInsets.only(bottom: 8),
-                        child: ListTile(
-                          leading: CircularProgressIndicator(),
-                          title: Text('読み込み中...'),
-                        ),
-                      );
-                    }
-                    final member = snapshot.data;
-                    if (member == null) {
-                      return const SizedBox.shrink();
-                    }
-                    return Card(
-                      margin: const EdgeInsets.only(bottom: 8),
-                      child: ListTile(
-                        leading: CircleAvatar(
-                          backgroundImage: member.iconUrl != null
-                              ? NetworkImage(member.iconUrl!)
-                              : null,
-                          child: member.iconUrl == null
-                              ? const Icon(Icons.person)
-                              : null,
-                        ),
-                        title: Text(member.displayName),
-                        trailing: IconButton(
-                          tooltip: 'メンバーから削除',
-                          icon: const Icon(Icons.remove_circle_outline),
-                          onPressed: () async {
-                            await ref
-                                .read(displayListRepositoryProvider)
-                                .removeMember(
-                                  ownerId: currentDisplayList.ownerId,
-                                  displayListId: currentDisplayList.id,
-                                  userId: memberId,
-                                );
-                          },
-                        ),
-                      ),
-                    );
-                  },
+                return _DisplayListMemberTile(
+                  memberId: memberId,
+                  displayList: currentDisplayList,
                 );
               },
             ),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+class _DisplayListMemberTile extends ConsumerWidget {
+  const _DisplayListMemberTile({
+    required this.memberId,
+    required this.displayList,
+  });
+
+  final String memberId;
+  final DisplayList displayList;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final memberAsync = ref.watch(publicUserProvider(memberId));
+
+    return memberAsync.when(
+      data: (member) {
+        if (member == null) {
+          return const SizedBox.shrink();
+        }
+
+        return Card(
+          margin: const EdgeInsets.only(bottom: 8),
+          child: ListTile(
+            leading: CircleAvatar(
+              backgroundImage:
+                  member.iconUrl != null ? NetworkImage(member.iconUrl!) : null,
+              child: member.iconUrl == null ? const Icon(Icons.person) : null,
+            ),
+            title: Text(member.displayName),
+            trailing: IconButton(
+              tooltip: 'メンバーから削除',
+              icon: const Icon(Icons.remove_circle_outline),
+              onPressed: () async {
+                await ref.read(displayListRepositoryProvider).removeMember(
+                      ownerId: displayList.ownerId,
+                      displayListId: displayList.id,
+                      userId: memberId,
+                    );
+              },
+            ),
+          ),
+        );
+      },
+      loading: () => const Card(
+        margin: EdgeInsets.only(bottom: 8),
+        child: ListTile(
+          leading: CircularProgressIndicator(),
+          title: Text('読み込み中...'),
+        ),
+      ),
+      error: (error, _) => Card(
+        margin: const EdgeInsets.only(bottom: 8),
+        child: ListTile(
+          leading: const Icon(Icons.error),
+          title: Text('エラーが発生しました: $error'),
         ),
       ),
     );

--- a/lib/presentation/list/display_list_detail_page.dart
+++ b/lib/presentation/list/display_list_detail_page.dart
@@ -6,7 +6,8 @@ import 'package:lakiite/presentation/list/display_list_edit_page.dart';
 import 'package:lakiite/presentation/list/display_list_member_invite_page.dart';
 import 'package:lakiite/presentation/list/display_list_palette.dart';
 import 'package:lakiite/presentation/list/display_list_providers.dart';
-import 'package:lakiite/presentation/user/user_providers.dart';
+import 'package:lakiite/presentation/list/list_detail_scaffold.dart';
+import 'package:lakiite/presentation/list/list_member_profile_tile.dart';
 
 class DisplayListDetailPage extends ConsumerWidget {
   const DisplayListDetailPage({super.key, required this.displayList});
@@ -21,204 +22,61 @@ class DisplayListDetailPage extends ConsumerWidget {
         watchedDisplayLists.where((item) => item.id == displayList.id).toList();
     final currentDisplayList =
         matchingDisplayLists.isEmpty ? displayList : matchingDisplayLists.first;
-    final theme = Theme.of(context);
     final listColor =
         DisplayListPalette.colorForKey(currentDisplayList.colorKey);
 
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('表示用リストの詳細'),
-        actions: [
-          PopupMenuButton<String>(
-            onSelected: (value) async {
-              if (value != 'delete') {
-                return;
-              }
-              final navigator = Navigator.of(context);
-              final scaffoldMessenger = ScaffoldMessenger.of(context);
-              final confirmed = await showDialog<bool>(
-                context: context,
-                builder: (context) => AlertDialog(
-                  title: const Text('表示用リストを削除'),
-                  content: const Text('この表示用リストを削除してもよろしいですか？'),
-                  actions: [
-                    TextButton(
-                      onPressed: () => Navigator.of(context).pop(false),
-                      child: const Text('キャンセル'),
-                    ),
-                    TextButton(
-                      onPressed: () => Navigator.of(context).pop(true),
-                      child: const Text('削除'),
-                    ),
-                  ],
-                ),
-              );
-              if (confirmed != true) {
-                return;
-              }
-              try {
-                await ref.read(displayListRepositoryProvider).deleteDisplayList(
-                      ownerId: currentDisplayList.ownerId,
-                      displayListId: currentDisplayList.id,
-                    );
-                navigator.pop();
-              } catch (e) {
-                scaffoldMessenger.showSnackBar(
-                  SnackBar(content: Text('削除に失敗しました: $e')),
-                );
-              }
-            },
-            itemBuilder: (context) => [
-              const PopupMenuItem(value: 'delete', child: Text('削除')),
-            ],
-          ),
-        ],
+    return ListDetailScaffold(
+      appBarTitle: '表示用リストの詳細',
+      title: currentDisplayList.name,
+      leading: CircleAvatar(
+        radius: 40,
+        backgroundColor: listColor.withValues(alpha: 0.18),
+        child: Icon(Icons.palette, size: 40, color: listColor),
       ),
-      body: SingleChildScrollView(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Padding(
-              padding: const EdgeInsets.all(16),
-              child: Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  CircleAvatar(
-                    radius: 40,
-                    backgroundColor: listColor.withValues(alpha: 0.18),
-                    child: Icon(Icons.palette, size: 40, color: listColor),
-                  ),
-                  const SizedBox(width: 16),
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          currentDisplayList.name,
-                          style: theme.textTheme.headlineSmall,
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                        const SizedBox(height: 8),
-                        OutlinedButton.icon(
-                          onPressed: () {
-                            Navigator.of(context).push(
-                              MaterialPageRoute(
-                                builder: (context) => DisplayListEditPage(
-                                  displayList: currentDisplayList,
-                                ),
-                              ),
-                            );
-                          },
-                          icon: const Icon(Icons.edit),
-                          label: const Text('編集'),
-                        ),
-                      ],
-                    ),
-                  ),
-                ],
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16),
-              child: Row(
-                children: [
-                  Text('メンバー', style: theme.textTheme.titleLarge),
-                  const SizedBox(width: 8),
-                  Text('${currentDisplayList.memberIds.length}人'),
-                  const Spacer(),
-                  OutlinedButton.icon(
-                    onPressed: () {
-                      Navigator.of(context).push(
-                        MaterialPageRoute(
-                          builder: (context) => DisplayListMemberInvitePage(
-                            displayList: currentDisplayList,
-                          ),
-                        ),
-                      );
-                    },
-                    icon: const Icon(Icons.person_add),
-                    label: const Text('友達を追加'),
-                  ),
-                ],
-              ),
-            ),
-            const SizedBox(height: 8),
-            ListView.builder(
-              shrinkWrap: true,
-              physics: const NeverScrollableScrollPhysics(),
-              padding: const EdgeInsets.symmetric(horizontal: 16),
-              itemCount: currentDisplayList.memberIds.length,
-              itemBuilder: (context, index) {
-                final memberId = currentDisplayList.memberIds[index];
-                return _DisplayListMemberTile(
-                  memberId: memberId,
-                  displayList: currentDisplayList,
-                );
-              },
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _DisplayListMemberTile extends ConsumerWidget {
-  const _DisplayListMemberTile({
-    required this.memberId,
-    required this.displayList,
-  });
-
-  final String memberId;
-  final DisplayList displayList;
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final memberAsync = ref.watch(publicUserProvider(memberId));
-
-    return memberAsync.when(
-      data: (member) {
-        if (member == null) {
-          return const SizedBox.shrink();
-        }
-
-        return Card(
-          margin: const EdgeInsets.only(bottom: 8),
-          child: ListTile(
-            leading: CircleAvatar(
-              backgroundImage:
-                  member.iconUrl != null ? NetworkImage(member.iconUrl!) : null,
-              child: member.iconUrl == null ? const Icon(Icons.person) : null,
-            ),
-            title: Text(member.displayName),
-            trailing: IconButton(
-              tooltip: 'メンバーから削除',
-              icon: const Icon(Icons.remove_circle_outline),
-              onPressed: () async {
-                await ref.read(displayListRepositoryProvider).removeMember(
-                      ownerId: displayList.ownerId,
-                      displayListId: displayList.id,
-                      userId: memberId,
-                    );
-              },
+      memberCount: currentDisplayList.memberIds.length,
+      onEdit: () {
+        Navigator.of(context).push(
+          MaterialPageRoute(
+            builder: (context) => DisplayListEditPage(
+              displayList: currentDisplayList,
             ),
           ),
         );
       },
-      loading: () => const Card(
-        margin: EdgeInsets.only(bottom: 8),
-        child: ListTile(
-          leading: CircularProgressIndicator(),
-          title: Text('読み込み中...'),
-        ),
-      ),
-      error: (error, _) => Card(
-        margin: const EdgeInsets.only(bottom: 8),
-        child: ListTile(
-          leading: const Icon(Icons.error),
-          title: Text('エラーが発生しました: $error'),
-        ),
-      ),
+      onAddMember: () {
+        Navigator.of(context).push(
+          MaterialPageRoute(
+            builder: (context) => DisplayListMemberInvitePage(
+              displayList: currentDisplayList,
+            ),
+          ),
+        );
+      },
+      onDelete: () {
+        return ref.read(displayListRepositoryProvider).deleteDisplayList(
+              ownerId: currentDisplayList.ownerId,
+              displayListId: currentDisplayList.id,
+            );
+      },
+      deleteDialogTitle: '表示用リストを削除',
+      deleteDialogMessage: 'この表示用リストを削除してもよろしいですか？',
+      memberIds: currentDisplayList.memberIds,
+      memberTileBuilder: (memberId) {
+        return ListMemberProfileTile(
+          memberId: memberId,
+          trailing: IconButton(
+            tooltip: 'メンバーから削除',
+            icon: const Icon(Icons.remove_circle_outline),
+            onPressed: () async {
+              await ref.read(displayListRepositoryProvider).removeMember(
+                    ownerId: currentDisplayList.ownerId,
+                    displayListId: currentDisplayList.id,
+                    userId: memberId,
+                  );
+            },
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/presentation/list/display_list_edit_page.dart
+++ b/lib/presentation/list/display_list_edit_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lakiite/app/di/providers.dart';
 import 'package:lakiite/domain/entity/display_list.dart';
 import 'package:lakiite/presentation/list/display_list_palette.dart';
+import 'package:lakiite/presentation/list/list_edit_save_action.dart';
 
 class DisplayListEditPage extends ConsumerStatefulWidget {
   const DisplayListEditPage({super.key, required this.displayList});
@@ -71,12 +72,9 @@ class _DisplayListEditPageState extends ConsumerState<DisplayListEditPage> {
       appBar: AppBar(
         title: const Text('表示用リストを編集'),
         actions: [
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-            child: FilledButton(
-              onPressed: _isSaving ? null : _save,
-              child: const Text('保存'),
-            ),
+          ListEditSaveAction(
+            isSaving: _isSaving,
+            onSave: _save,
           ),
         ],
       ),

--- a/lib/presentation/list/list_detail_page.dart
+++ b/lib/presentation/list/list_detail_page.dart
@@ -1,9 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import '../../app/di/providers.dart';
 import '../../application/list/list_notifier.dart';
 import '../../domain/entity/list.dart';
-import '../../domain/entity/user.dart';
+import '../user/user_providers.dart';
 import 'list_member_invite_page.dart';
 import 'list_edit_page.dart';
 import 'list_providers.dart';
@@ -179,65 +178,7 @@ class _ListDetailPageState extends ConsumerState<ListDetailPage> {
                   itemCount: list.memberIds.length,
                   itemBuilder: (context, index) {
                     final memberId = list.memberIds[index];
-                    return FutureBuilder<PublicUserModel?>(
-                      future: ref
-                          .read(userRepositoryProvider)
-                          .getFriendPublicProfile(memberId),
-                      builder: (context, snapshot) {
-                        if (snapshot.connectionState ==
-                            ConnectionState.waiting) {
-                          return const Card(
-                            margin: EdgeInsets.only(bottom: 8),
-                            child: ListTile(
-                              leading: CircularProgressIndicator(),
-                              title: Text('読み込み中...'),
-                            ),
-                          );
-                        }
-
-                        if (snapshot.hasError) {
-                          return Card(
-                            margin: const EdgeInsets.only(bottom: 8),
-                            child: ListTile(
-                              leading: const Icon(Icons.error),
-                              title: Text('エラーが発生しました: ${snapshot.error}'),
-                            ),
-                          );
-                        }
-
-                        final member = snapshot.data;
-                        if (member == null) {
-                          return const SizedBox.shrink();
-                        }
-
-                        return Card(
-                          margin: const EdgeInsets.only(bottom: 8),
-                          child: ListTile(
-                            leading: CircleAvatar(
-                              backgroundImage: member.iconUrl != null
-                                  ? NetworkImage(member.iconUrl!)
-                                  : null,
-                              child: member.iconUrl == null
-                                  ? const Icon(Icons.person)
-                                  : null,
-                            ),
-                            title: Text(member.displayName),
-                            subtitle: member.shortBio != null &&
-                                    member.shortBio!.isNotEmpty
-                                ? Text(
-                                    member.shortBio!,
-                                    style: TextStyle(
-                                      color: Colors.grey[600],
-                                      fontSize: 14,
-                                    ),
-                                    maxLines: 1,
-                                    overflow: TextOverflow.ellipsis,
-                                  )
-                                : null,
-                          ),
-                        );
-                      },
-                    );
+                    return _ListMemberTile(memberId: memberId);
                   },
                 ),
                 const SizedBox(height: 16),
@@ -250,6 +191,62 @@ class _ListDetailPageState extends ConsumerState<ListDetailPage> {
           const Scaffold(body: Center(child: CircularProgressIndicator())),
       error: (error, _) =>
           Scaffold(body: Center(child: Text('エラーが発生しました: $error'))),
+    );
+  }
+}
+
+class _ListMemberTile extends ConsumerWidget {
+  const _ListMemberTile({required this.memberId});
+
+  final String memberId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final memberAsync = ref.watch(publicUserProvider(memberId));
+
+    return memberAsync.when(
+      data: (member) {
+        if (member == null) {
+          return const SizedBox.shrink();
+        }
+
+        return Card(
+          margin: const EdgeInsets.only(bottom: 8),
+          child: ListTile(
+            leading: CircleAvatar(
+              backgroundImage:
+                  member.iconUrl != null ? NetworkImage(member.iconUrl!) : null,
+              child: member.iconUrl == null ? const Icon(Icons.person) : null,
+            ),
+            title: Text(member.displayName),
+            subtitle: member.shortBio != null && member.shortBio!.isNotEmpty
+                ? Text(
+                    member.shortBio!,
+                    style: TextStyle(
+                      color: Colors.grey[600],
+                      fontSize: 14,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  )
+                : null,
+          ),
+        );
+      },
+      loading: () => const Card(
+        margin: EdgeInsets.only(bottom: 8),
+        child: ListTile(
+          leading: CircularProgressIndicator(),
+          title: Text('読み込み中...'),
+        ),
+      ),
+      error: (error, _) => Card(
+        margin: const EdgeInsets.only(bottom: 8),
+        child: ListTile(
+          leading: const Icon(Icons.error),
+          title: Text('エラーが発生しました: $error'),
+        ),
+      ),
     );
   }
 }

--- a/lib/presentation/list/list_detail_page.dart
+++ b/lib/presentation/list/list_detail_page.dart
@@ -7,6 +7,7 @@ import 'list_edit_page.dart';
 import 'list_detail_scaffold.dart';
 import 'list_member_profile_tile.dart';
 import 'list_providers.dart';
+import 'user_list_icon.dart';
 
 /// プライベートリストの詳細画面を表示するウィジェット
 ///
@@ -36,13 +37,7 @@ class _ListDetailPageState extends ConsumerState<ListDetailPage> {
         return ListDetailScaffold(
           appBarTitle: 'リストの詳細',
           title: list.listName,
-          leading: CircleAvatar(
-            radius: 40,
-            backgroundImage:
-                list.iconUrl != null ? NetworkImage(list.iconUrl!) : null,
-            child:
-                list.iconUrl == null ? const Icon(Icons.list, size: 40) : null,
-          ),
+          leading: UserListIcon(iconUrl: list.iconUrl, radius: 40),
           description: list.description,
           memberCount: list.memberIds.length,
           onEdit: () {

--- a/lib/presentation/list/list_detail_page.dart
+++ b/lib/presentation/list/list_detail_page.dart
@@ -2,9 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../application/list/list_notifier.dart';
 import '../../domain/entity/list.dart';
-import '../user/user_providers.dart';
 import 'list_member_invite_page.dart';
 import 'list_edit_page.dart';
+import 'list_detail_scaffold.dart';
+import 'list_member_profile_tile.dart';
 import 'list_providers.dart';
 
 /// プライベートリストの詳細画面を表示するウィジェット
@@ -24,7 +25,6 @@ class ListDetailPage extends ConsumerStatefulWidget {
 class _ListDetailPageState extends ConsumerState<ListDetailPage> {
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
     final listAsync = ref.watch(listStreamProvider(widget.list.id));
 
     return listAsync.when(
@@ -33,220 +33,47 @@ class _ListDetailPageState extends ConsumerState<ListDetailPage> {
           return const Scaffold(body: Center(child: Text('リストが見つかりません')));
         }
 
-        return Scaffold(
-          appBar: AppBar(
-            title: const Text('リストの詳細'),
-            actions: [
-              PopupMenuButton<String>(
-                onSelected: (value) async {
-                  if (value == 'delete') {
-                    final scaffoldMessenger = ScaffoldMessenger.of(context);
-                    final navigator = Navigator.of(context);
-                    final confirmed = await showDialog<bool>(
-                      context: context,
-                      builder: (context) => AlertDialog(
-                        title: const Text('リストを削除'),
-                        content: const Text('このリストを削除してもよろしいですか？'),
-                        actions: [
-                          TextButton(
-                            onPressed: () => Navigator.of(context).pop(false),
-                            child: const Text('キャンセル'),
-                          ),
-                          TextButton(
-                            onPressed: () => Navigator.of(context).pop(true),
-                            child: const Text('削除'),
-                          ),
-                        ],
-                      ),
-                    );
-
-                    if (confirmed == true) {
-                      try {
-                        await ref
-                            .read(listNotifierProvider.notifier)
-                            .deleteList(list.id);
-                        if (mounted) {
-                          navigator.pop();
-                        }
-                      } catch (e) {
-                        if (mounted) {
-                          scaffoldMessenger.showSnackBar(
-                            SnackBar(
-                              content: Text('削除に失敗しました: ${e.toString()}'),
-                            ),
-                          );
-                        }
-                      }
-                    }
-                  }
-                },
-                itemBuilder: (context) => [
-                  const PopupMenuItem(value: 'delete', child: Text('リストを削除')),
-                ],
+        return ListDetailScaffold(
+          appBarTitle: 'リストの詳細',
+          title: list.listName,
+          leading: CircleAvatar(
+            radius: 40,
+            backgroundImage:
+                list.iconUrl != null ? NetworkImage(list.iconUrl!) : null,
+            child:
+                list.iconUrl == null ? const Icon(Icons.list, size: 40) : null,
+          ),
+          description: list.description,
+          memberCount: list.memberIds.length,
+          onEdit: () {
+            Navigator.of(context).push(
+              MaterialPageRoute(
+                builder: (context) => ListEditPage(list: list),
               ),
-            ],
-          ),
-          body: SingleChildScrollView(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                // リスト情報セクション
-                Padding(
-                  padding: const EdgeInsets.all(16.0),
-                  child: Row(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      // リストアイコン
-                      CircleAvatar(
-                        radius: 40,
-                        backgroundImage: list.iconUrl != null
-                            ? NetworkImage(list.iconUrl!)
-                            : null,
-                        child: list.iconUrl == null
-                            ? const Icon(Icons.list, size: 40)
-                            : null,
-                      ),
-                      const SizedBox(width: 16),
-                      Expanded(
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Text(
-                              list.listName,
-                              style: theme.textTheme.headlineSmall,
-                              overflow: TextOverflow.ellipsis,
-                            ),
-                            const SizedBox(height: 8),
-                            OutlinedButton.icon(
-                              onPressed: () {
-                                Navigator.of(context).push(
-                                  MaterialPageRoute(
-                                    builder: (context) =>
-                                        ListEditPage(list: list),
-                                  ),
-                                );
-                              },
-                              icon: const Icon(Icons.edit),
-                              label: const Text('リストを編集'),
-                            ),
-                          ],
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-                // リストの説明
-                if (list.description != null)
-                  Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                    child: Text(
-                      list.description!,
-                      style: theme.textTheme.bodyLarge,
-                    ),
-                  ),
-                const SizedBox(height: 16),
-                // メンバー数
-                Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                  child: Row(
-                    children: [
-                      Text('メンバー', style: theme.textTheme.titleLarge),
-                      const SizedBox(width: 8),
-                      Text('${list.memberIds.length}人'),
-                      const Spacer(),
-                      OutlinedButton.icon(
-                        onPressed: () {
-                          Navigator.of(context).push(
-                            MaterialPageRoute(
-                              builder: (context) =>
-                                  ListMemberInvitePage(list: list),
-                            ),
-                          );
-                        },
-                        icon: const Icon(Icons.person_add),
-                        label: const Text('友達を追加'),
-                      ),
-                    ],
-                  ),
-                ),
-                const SizedBox(height: 8),
-                // メンバーリスト
-                ListView.builder(
-                  shrinkWrap: true,
-                  physics: const NeverScrollableScrollPhysics(),
-                  padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                  itemCount: list.memberIds.length,
-                  itemBuilder: (context, index) {
-                    final memberId = list.memberIds[index];
-                    return _ListMemberTile(memberId: memberId);
-                  },
-                ),
-                const SizedBox(height: 16),
-              ],
-            ),
-          ),
+            );
+          },
+          onAddMember: () {
+            Navigator.of(context).push(
+              MaterialPageRoute(
+                builder: (context) => ListMemberInvitePage(list: list),
+              ),
+            );
+          },
+          onDelete: () {
+            return ref.read(listNotifierProvider.notifier).deleteList(list.id);
+          },
+          deleteDialogTitle: 'リストを削除',
+          deleteDialogMessage: 'このリストを削除してもよろしいですか？',
+          memberIds: list.memberIds,
+          memberTileBuilder: (memberId) {
+            return ListMemberProfileTile(memberId: memberId);
+          },
         );
       },
       loading: () =>
           const Scaffold(body: Center(child: CircularProgressIndicator())),
       error: (error, _) =>
           Scaffold(body: Center(child: Text('エラーが発生しました: $error'))),
-    );
-  }
-}
-
-class _ListMemberTile extends ConsumerWidget {
-  const _ListMemberTile({required this.memberId});
-
-  final String memberId;
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final memberAsync = ref.watch(publicUserProvider(memberId));
-
-    return memberAsync.when(
-      data: (member) {
-        if (member == null) {
-          return const SizedBox.shrink();
-        }
-
-        return Card(
-          margin: const EdgeInsets.only(bottom: 8),
-          child: ListTile(
-            leading: CircleAvatar(
-              backgroundImage:
-                  member.iconUrl != null ? NetworkImage(member.iconUrl!) : null,
-              child: member.iconUrl == null ? const Icon(Icons.person) : null,
-            ),
-            title: Text(member.displayName),
-            subtitle: member.shortBio != null && member.shortBio!.isNotEmpty
-                ? Text(
-                    member.shortBio!,
-                    style: TextStyle(
-                      color: Colors.grey[600],
-                      fontSize: 14,
-                    ),
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                  )
-                : null,
-          ),
-        );
-      },
-      loading: () => const Card(
-        margin: EdgeInsets.only(bottom: 8),
-        child: ListTile(
-          leading: CircularProgressIndicator(),
-          title: Text('読み込み中...'),
-        ),
-      ),
-      error: (error, _) => Card(
-        margin: const EdgeInsets.only(bottom: 8),
-        child: ListTile(
-          leading: const Icon(Icons.error),
-          title: Text('エラーが発生しました: $error'),
-        ),
-      ),
     );
   }
 }

--- a/lib/presentation/list/list_detail_scaffold.dart
+++ b/lib/presentation/list/list_detail_scaffold.dart
@@ -1,0 +1,157 @@
+import 'package:flutter/material.dart';
+
+class ListDetailScaffold extends StatelessWidget {
+  const ListDetailScaffold({
+    super.key,
+    required this.appBarTitle,
+    required this.title,
+    required this.leading,
+    required this.memberCount,
+    required this.onEdit,
+    required this.onAddMember,
+    required this.onDelete,
+    required this.deleteDialogTitle,
+    required this.deleteDialogMessage,
+    required this.memberIds,
+    required this.memberTileBuilder,
+    this.description,
+  });
+
+  final String appBarTitle;
+  final String title;
+  final Widget leading;
+  final String? description;
+  final int memberCount;
+  final VoidCallback onEdit;
+  final VoidCallback onAddMember;
+  final Future<void> Function() onDelete;
+  final String deleteDialogTitle;
+  final String deleteDialogMessage;
+  final List<String> memberIds;
+  final Widget Function(String memberId) memberTileBuilder;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(appBarTitle),
+        actions: [
+          PopupMenuButton<String>(
+            onSelected: (value) async {
+              if (value != 'delete') {
+                return;
+              }
+
+              final confirmed = await showDialog<bool>(
+                context: context,
+                builder: (context) => AlertDialog(
+                  title: Text(deleteDialogTitle),
+                  content: Text(deleteDialogMessage),
+                  actions: [
+                    TextButton(
+                      onPressed: () => Navigator.of(context).pop(false),
+                      child: const Text('キャンセル'),
+                    ),
+                    TextButton(
+                      onPressed: () => Navigator.of(context).pop(true),
+                      child: const Text('削除'),
+                    ),
+                  ],
+                ),
+              );
+              if (confirmed != true) {
+                return;
+              }
+
+              try {
+                await onDelete();
+                if (context.mounted) {
+                  Navigator.of(context).pop();
+                }
+              } catch (e) {
+                if (context.mounted) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(content: Text('削除に失敗しました: $e')),
+                  );
+                }
+              }
+            },
+            itemBuilder: (context) => [
+              const PopupMenuItem(value: 'delete', child: Text('削除')),
+            ],
+          ),
+        ],
+      ),
+      body: SingleChildScrollView(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Padding(
+              padding: const EdgeInsets.all(16),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  leading,
+                  const SizedBox(width: 16),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          title,
+                          style: theme.textTheme.headlineSmall,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                        const SizedBox(height: 8),
+                        OutlinedButton.icon(
+                          onPressed: onEdit,
+                          icon: const Icon(Icons.edit),
+                          label: const Text('編集'),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            if (description != null && description!.isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: Text(description!, style: theme.textTheme.bodyLarge),
+              ),
+            const SizedBox(height: 16),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: Row(
+                children: [
+                  Text('メンバー', style: theme.textTheme.titleLarge),
+                  const SizedBox(width: 8),
+                  Text('$memberCount人'),
+                  const Spacer(),
+                  OutlinedButton.icon(
+                    onPressed: onAddMember,
+                    icon: const Icon(Icons.person_add),
+                    label: const Text('友達を追加'),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 8),
+            ListView.builder(
+              shrinkWrap: true,
+              physics: const NeverScrollableScrollPhysics(),
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              itemCount: memberIds.length,
+              itemBuilder: (context, index) {
+                return memberTileBuilder(memberIds[index]);
+              },
+            ),
+            const SizedBox(height: 16),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/list/list_edit_page.dart
+++ b/lib/presentation/list/list_edit_page.dart
@@ -4,7 +4,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:image_picker/image_picker.dart';
 import '../../application/list/list_notifier.dart';
 import '../../domain/entity/list.dart';
-import '../user/user_providers.dart';
+import 'list_edit_save_action.dart';
+import 'list_member_profile_tile.dart';
 import 'list_providers.dart';
 
 class ListEditPage extends ConsumerStatefulWidget {
@@ -106,22 +107,10 @@ class _ListEditPageState extends ConsumerState<ListEditPage> {
       appBar: AppBar(
         title: const Text('リストを編集'),
         actions: [
-          if (_isLoading)
-            const Center(
-              child: Padding(
-                padding: EdgeInsets.all(16.0),
-                child: CircularProgressIndicator(),
-              ),
-            )
-          else
-            Padding(
-              padding:
-                  const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
-              child: FilledButton(
-                onPressed: () => _saveChanges(currentList),
-                child: const Text('保存'),
-              ),
-            ),
+          ListEditSaveAction(
+            isSaving: _isLoading,
+            onSave: () => _saveChanges(currentList),
+          ),
         ],
       ),
       body: SingleChildScrollView(
@@ -190,7 +179,7 @@ class _ListEditPageState extends ConsumerState<ListEditPage> {
                     itemCount: currentList.memberIds.length,
                     itemBuilder: (context, index) {
                       final memberId = currentList.memberIds[index];
-                      return _EditableListMemberTile(
+                      return EditableListMemberProfileTile(
                         memberId: memberId,
                         isExcluded: _excludedMemberIds.contains(memberId),
                         onChanged: (isExcluded) {
@@ -209,78 +198,6 @@ class _ListEditPageState extends ConsumerState<ListEditPage> {
               ),
             ),
           ],
-        ),
-      ),
-    );
-  }
-}
-
-class _EditableListMemberTile extends ConsumerWidget {
-  const _EditableListMemberTile({
-    required this.memberId,
-    required this.isExcluded,
-    required this.onChanged,
-  });
-
-  final String memberId;
-  final bool isExcluded;
-  final ValueChanged<bool> onChanged;
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final memberAsync = ref.watch(publicUserProvider(memberId));
-
-    return memberAsync.when(
-      data: (member) {
-        if (member == null) {
-          return const SizedBox.shrink();
-        }
-
-        return Card(
-          margin: const EdgeInsets.only(bottom: 8),
-          color: isExcluded ? Colors.grey.shade200 : null,
-          child: InkWell(
-            onTap: () => onChanged(!isExcluded),
-            child: ListTile(
-              leading: CircleAvatar(
-                backgroundImage: member.iconUrl != null
-                    ? NetworkImage(member.iconUrl!)
-                    : null,
-                child: member.iconUrl == null ? const Icon(Icons.person) : null,
-              ),
-              title: Text(
-                member.displayName,
-                style: isExcluded ? const TextStyle(color: Colors.grey) : null,
-              ),
-              subtitle: member.shortBio != null && member.shortBio!.isNotEmpty
-                  ? Text(
-                      member.shortBio!,
-                      style: TextStyle(
-                        color: Colors.grey[600],
-                        fontSize: 14,
-                      ),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                    )
-                  : null,
-              trailing: Checkbox(
-                value: isExcluded,
-                onChanged: (value) => onChanged(value ?? false),
-              ),
-            ),
-          ),
-        );
-      },
-      loading: () => const Card(
-        child: ListTile(
-          leading: CircularProgressIndicator(),
-          title: Text('読み込み中...'),
-        ),
-      ),
-      error: (error, _) => Card(
-        child: ListTile(
-          leading: const Icon(Icons.error),
-          title: Text('エラーが発生しました: $error'),
         ),
       ),
     );

--- a/lib/presentation/list/list_edit_page.dart
+++ b/lib/presentation/list/list_edit_page.dart
@@ -2,10 +2,9 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:image_picker/image_picker.dart';
-import '../../app/di/providers.dart';
 import '../../application/list/list_notifier.dart';
 import '../../domain/entity/list.dart';
-import '../../domain/entity/user.dart';
+import '../user/user_providers.dart';
 import 'list_providers.dart';
 
 class ListEditPage extends ConsumerStatefulWidget {
@@ -191,97 +190,17 @@ class _ListEditPageState extends ConsumerState<ListEditPage> {
                     itemCount: currentList.memberIds.length,
                     itemBuilder: (context, index) {
                       final memberId = currentList.memberIds[index];
-                      return FutureBuilder<PublicUserModel?>(
-                        future: ref
-                            .read(userRepositoryProvider)
-                            .getFriendPublicProfile(memberId),
-                        builder: (context, snapshot) {
-                          if (snapshot.connectionState ==
-                              ConnectionState.waiting) {
-                            return const Card(
-                              child: ListTile(
-                                leading: CircularProgressIndicator(),
-                                title: Text('読み込み中...'),
-                              ),
-                            );
-                          }
-
-                          if (snapshot.hasError) {
-                            return Card(
-                              child: ListTile(
-                                leading: const Icon(Icons.error),
-                                title: Text('エラーが発生しました: ${snapshot.error}'),
-                              ),
-                            );
-                          }
-
-                          final member = snapshot.data;
-                          if (member == null) {
-                            return const SizedBox.shrink();
-                          }
-
-                          final isExcluded =
-                              _excludedMemberIds.contains(memberId);
-                          return Card(
-                            margin: const EdgeInsets.only(bottom: 8),
-                            color: isExcluded ? Colors.grey.shade200 : null,
-                            child: InkWell(
-                              onTap: () {
-                                setState(() {
-                                  if (isExcluded) {
-                                    _excludedMemberIds.remove(memberId);
-                                  } else {
-                                    _excludedMemberIds.add(memberId);
-                                  }
-                                });
-                              },
-                              child: ListTile(
-                                leading: CircleAvatar(
-                                  backgroundImage: member.iconUrl != null
-                                      ? NetworkImage(member.iconUrl!)
-                                      : null,
-                                  child: member.iconUrl == null
-                                      ? const Icon(Icons.person)
-                                      : null,
-                                ),
-                                title: Text(
-                                  member.displayName,
-                                  style: isExcluded
-                                      ? const TextStyle(color: Colors.grey)
-                                      : null,
-                                ),
-                                subtitle: member.shortBio != null &&
-                                        member.shortBio!.isNotEmpty
-                                    ? Text(
-                                        member.shortBio!,
-                                        style: isExcluded
-                                            ? TextStyle(
-                                                color: Colors.grey[600],
-                                                fontSize: 14,
-                                              )
-                                            : TextStyle(
-                                                color: Colors.grey[600],
-                                                fontSize: 14,
-                                              ),
-                                        maxLines: 1,
-                                        overflow: TextOverflow.ellipsis,
-                                      )
-                                    : null,
-                                trailing: Checkbox(
-                                  value: isExcluded,
-                                  onChanged: (value) {
-                                    setState(() {
-                                      if (value == true) {
-                                        _excludedMemberIds.add(memberId);
-                                      } else {
-                                        _excludedMemberIds.remove(memberId);
-                                      }
-                                    });
-                                  },
-                                ),
-                              ),
-                            ),
-                          );
+                      return _EditableListMemberTile(
+                        memberId: memberId,
+                        isExcluded: _excludedMemberIds.contains(memberId),
+                        onChanged: (isExcluded) {
+                          setState(() {
+                            if (isExcluded) {
+                              _excludedMemberIds.add(memberId);
+                            } else {
+                              _excludedMemberIds.remove(memberId);
+                            }
+                          });
                         },
                       );
                     },
@@ -290,6 +209,78 @@ class _ListEditPageState extends ConsumerState<ListEditPage> {
               ),
             ),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+class _EditableListMemberTile extends ConsumerWidget {
+  const _EditableListMemberTile({
+    required this.memberId,
+    required this.isExcluded,
+    required this.onChanged,
+  });
+
+  final String memberId;
+  final bool isExcluded;
+  final ValueChanged<bool> onChanged;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final memberAsync = ref.watch(publicUserProvider(memberId));
+
+    return memberAsync.when(
+      data: (member) {
+        if (member == null) {
+          return const SizedBox.shrink();
+        }
+
+        return Card(
+          margin: const EdgeInsets.only(bottom: 8),
+          color: isExcluded ? Colors.grey.shade200 : null,
+          child: InkWell(
+            onTap: () => onChanged(!isExcluded),
+            child: ListTile(
+              leading: CircleAvatar(
+                backgroundImage: member.iconUrl != null
+                    ? NetworkImage(member.iconUrl!)
+                    : null,
+                child: member.iconUrl == null ? const Icon(Icons.person) : null,
+              ),
+              title: Text(
+                member.displayName,
+                style: isExcluded ? const TextStyle(color: Colors.grey) : null,
+              ),
+              subtitle: member.shortBio != null && member.shortBio!.isNotEmpty
+                  ? Text(
+                      member.shortBio!,
+                      style: TextStyle(
+                        color: Colors.grey[600],
+                        fontSize: 14,
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    )
+                  : null,
+              trailing: Checkbox(
+                value: isExcluded,
+                onChanged: (value) => onChanged(value ?? false),
+              ),
+            ),
+          ),
+        );
+      },
+      loading: () => const Card(
+        child: ListTile(
+          leading: CircularProgressIndicator(),
+          title: Text('読み込み中...'),
+        ),
+      ),
+      error: (error, _) => Card(
+        child: ListTile(
+          leading: const Icon(Icons.error),
+          title: Text('エラーが発生しました: $error'),
         ),
       ),
     );

--- a/lib/presentation/list/list_edit_save_action.dart
+++ b/lib/presentation/list/list_edit_save_action.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+
+class ListEditSaveAction extends StatelessWidget {
+  const ListEditSaveAction({
+    super.key,
+    required this.isSaving,
+    required this.onSave,
+  });
+
+  final bool isSaving;
+  final VoidCallback onSave;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: isSaving
+          ? const Center(
+              child: SizedBox.square(
+                dimension: 24,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              ),
+            )
+          : FilledButton(
+              onPressed: onSave,
+              child: const Text('保存'),
+            ),
+    );
+  }
+}

--- a/lib/presentation/list/list_member_profile_tile.dart
+++ b/lib/presentation/list/list_member_profile_tile.dart
@@ -1,0 +1,138 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:lakiite/presentation/user/user_providers.dart';
+
+class ListMemberProfileTile extends ConsumerWidget {
+  const ListMemberProfileTile({
+    super.key,
+    required this.memberId,
+    this.trailing,
+  });
+
+  final String memberId;
+  final Widget? trailing;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final memberAsync = ref.watch(publicUserProvider(memberId));
+
+    return memberAsync.when(
+      data: (member) {
+        if (member == null) {
+          return const SizedBox.shrink();
+        }
+
+        return Card(
+          margin: const EdgeInsets.only(bottom: 8),
+          child: ListTile(
+            leading: CircleAvatar(
+              backgroundImage:
+                  member.iconUrl != null ? NetworkImage(member.iconUrl!) : null,
+              child: member.iconUrl == null ? const Icon(Icons.person) : null,
+            ),
+            title: Text(member.displayName),
+            subtitle: member.shortBio != null && member.shortBio!.isNotEmpty
+                ? Text(
+                    member.shortBio!,
+                    style: TextStyle(
+                      color: Colors.grey[600],
+                      fontSize: 14,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  )
+                : null,
+            trailing: trailing,
+          ),
+        );
+      },
+      loading: () => const Card(
+        margin: EdgeInsets.only(bottom: 8),
+        child: ListTile(
+          leading: CircularProgressIndicator(),
+          title: Text('読み込み中...'),
+        ),
+      ),
+      error: (error, _) => Card(
+        margin: const EdgeInsets.only(bottom: 8),
+        child: ListTile(
+          leading: const Icon(Icons.error),
+          title: Text('エラーが発生しました: $error'),
+        ),
+      ),
+    );
+  }
+}
+
+class EditableListMemberProfileTile extends ConsumerWidget {
+  const EditableListMemberProfileTile({
+    super.key,
+    required this.memberId,
+    required this.isExcluded,
+    required this.onChanged,
+  });
+
+  final String memberId;
+  final bool isExcluded;
+  final ValueChanged<bool> onChanged;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final memberAsync = ref.watch(publicUserProvider(memberId));
+
+    return memberAsync.when(
+      data: (member) {
+        if (member == null) {
+          return const SizedBox.shrink();
+        }
+
+        return Card(
+          margin: const EdgeInsets.only(bottom: 8),
+          color: isExcluded ? Colors.grey.shade200 : null,
+          child: InkWell(
+            onTap: () => onChanged(!isExcluded),
+            child: ListTile(
+              leading: CircleAvatar(
+                backgroundImage: member.iconUrl != null
+                    ? NetworkImage(member.iconUrl!)
+                    : null,
+                child: member.iconUrl == null ? const Icon(Icons.person) : null,
+              ),
+              title: Text(
+                member.displayName,
+                style: isExcluded ? const TextStyle(color: Colors.grey) : null,
+              ),
+              subtitle: member.shortBio != null && member.shortBio!.isNotEmpty
+                  ? Text(
+                      member.shortBio!,
+                      style: TextStyle(
+                        color: Colors.grey[600],
+                        fontSize: 14,
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    )
+                  : null,
+              trailing: Checkbox(
+                value: isExcluded,
+                onChanged: (value) => onChanged(value ?? false),
+              ),
+            ),
+          ),
+        );
+      },
+      loading: () => const Card(
+        child: ListTile(
+          leading: CircularProgressIndicator(),
+          title: Text('読み込み中...'),
+        ),
+      ),
+      error: (error, _) => Card(
+        child: ListTile(
+          leading: const Icon(Icons.error),
+          title: Text('エラーが発生しました: $error'),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/list/list_page.dart
+++ b/lib/presentation/list/list_page.dart
@@ -10,6 +10,7 @@ import 'display_list_providers.dart';
 import 'list_detail_page.dart';
 import 'list_providers.dart';
 import 'list_summary_tile.dart';
+import 'user_list_icon.dart';
 import '../widgets/banner_ad_widget.dart';
 
 /// プライベートリスト一覧を表示するウィジェット
@@ -164,12 +165,8 @@ class _PublicListsView extends StatelessWidget {
           itemCount: lists.length,
           itemBuilder: (context, index) {
             final list = lists[index];
-            final color = Theme.of(context).primaryColor;
             return ListSummaryTile(
-              leading: CircleAvatar(
-                backgroundColor: color.withValues(alpha: 0.18),
-                child: Icon(Icons.list, color: color),
-              ),
+              leading: UserListIcon(iconUrl: list.iconUrl),
               title: list.listName,
               memberCount: list.memberIds.length,
               onTap: () {

--- a/lib/presentation/list/list_page.dart
+++ b/lib/presentation/list/list_page.dart
@@ -9,6 +9,7 @@ import 'display_list_palette.dart';
 import 'display_list_providers.dart';
 import 'list_detail_page.dart';
 import 'list_providers.dart';
+import 'list_summary_tile.dart';
 import '../widgets/banner_ad_widget.dart';
 
 /// プライベートリスト一覧を表示するウィジェット
@@ -163,10 +164,14 @@ class _PublicListsView extends StatelessWidget {
           itemCount: lists.length,
           itemBuilder: (context, index) {
             final list = lists[index];
-            return ListTile(
-              leading: const Icon(Icons.list),
-              title: Text(list.listName),
-              subtitle: Text('${list.memberIds.length}人のメンバー'),
+            final color = Theme.of(context).primaryColor;
+            return ListSummaryTile(
+              leading: CircleAvatar(
+                backgroundColor: color.withValues(alpha: 0.18),
+                child: Icon(Icons.list, color: color),
+              ),
+              title: list.listName,
+              memberCount: list.memberIds.length,
               onTap: () {
                 Navigator.of(context).push(
                   MaterialPageRoute(
@@ -203,13 +208,13 @@ class _DisplayListsView extends StatelessWidget {
           itemBuilder: (context, index) {
             final displayList = displayLists[index];
             final color = DisplayListPalette.colorForKey(displayList.colorKey);
-            return ListTile(
+            return ListSummaryTile(
               leading: CircleAvatar(
                 backgroundColor: color.withValues(alpha: 0.18),
                 child: Icon(Icons.palette, color: color),
               ),
-              title: Text(displayList.name),
-              subtitle: Text('${displayList.memberIds.length}人のメンバー'),
+              title: displayList.name,
+              memberCount: displayList.memberIds.length,
               onTap: () {
                 Navigator.of(context).push(
                   MaterialPageRoute(

--- a/lib/presentation/list/list_summary_tile.dart
+++ b/lib/presentation/list/list_summary_tile.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+
+class ListSummaryTile extends StatelessWidget {
+  const ListSummaryTile({
+    super.key,
+    required this.title,
+    required this.memberCount,
+    required this.leading,
+    required this.onTap,
+  });
+
+  final String title;
+  final int memberCount;
+  final Widget leading;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      leading: leading,
+      title: Text(title),
+      subtitle: Text('$memberCount人のメンバー'),
+      onTap: onTap,
+    );
+  }
+}

--- a/lib/presentation/list/user_list_icon.dart
+++ b/lib/presentation/list/user_list_icon.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+
+class UserListIcon extends StatelessWidget {
+  const UserListIcon({
+    super.key,
+    this.iconUrl,
+    this.radius = 20,
+  });
+
+  final String? iconUrl;
+  final double radius;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = Theme.of(context).primaryColor;
+
+    return CircleAvatar(
+      radius: radius,
+      backgroundColor: iconUrl == null ? color.withValues(alpha: 0.18) : null,
+      backgroundImage: iconUrl != null ? NetworkImage(iconUrl!) : null,
+      child: iconUrl == null ? Icon(Icons.list, color: color) : null,
+    );
+  }
+}

--- a/lib/presentation/presentation_provider.dart
+++ b/lib/presentation/presentation_provider.dart
@@ -19,4 +19,4 @@ export 'package:lakiite/presentation/friend/friend_providers.dart'
 export 'package:lakiite/presentation/list/list_providers.dart'
     show listStreamProvider, userListsStreamProvider;
 export 'package:lakiite/presentation/user/user_providers.dart'
-    show userStreamProvider;
+    show publicUserProvider, userStreamProvider;

--- a/lib/presentation/user/user_providers.dart
+++ b/lib/presentation/user/user_providers.dart
@@ -24,3 +24,9 @@ final userStreamProvider =
     error: (_, __) => Stream.value(null),
   );
 });
+
+/// Public user profile read model for member rows and lightweight user chips.
+final publicUserProvider =
+    FutureProvider.autoDispose.family<PublicUserModel?, String>((ref, userId) {
+  return ref.watch(userRepositoryProvider).getFriendPublicProfile(userId);
+});

--- a/test/domain/service/user_manager_test.dart
+++ b/test/domain/service/user_manager_test.dart
@@ -1,0 +1,78 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lakiite/domain/entity/user.dart';
+import 'package:lakiite/domain/service/user_manager.dart';
+
+import '../../mock/repository/mock_user_repository.dart';
+
+void main() {
+  group('UserManager', () {
+    late MockUserRepository repository;
+    late UserManager manager;
+
+    setUp(() {
+      repository = MockUserRepository();
+      manager = UserManager(repository);
+    });
+
+    UserModel createUser({
+      required String id,
+      required String displayName,
+      List<String> friends = const [],
+    }) {
+      final user = UserModel.create(
+        id: id,
+        name: displayName,
+        displayName: displayName,
+      );
+
+      return user.copyWith(
+        privateProfile: user.privateProfile.copyWith(friends: friends),
+      );
+    }
+
+    test('getAuthenticatedUserFriends returns friends sorted by display name',
+        () async {
+      final currentUser = createUser(
+        id: 'current-user',
+        displayName: 'Current User',
+        friends: const ['charlie-id', 'alice-id', 'bob-id'],
+      );
+
+      repository
+        ..addTestUser(currentUser)
+        ..addTestUser(createUser(id: 'charlie-id', displayName: 'Charlie'))
+        ..addTestUser(createUser(id: 'alice-id', displayName: 'Alice'))
+        ..addTestUser(createUser(id: 'bob-id', displayName: 'Bob'));
+
+      final friends = await manager.getAuthenticatedUserFriends(currentUser.id);
+
+      expect(
+        friends.map((friend) => friend.displayName),
+        ['Alice', 'Bob', 'Charlie'],
+      );
+    });
+
+    test('watchAuthenticatedUserFriends emits friends sorted by display name',
+        () async {
+      final currentUser = createUser(
+        id: 'current-user',
+        displayName: 'Current User',
+        friends: const ['charlie-id', 'alice-id', 'bob-id'],
+      );
+
+      repository
+        ..addTestUser(currentUser)
+        ..addTestUser(createUser(id: 'charlie-id', displayName: 'Charlie'))
+        ..addTestUser(createUser(id: 'alice-id', displayName: 'Alice'))
+        ..addTestUser(createUser(id: 'bob-id', displayName: 'Bob'));
+
+      final friends =
+          await manager.watchAuthenticatedUserFriends(currentUser.id).first;
+
+      expect(
+        friends.map((friend) => friend.displayName),
+        ['Alice', 'Bob', 'Charlie'],
+      );
+    });
+  });
+}

--- a/test/presentation/friend/friend_list_page_test.dart
+++ b/test/presentation/friend/friend_list_page_test.dart
@@ -11,6 +11,7 @@ import 'package:lakiite/domain/entity/notification.dart' as domain;
 import 'package:lakiite/domain/entity/user.dart';
 import 'package:lakiite/presentation/friend/friend_list_page.dart';
 import 'package:lakiite/presentation/friend/friend_providers.dart';
+import 'package:lakiite/presentation/user/user_providers.dart' as user;
 
 class _StubAuthNotifier extends auth.AuthNotifier {
   _StubAuthNotifier(this._state);
@@ -69,6 +70,71 @@ void main() {
       expect(find.text('申請中'), findsOneWidget);
       expect(find.text('申請先ユーザー'), findsOneWidget);
       expect(find.text('承認待ち'), findsOneWidget);
+    });
+
+    testWidgets('申請中の相手にアイコンURLがある場合はユーザーアイコンを表示する', (tester) async {
+      const pendingIconUrl = 'https://example.com/pending-user.png';
+      final currentUser = UserModel.create(
+        id: 'current-user-id',
+        name: '現在ユーザー',
+        displayName: '現在ユーザー',
+      );
+      final pendingUserBase = UserModel.create(
+        id: 'pending-friend-id',
+        name: '申請先ユーザー',
+        displayName: '申請先ユーザー',
+      );
+      final pendingUser = pendingUserBase.copyWith(
+        publicProfile:
+            pendingUserBase.publicProfile.copyWith(iconUrl: pendingIconUrl),
+      );
+      final pendingRequest = domain.Notification.createFriendRequest(
+        fromUserId: currentUser.id,
+        toUserId: pendingUser.id,
+        fromUserDisplayName: currentUser.displayName,
+        toUserDisplayName: pendingUser.displayName,
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            auth.authNotifierProvider.overrideWith(
+              () => _StubAuthNotifier(AuthState.authenticated(currentUser)),
+            ),
+            userFriendsStreamProvider.overrideWith(
+              (ref) => Stream.value([]),
+            ),
+            notification.sentNotificationsByTypeProvider.overrideWith(
+              (ref, type) => Stream.value([pendingRequest]),
+            ),
+            user.userStreamProvider.overrideWith(
+              (ref, userId) => Stream.value(
+                userId == pendingUser.id ? pendingUser : null,
+              ),
+            ),
+            notification.unreadNotificationCountProvider.overrideWith(
+              (ref) => Stream.value(0),
+            ),
+            notification.unreadNotificationCountByTypeProvider.overrideWith(
+              (ref, type) => Stream.value(0),
+            ),
+          ],
+          child: const MaterialApp(home: FriendListPage()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('申請先ユーザー'), findsOneWidget);
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is CircleAvatar &&
+              widget.backgroundImage is NetworkImage &&
+              (widget.backgroundImage! as NetworkImage).url == pendingIconUrl,
+        ),
+        findsOneWidget,
+      );
+      expect(tester.takeException(), isA<NetworkImageLoadException>());
     });
 
     testWidgets('拒否済みの送信済み友達申請は申請中セクションに表示しない', (tester) async {

--- a/test/presentation/friend/friend_list_page_test.dart
+++ b/test/presentation/friend/friend_list_page_test.dart
@@ -107,9 +107,9 @@ void main() {
             notification.sentNotificationsByTypeProvider.overrideWith(
               (ref, type) => Stream.value([pendingRequest]),
             ),
-            user.userStreamProvider.overrideWith(
-              (ref, userId) => Stream.value(
-                userId == pendingUser.id ? pendingUser : null,
+            user.publicUserProvider.overrideWith(
+              (ref, userId) => Future.value(
+                userId == pendingUser.id ? pendingUser.publicProfile : null,
               ),
             ),
             notification.unreadNotificationCountProvider.overrideWith(

--- a/test/presentation/friend/friend_search_page_test.dart
+++ b/test/presentation/friend/friend_search_page_test.dart
@@ -98,7 +98,9 @@ void main() {
         ),
         [friend.id],
       );
-      final userRepository = MockUserRepository()..addTestUser(friend);
+      final userRepository = MockUserRepository()
+        ..addTestUser(currentUser)
+        ..addTestUser(friend);
 
       await tester.pumpWidget(
         ProviderScope(
@@ -130,6 +132,53 @@ void main() {
         find.widgetWithText(ElevatedButton, '追加済み'),
       );
       expect(button.onPressed, isNull);
+    });
+
+    testWidgets('検索時はログイン時点ではなく最新の友達状態で追加済みを判定する', (tester) async {
+      final friend = UserModel.create(
+        id: 'friend-user-id',
+        name: 'フレンドユーザー',
+        displayName: 'フレンドユーザー',
+      );
+      final staleAuthUser = userWithFriends(
+        UserModel.create(
+          id: 'current-user-id',
+          name: '現在ユーザー',
+          displayName: '現在ユーザー',
+        ),
+        [friend.id],
+      );
+      final latestCurrentUser = userWithFriends(staleAuthUser, const []);
+      final userRepository = MockUserRepository()
+        ..addTestUser(latestCurrentUser)
+        ..addTestUser(friend);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            auth.authNotifierProvider.overrideWith(
+              () => _StubAuthNotifier(AuthState.authenticated(staleAuthUser)),
+            ),
+            userRepositoryProvider.overrideWithValue(userRepository),
+            notificationRepositoryProvider.overrideWithValue(
+              MockNotificationRepository(),
+            ),
+            notification.unreadNotificationCountByTypeProvider.overrideWith(
+              (ref, domain.NotificationType type) => Stream.value(0),
+            ),
+          ],
+          child: const MaterialApp(home: FriendSearchPage()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+          find.byType(TextField), friend.searchId.toString());
+      await tester.tap(find.byIcon(Icons.search));
+      await tester.pumpAndSettle();
+
+      expect(find.text('申請する'), findsOneWidget);
+      expect(find.text('追加済み'), findsNothing);
     });
   });
 }

--- a/test/presentation/list/display_list_detail_page_test.dart
+++ b/test/presentation/list/display_list_detail_page_test.dart
@@ -1,0 +1,91 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lakiite/app/di/providers.dart';
+import 'package:lakiite/domain/entity/display_list.dart';
+import 'package:lakiite/domain/entity/user.dart';
+import 'package:lakiite/presentation/list/display_list_detail_page.dart';
+import 'package:lakiite/presentation/list/display_list_providers.dart';
+
+import '../../mock/repository/mock_user_repository.dart';
+
+void main() {
+  testWidgets('表示用リスト詳細は同じメンバーの公開プロフィールを再取得しない', (tester) async {
+    final displayListController = StreamController<List<DisplayList>>();
+    final userRepository = _CountingUserRepository()
+      ..addTestUser(
+        UserModel.create(id: 'member-1', name: 'メンバー1', displayName: 'メンバー一郎'),
+      );
+    final initialDisplayList = _displayList(
+      name: '公開リスト',
+      memberIds: const ['member-1'],
+    );
+    final updatedDisplayList = _displayList(
+      name: '公開リスト 更新後',
+      memberIds: const ['member-1'],
+    );
+
+    addTearDown(displayListController.close);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          userRepositoryProvider.overrideWithValue(userRepository),
+          userDisplayListsStreamProvider.overrideWith(
+            (ref) => displayListController.stream,
+          ),
+        ],
+        child: MaterialApp(
+          home: DisplayListDetailPage(displayList: initialDisplayList),
+        ),
+      ),
+    );
+
+    displayListController.add([initialDisplayList]);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 250));
+
+    expect(find.text('メンバー一郎'), findsOneWidget);
+    expect(userRepository.getFriendPublicProfileCallCount('member-1'), 1);
+
+    displayListController.add([updatedDisplayList]);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 250));
+
+    expect(find.text('公開リスト 更新後'), findsOneWidget);
+    expect(find.text('メンバー一郎'), findsOneWidget);
+    expect(userRepository.getFriendPublicProfileCallCount('member-1'), 1);
+  });
+}
+
+class _CountingUserRepository extends MockUserRepository {
+  final Map<String, int> _getFriendPublicProfileCallCounts = {};
+
+  int getFriendPublicProfileCallCount(String id) {
+    return _getFriendPublicProfileCallCounts[id] ?? 0;
+  }
+
+  @override
+  Future<PublicUserModel?> getFriendPublicProfile(String id) {
+    _getFriendPublicProfileCallCounts[id] =
+        getFriendPublicProfileCallCount(id) + 1;
+    return super.getFriendPublicProfile(id);
+  }
+}
+
+DisplayList _displayList({
+  required String name,
+  required List<String> memberIds,
+}) {
+  return DisplayList(
+    id: 'display-list-1',
+    name: name,
+    ownerId: 'owner',
+    colorKey: 'blue',
+    memberIds: memberIds,
+    createdAt: DateTime(2026, 6, 6),
+    updatedAt: DateTime(2026, 6, 6),
+  );
+}

--- a/test/presentation/list/list_detail_page_test.dart
+++ b/test/presentation/list/list_detail_page_test.dart
@@ -54,6 +54,60 @@ void main() {
     expect(find.text('メンバー一郎'), findsOneWidget);
     expect(find.text('メンバー二郎'), findsOneWidget);
   });
+
+  testWidgets('リスト詳細は同じメンバーの公開プロフィールを再取得しない', (tester) async {
+    final listController = StreamController<UserList?>();
+    final userRepository = _CountingUserRepository()
+      ..addTestUser(
+        UserModel.create(id: 'member-1', name: 'メンバー1', displayName: 'メンバー一郎'),
+      );
+    final initialList = _list(memberIds: const ['member-1']);
+    final updatedList = initialList.copyWith(listName: 'テストリスト 更新後');
+
+    addTearDown(listController.close);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          userRepositoryProvider.overrideWithValue(userRepository),
+          listStreamProvider.overrideWith(
+            (ref, listId) => listController.stream,
+          ),
+        ],
+        child: MaterialApp(home: ListDetailPage(list: initialList)),
+      ),
+    );
+
+    listController.add(initialList);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 250));
+
+    expect(find.text('メンバー一郎'), findsOneWidget);
+    expect(userRepository.getFriendPublicProfileCallCount('member-1'), 1);
+
+    listController.add(updatedList);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 250));
+
+    expect(find.text('テストリスト 更新後'), findsOneWidget);
+    expect(find.text('メンバー一郎'), findsOneWidget);
+    expect(userRepository.getFriendPublicProfileCallCount('member-1'), 1);
+  });
+}
+
+class _CountingUserRepository extends MockUserRepository {
+  final Map<String, int> _getFriendPublicProfileCallCounts = {};
+
+  int getFriendPublicProfileCallCount(String id) {
+    return _getFriendPublicProfileCallCounts[id] ?? 0;
+  }
+
+  @override
+  Future<PublicUserModel?> getFriendPublicProfile(String id) {
+    _getFriendPublicProfileCallCounts[id] =
+        getFriendPublicProfileCallCount(id) + 1;
+    return super.getFriendPublicProfile(id);
+  }
 }
 
 UserList _list({required List<String> memberIds}) {

--- a/test/presentation/list/list_edit_page_test.dart
+++ b/test/presentation/list/list_edit_page_test.dart
@@ -52,6 +52,58 @@ void main() {
     expect(listRepository.updatedList, isNotNull);
     expect(listRepository.updatedList!.memberIds, ['member-1', 'member-2']);
   });
+
+  testWidgets('リスト編集は同じメンバーの公開プロフィールを再取得しない', (tester) async {
+    final listController = StreamController<UserList?>();
+    final userRepository = _CountingUserRepository()
+      ..addTestUser(
+        UserModel.create(id: 'member-1', name: 'メンバー1', displayName: 'メンバー一郎'),
+      );
+    final list = _list(memberIds: const ['member-1']);
+
+    addTearDown(listController.close);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          userRepositoryProvider.overrideWithValue(userRepository),
+          listStreamProvider.overrideWith(
+            (ref, listId) => listController.stream,
+          ),
+        ],
+        child: MaterialApp(home: ListEditPage(list: list)),
+      ),
+    );
+
+    listController.add(list);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 250));
+
+    expect(find.text('メンバー一郎'), findsOneWidget);
+    expect(userRepository.getFriendPublicProfileCallCount('member-1'), 1);
+
+    await tester.tap(find.byType(Checkbox));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 250));
+
+    expect(find.text('メンバー一郎'), findsOneWidget);
+    expect(userRepository.getFriendPublicProfileCallCount('member-1'), 1);
+  });
+}
+
+class _CountingUserRepository extends MockUserRepository {
+  final Map<String, int> _getFriendPublicProfileCallCounts = {};
+
+  int getFriendPublicProfileCallCount(String id) {
+    return _getFriendPublicProfileCallCounts[id] ?? 0;
+  }
+
+  @override
+  Future<PublicUserModel?> getFriendPublicProfile(String id) {
+    _getFriendPublicProfileCallCounts[id] =
+        getFriendPublicProfileCallCount(id) + 1;
+    return super.getFriendPublicProfile(id);
+  }
 }
 
 class _CapturingListRepository implements IListRepository {

--- a/test/presentation/schedule/schedule_detail_page_test.dart
+++ b/test/presentation/schedule/schedule_detail_page_test.dart
@@ -1,0 +1,170 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/date_symbol_data_local.dart';
+import 'package:lakiite/app/di/providers.dart';
+import 'package:lakiite/application/auth/auth_notifier.dart' as auth;
+import 'package:lakiite/application/auth/auth_state.dart';
+import 'package:lakiite/application/schedule/schedule_interaction_notifier.dart';
+import 'package:lakiite/domain/entity/schedule_comment.dart';
+import 'package:lakiite/domain/entity/schedule_reaction.dart';
+import 'package:lakiite/domain/interfaces/i_schedule_interaction_repository.dart';
+import 'package:lakiite/presentation/calendar/schedule_detail_page.dart';
+
+import '../../mock/base_mock.dart';
+import '../../mock/providers/test_providers.dart';
+import '../../utils/test_utils.dart';
+
+void main() {
+  setUpAll(() async {
+    await initializeDateFormatting('ja_JP', null);
+  });
+
+  setUp(() {
+    TestProviders.reset();
+  });
+
+  testWidgets('自分の予定には公開先リストボタンを表示する', (tester) async {
+    final overrides = [
+      ...TestProviders.forScheduleCreation,
+      auth.authNotifierProvider.overrideWith(
+        () => _StubAuthNotifier(
+          AuthState.authenticated(BaseMock.createTestUser()),
+        ),
+      ),
+      repositorySessionKeyProvider.overrideWith(
+        (ref) => Stream.value(BaseMock.testUserId),
+      ),
+      scheduleInteractionRepositoryProvider.overrideWithValue(
+        _EmptyScheduleInteractionRepository(),
+      ),
+      scheduleInteractionNotifierProvider.overrideWith((ref, scheduleId) {
+        return ScheduleInteractionNotifier(
+          ref.watch(scheduleInteractionRepositoryProvider),
+          scheduleId,
+          ref,
+          enablePushNotifications: false,
+        );
+      }),
+    ];
+    final schedule = BaseMock.createTestSchedule().copyWith(
+      sharedLists: const ['list-1'],
+    );
+    TestProviders.mockScheduleRepository.addTestSchedule(schedule);
+
+    await tester.pumpWidget(
+      TestUtils.createTestApp(
+        overrides: overrides,
+        child: ScheduleDetailPage(schedule: schedule),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(
+        find.byKey(const Key('schedule_shared_lists_button')), findsOneWidget);
+    expect(find.text('公開先リスト'), findsOneWidget);
+  });
+
+  testWidgets('他人の予定には公開先リストボタンを表示しない', (tester) async {
+    final overrides = [
+      ...TestProviders.forScheduleCreation,
+      auth.authNotifierProvider.overrideWith(
+        () => _StubAuthNotifier(
+          AuthState.authenticated(BaseMock.createTestUser()),
+        ),
+      ),
+      repositorySessionKeyProvider.overrideWith(
+        (ref) => Stream.value(BaseMock.testUserId),
+      ),
+      scheduleInteractionRepositoryProvider.overrideWithValue(
+        _EmptyScheduleInteractionRepository(),
+      ),
+      scheduleInteractionNotifierProvider.overrideWith((ref, scheduleId) {
+        return ScheduleInteractionNotifier(
+          ref.watch(scheduleInteractionRepositoryProvider),
+          scheduleId,
+          ref,
+          enablePushNotifications: false,
+        );
+      }),
+    ];
+    final schedule = BaseMock.createTestSchedule(
+      id: 'other-user-schedule-id',
+      ownerId: 'other-user',
+      ownerDisplayName: 'ほかのユーザー',
+    ).copyWith(
+      sharedLists: const ['list-1'],
+    );
+    TestProviders.mockScheduleRepository.addTestSchedule(schedule);
+
+    await tester.pumpWidget(
+      TestUtils.createTestApp(
+        overrides: overrides,
+        child: ScheduleDetailPage(schedule: schedule),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(find.byKey(const Key('schedule_shared_lists_button')), findsNothing);
+  });
+}
+
+class _StubAuthNotifier extends auth.AuthNotifier {
+  _StubAuthNotifier(this._state);
+
+  final AuthState _state;
+
+  @override
+  FutureOr<AuthState> build() => _state;
+}
+
+class _EmptyScheduleInteractionRepository
+    implements IScheduleInteractionRepository {
+  @override
+  Future<String> addComment(String scheduleId, String userId, String content) =>
+      Future.value('comment-id');
+
+  @override
+  Future<String> addReaction(
+    String scheduleId,
+    String userId,
+    ReactionType type,
+  ) =>
+      Future.value('reaction-id');
+
+  @override
+  Future<void> deleteComment(String scheduleId, String commentId) async {}
+
+  @override
+  Future<int> getCommentCount(String scheduleId) => Future.value(0);
+
+  @override
+  Future<List<ScheduleComment>> getComments(String scheduleId) =>
+      Future.value([]);
+
+  @override
+  Future<int> getReactionCount(String scheduleId) => Future.value(0);
+
+  @override
+  Future<List<ScheduleReaction>> getReactions(String scheduleId) =>
+      Future.value([]);
+
+  @override
+  Future<void> removeReaction(String scheduleId, String userId) async {}
+
+  @override
+  Future<void> updateComment(
+    String scheduleId,
+    String commentId,
+    String content,
+  ) async {}
+
+  @override
+  Stream<List<ScheduleComment>> watchComments(String scheduleId) =>
+      Stream.value([]);
+
+  @override
+  Stream<List<ScheduleReaction>> watchReactions(String scheduleId) =>
+      Stream.value([]);
+}

--- a/test/presentation/schedule/schedule_shared_lists_page_test.dart
+++ b/test/presentation/schedule/schedule_shared_lists_page_test.dart
@@ -1,0 +1,105 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lakiite/domain/entity/list.dart';
+import 'package:lakiite/presentation/calendar/schedule_shared_lists_page.dart';
+import 'package:lakiite/presentation/list/list_providers.dart';
+import 'package:lakiite/presentation/user/user_providers.dart';
+
+import '../../mock/base_mock.dart';
+import '../../mock/providers/test_providers.dart';
+import '../../utils/test_utils.dart';
+
+void main() {
+  setUp(() {
+    TestProviders.reset();
+  });
+
+  testWidgets('公開先リストページは予定のsharedLists順にリストとメンバーを表示する', (tester) async {
+    final listA = _list(
+      id: 'list-a',
+      name: 'Aリスト',
+      memberIds: const ['friend-1'],
+    );
+    final listB = _list(
+      id: 'list-b',
+      name: 'Bリスト',
+      memberIds: const ['friend-2'],
+    );
+    final overrides = [
+      ...TestProviders.authenticatedWithFriends,
+      userListsStreamProvider
+          .overrideWith((ref) => Stream.value([listA, listB])),
+      publicUserProvider.overrideWith((ref, userId) {
+        return Future.value(_publicUsers[userId]);
+      }),
+    ];
+    final schedule = BaseMock.createTestSchedule().copyWith(
+      sharedLists: const ['list-b', 'list-a'],
+    );
+
+    await tester.pumpWidget(
+      TestUtils.createTestApp(
+        overrides: overrides,
+        child: ScheduleSharedListsPage(schedule: schedule),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 1000));
+    await tester.pump();
+
+    expect(find.text('公開先リスト'), findsOneWidget);
+    expect(find.text('Bリスト'), findsOneWidget);
+    expect(find.text('Aリスト'), findsOneWidget);
+    expect(find.text('友達二郎'), findsOneWidget);
+    expect(find.text('友達一郎'), findsOneWidget);
+
+    final listBTop = tester.getTopLeft(find.text('Bリスト')).dy;
+    final listATop = tester.getTopLeft(find.text('Aリスト')).dy;
+    expect(listBTop, lessThan(listATop));
+  });
+
+  testWidgets('公開先リストページは公開先リストがない場合に空状態を表示する', (tester) async {
+    final overrides = [
+      ...TestProviders.authenticated,
+      userListsStreamProvider.overrideWith((ref) => Stream.value([])),
+    ];
+    final schedule = BaseMock.createTestSchedule();
+
+    await tester.pumpWidget(
+      TestUtils.createTestApp(
+        overrides: overrides,
+        child: ScheduleSharedListsPage(schedule: schedule),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 200));
+
+    expect(find.text('公開先リストがありません'), findsOneWidget);
+  });
+}
+
+final _publicUsers = {
+  'friend-1': BaseMock.createTestUser(
+    id: 'friend-1',
+    name: '友達1',
+    displayName: '友達一郎',
+  ).publicProfile,
+  'friend-2': BaseMock.createTestUser(
+    id: 'friend-2',
+    name: '友達2',
+    displayName: '友達二郎',
+  ).publicProfile,
+};
+
+UserList _list({
+  required String id,
+  required String name,
+  required List<String> memberIds,
+}) {
+  return UserList(
+    id: id,
+    listName: name,
+    ownerId: BaseMock.testUserId,
+    memberIds: memberIds,
+    createdAt: DateTime(2026, 6, 6),
+  );
+}

--- a/test/presentation/schedule/schedule_widget_test.dart
+++ b/test/presentation/schedule/schedule_widget_test.dart
@@ -168,6 +168,10 @@ void main() {
         );
       }
 
+      Finder saveActionButton() {
+        return find.byKey(const Key('schedule_form_save_action'));
+      }
+
       testWidgets('タイトル空欄では保存不可だがフォーカスだけではエラー表示しない', (tester) async {
         await tester.pumpWidget(
           TestUtils.createTestApp(
@@ -181,9 +185,7 @@ void main() {
         expect(find.textContaining('場所を入力してください'), findsNothing);
         expect(find.text('タイトル（必須）'), findsOneWidget);
 
-        var saveButton = tester.widget<FloatingActionButton>(
-          find.byType(FloatingActionButton),
-        );
+        var saveButton = tester.widget<TextButton>(saveActionButton());
         expect(saveButton.onPressed, isNull);
 
         await tester.tap(titleField());
@@ -192,9 +194,7 @@ void main() {
         expect(find.text('タイトル（必須）'), findsOneWidget);
         expect(find.text('タイトルを入力してください'), findsNothing);
         expect(find.textContaining('場所を入力してください'), findsNothing);
-        saveButton = tester.widget<FloatingActionButton>(
-          find.byType(FloatingActionButton),
-        );
+        saveButton = tester.widget<TextButton>(saveActionButton());
         expect(saveButton.onPressed, isNull);
       });
 
@@ -210,9 +210,7 @@ void main() {
         await tester.enterText(titleField(), 'テスト予定');
         await tester.pump();
 
-        final saveButton = tester.widget<FloatingActionButton>(
-          find.byType(FloatingActionButton),
-        );
+        final saveButton = tester.widget<TextButton>(saveActionButton());
         expect(saveButton.onPressed, isNotNull);
         expect(find.text('未入力でも保存できます'), findsNothing);
         expect(find.textContaining('場所を入力してください'), findsNothing);
@@ -231,14 +229,12 @@ void main() {
         await tester.enterText(titleField(), '');
         await tester.pump();
 
-        final saveButton = tester.widget<FloatingActionButton>(
-          find.byType(FloatingActionButton),
-        );
+        final saveButton = tester.widget<TextButton>(saveActionButton());
         expect(saveButton.onPressed, isNull);
         expect(find.text('タイトルを入力してください'), findsNothing);
       });
 
-      testWidgets('公開するリスト下には保存ボタンに隠れない余白を確保する', (tester) async {
+      testWidgets('保存操作はAppBarに表示しフォーム上のFABを使わない', (tester) async {
         await tester.pumpWidget(
           TestUtils.createTestApp(
             overrides: TestProviders.forScheduleCreation,
@@ -247,15 +243,13 @@ void main() {
         );
         await tester.pump(const Duration(milliseconds: 200));
 
-        final spacerFinder =
-            find.byKey(const Key('schedule_form_bottom_spacer'));
-
         expect(find.text('公開するリスト'), findsOneWidget);
-        expect(spacerFinder, findsOneWidget);
         expect(
-          tester.getSize(spacerFinder).height,
-          greaterThanOrEqualTo(72),
+          find.descendant(of: find.byType(AppBar), matching: find.text('保存')),
+          findsOneWidget,
         );
+        expect(saveActionButton(), findsOneWidget);
+        expect(find.byType(FloatingActionButton), findsNothing);
       });
 
       testWidgets('スケジュール作成フォームが正しく表示される', (tester) async {

--- a/test/presentation/schedule/schedule_widget_test.dart
+++ b/test/presentation/schedule/schedule_widget_test.dart
@@ -1,6 +1,10 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lakiite/domain/entity/list.dart';
 import 'package:lakiite/presentation/calendar/schedule_form_page.dart';
+import 'package:lakiite/presentation/list/list_providers.dart';
 import '../../mock/providers/test_providers.dart';
 import '../../mock/base_mock.dart';
 import '../../utils/test_utils.dart';
@@ -250,6 +254,32 @@ void main() {
         );
         expect(saveActionButton(), findsOneWidget);
         expect(find.byType(FloatingActionButton), findsNothing);
+      });
+
+      testWidgets('公開するリストにはリストアイコンを表示する', (tester) async {
+        final list = UserList(
+          id: 'icon-list',
+          listName: 'アイコン付きリスト',
+          ownerId: BaseMock.testUserId,
+          memberIds: const [],
+          createdAt: DateTime(2026, 6, 6),
+        );
+        final overrides = [
+          ...TestProviders.forScheduleCreation,
+          userListsStreamProvider.overrideWith((ref) => Stream.value([list])),
+        ];
+
+        await tester.pumpWidget(
+          TestUtils.createTestApp(
+            overrides: overrides,
+            child: const ScheduleFormPage(),
+          ),
+        );
+        await tester.pump(const Duration(milliseconds: 300));
+
+        expect(find.text('アイコン付きリスト'), findsOneWidget);
+        expect(find.byKey(const Key('schedule_form_list_icon_icon-list')),
+            findsOneWidget);
       });
 
       testWidgets('スケジュール作成フォームが正しく表示される', (tester) async {

--- a/test/presentation/schedule/schedule_widget_test.dart
+++ b/test/presentation/schedule/schedule_widget_test.dart
@@ -238,6 +238,26 @@ void main() {
         expect(find.text('タイトルを入力してください'), findsNothing);
       });
 
+      testWidgets('公開するリスト下には保存ボタンに隠れない余白を確保する', (tester) async {
+        await tester.pumpWidget(
+          TestUtils.createTestApp(
+            overrides: TestProviders.forScheduleCreation,
+            child: const ScheduleFormPage(),
+          ),
+        );
+        await tester.pump(const Duration(milliseconds: 200));
+
+        final spacerFinder =
+            find.byKey(const Key('schedule_form_bottom_spacer'));
+
+        expect(find.text('公開するリスト'), findsOneWidget);
+        expect(spacerFinder, findsOneWidget);
+        expect(
+          tester.getSize(spacerFinder).height,
+          greaterThanOrEqualTo(72),
+        );
+      });
+
       testWidgets('スケジュール作成フォームが正しく表示される', (tester) async {
         await tester.pumpWidget(
           TestUtils.createTestApp(


### PR DESCRIPTION
## Summary
- Sort friend list profiles by display name instead of stored friend ID order.
- Show the pending request target user avatar when their public profile has an icon URL.
- Move the schedule form save action from a floating button into the AppBar so the public-list section can scroll normally without overlap.
- Avoid repeated member public-profile loads on list/detail/edit screens by sharing member profile reads through a Riverpod family provider.
- Share list UI components across public-list and display-list screens so list rows, detail headers, edit actions, delete menus, and member rows use the same structure.
- Show list icons in the schedule form public-list selector and list detail/list rows.
- Add an owner-only schedule detail action that opens a public-list viewer showing each shared list icon/name and all published members in shared-list order.
- Refresh friend-search relationship checks from the latest user repository state instead of login-time auth user data.

## Root Cause
- Friend profiles were returned in the same order as `user.friends`, which made the UI reflect friend-added order.
- Pending request rows rendered a static hourglass avatar from notification data only, without loading the target public profile.
- The schedule form used a floating save button, which could overlap the variable-height public-list section near the bottom of the form.
- List member rows created `FutureBuilder` futures directly during build, so stream updates and local rebuilds could trigger repeated `getFriendPublicProfile` reads for the same member.
- Public-list and display-list screens had separate hand-built widgets for equivalent UI patterns, which made their tone drift.
- Schedule creation rows were not rendering list icons, and schedule details had no owner-only page for checking the exact shared-list/member breakdown.
- Friend search used `authNotifierProvider.user.friends`, which can remain stale after deleting a friend because auth state is not the canonical source for mutable relationship data.

## Test Plan
- `fvm dart format lib/domain/service/user_manager.dart lib/presentation/friend/friend_list_page.dart lib/presentation/calendar/schedule_form_page.dart test/domain/service/user_manager_test.dart test/presentation/friend/friend_list_page_test.dart test/presentation/schedule/schedule_widget_test.dart`
- `fvm dart format lib/presentation/user/user_providers.dart lib/presentation/presentation_provider.dart lib/presentation/list/display_list_detail_page.dart lib/presentation/list/list_detail_page.dart lib/presentation/list/list_edit_page.dart test/presentation/list/display_list_detail_page_test.dart test/presentation/list/list_detail_page_test.dart test/presentation/list/list_edit_page_test.dart`
- `fvm dart format lib/presentation/list/list_summary_tile.dart lib/presentation/list/list_page.dart lib/presentation/list/list_detail_scaffold.dart lib/presentation/list/list_member_profile_tile.dart lib/presentation/list/list_edit_save_action.dart lib/presentation/list/display_list_detail_page.dart lib/presentation/list/list_detail_page.dart lib/presentation/list/display_list_edit_page.dart lib/presentation/list/list_edit_page.dart`
- `fvm dart format lib/presentation/list/user_list_icon.dart lib/presentation/list/list_page.dart lib/presentation/list/list_detail_page.dart lib/presentation/calendar/schedule_form_page.dart lib/presentation/calendar/schedule_detail_page.dart lib/presentation/calendar/schedule_shared_lists_page.dart test/presentation/schedule/schedule_widget_test.dart test/presentation/schedule/schedule_shared_lists_page_test.dart test/presentation/schedule/schedule_detail_page_test.dart`
- `fvm dart format lib/presentation/friend/friend_search_view_model.dart test/presentation/friend/friend_search_page_test.dart lib/presentation/friend/friend_list_page.dart test/presentation/friend/friend_list_page_test.dart`
- `fvm flutter test test/domain/service/user_manager_test.dart test/presentation/friend/friend_list_page_test.dart test/presentation/schedule/schedule_widget_test.dart`
- `fvm flutter test test/presentation/list/display_list_detail_page_test.dart test/presentation/list/list_detail_page_test.dart test/presentation/list/list_edit_page_test.dart test/presentation/list/list_member_invite_page_test.dart test/presentation/friend/friend_list_page_test.dart test/domain/service/user_manager_test.dart test/presentation/schedule/schedule_widget_test.dart`
- `fvm flutter test test/presentation/list/display_list_detail_page_test.dart test/presentation/list/list_detail_page_test.dart test/presentation/list/list_edit_page_test.dart test/presentation/list/list_member_invite_page_test.dart test/presentation/auth/auth_home_navigation_test.dart test/presentation/friend/friend_list_page_test.dart test/domain/service/user_manager_test.dart test/presentation/schedule/schedule_widget_test.dart`
- `fvm flutter test test/presentation/schedule/schedule_widget_test.dart test/presentation/schedule/schedule_shared_lists_page_test.dart test/presentation/schedule/schedule_detail_page_test.dart`
- `fvm flutter test test/presentation/friend/friend_search_page_test.dart test/presentation/friend/friend_list_page_test.dart`
- `fvm flutter analyze`
- Android dev flavor smoke test on `CPH2013` / Android 11 for friend-list ordering.

## Notes
- The Android smoke test used Firebase project `lakiite-flutter-app-dev`.
- The test account did not have pending outgoing friend requests, so the pending avatar behavior is covered by widget test rather than real device data.
- Dev Firestore was checked for `7WWImv4yThY0npF5xjxwuy17q303` and `RMltPpQV2MaKqDBAoOlPylFtpJ23`; neither side currently has the other in `private/profile.friends`, and there is no pending friend notification between them.
- The schedule save action change was verified by widget tests; device smoke was not rerun after moving the save action to the AppBar.
- The repeated profile-load fix is covered by widget tests that assert the same member profile is not fetched again across stream/local rebuilds.
- After the UI component refactor, direct `getFriendPublicProfile` calls in list presentation code are limited to `publicUserProvider`.
- The owner-only public-list viewer and schedule-form list icon are covered by widget tests.
- Friend search now uses auth only for the current user ID; mutable relationship state and request sender display name are loaded from the latest user repository state at search/send time.
