### PR TITLE
ci: add Release Drafter semver automation

### DIFF
--- a/.github/actions/resolve-release-version/action.yml
+++ b/.github/actions/resolve-release-version/action.yml
@@ -1,0 +1,63 @@
+name: Resolve Release Version
+description: Resolve the next app version from Release Drafter labels.
+
+outputs:
+  version:
+    description: SemVer version without the leading v.
+    value: ${{ steps.normalize.outputs.version }}
+  tag:
+    description: Release tag with the leading v.
+    value: ${{ steps.normalize.outputs.tag }}
+  release_id:
+    description: Draft release id from Release Drafter.
+    value: ${{ steps.release_drafter.outputs.id }}
+  release_url:
+    description: Draft release URL from Release Drafter.
+    value: ${{ steps.release_drafter.outputs.html_url }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Resolve version with Release Drafter
+      id: release_drafter
+      uses: release-drafter/release-drafter@v7
+      with:
+        config-name: release-drafter.yml
+        dry-run: true
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+
+    - name: Normalize release version
+      id: normalize
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        base_version="$(awk '/^version:/ { print $2; exit }' pubspec.yaml | cut -d '+' -f 1)"
+        version="${{ steps.release_drafter.outputs.resolved_version }}"
+        if [ -z "$version" ] || [ "$version" = "null" ]; then
+          version="$base_version"
+          echo "::warning ::Release Drafter did not return resolved_version. Falling back to pubspec.yaml version: $version"
+        fi
+
+        version="${version#v}"
+        if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "::error ::Resolved release version must be x.y.z for Android/iOS store builds: $version"
+          exit 1
+        fi
+
+        version="$(python3 - "$base_version" "$version" <<'PY'
+        import sys
+
+        def parse(value):
+            return tuple(int(part) for part in value.split("."))
+
+        base = sys.argv[1]
+        candidate = sys.argv[2]
+        print(candidate if parse(candidate) >= parse(base) else base)
+        PY
+        )"
+
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+        echo "tag=v$version" >> "$GITHUB_OUTPUT"
+        echo "Resolved app version: $version"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,131 @@
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+tag-prefix: "v"
+version-template: "$MAJOR.$MINOR.$PATCH"
+
+categories:
+  - type: "pre-exclude"
+    when:
+      label: "skip-changelog"
+
+  - type: "pre-exclude"
+    when:
+      label: "semver:none"
+
+  - title: "Breaking Changes"
+    semver-increment: "major"
+    when:
+      label: "breaking-change"
+
+  - title: "Features"
+    semver-increment: "minor"
+    when:
+      labels:
+        - "type:feature"
+        - "enhancement"
+        - "1 : ストーリー - story"
+
+  - title: "Fixes"
+    semver-increment: "patch"
+    when:
+      labels:
+        - "type:fix"
+        - "3 : バグ - bug"
+
+  - title: "Security"
+    semver-increment: "patch"
+    when:
+      label: "type:security"
+
+  - title: "Performance"
+    semver-increment: "patch"
+    when:
+      label: "type:performance"
+
+  - title: "Refactoring"
+    semver-increment: "patch"
+    when:
+      label: "type:refactor"
+
+  - title: "Tests"
+    semver-increment: "patch"
+    when:
+      label: "type:test"
+
+  - title: "Documentation"
+    semver-increment: "patch"
+    when:
+      labels:
+        - "type:docs"
+        - "0 : 書類 - documentation"
+
+  - title: "CI and Maintenance"
+    semver-increment: "patch"
+    when:
+      labels:
+        - "type:ci"
+        - "type:chore"
+        - "環境構築"
+
+  - title: "Other Changes"
+    semver-increment: "patch"
+
+  - type: "version-resolver"
+    semver-increment: "major"
+    when:
+      labels:
+        - "semver:major"
+        - "breaking-change"
+
+  - type: "version-resolver"
+    semver-increment: "minor"
+    when:
+      label: "semver:minor"
+
+  - type: "version-resolver"
+    semver-increment: "patch"
+    when:
+      label: "semver:patch"
+
+  - type: "version-resolver"
+    semver-increment: "patch"
+
+change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
+change-title-escapes: '\<*_&`#@'
+no-changes-template: "- No user-facing changes"
+
+template: |
+  ## Changes
+
+  $CHANGES
+
+  ## Contributors
+
+  $CONTRIBUTORS
+
+autolabeler:
+  - label: "type:ci"
+    files:
+      - ".github/**"
+    branch:
+      - "/^(ci|chore)\\//"
+    title:
+      - "/\\b(ci|workflow|actions?)\\b/i"
+
+  - label: "type:docs"
+    files:
+      - "**/*.md"
+      - "docs/**"
+    branch:
+      - "/^docs?\\//"
+
+  - label: "type:fix"
+    branch:
+      - "/^fix\\//"
+      - "/^hotfix\\//"
+    title:
+      - "/\\b(fix|bug|不具合|修正)\\b/i"
+
+  - label: "type:feature"
+    title:
+      - "/\\b(feat|feature|追加|実装)\\b/i"

--- a/.github/workflows/deploy_prod_android.yml
+++ b/.github/workflows/deploy_prod_android.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -125,6 +129,10 @@ jobs:
 
           echo "Prod runtime config validation passed."
 
+      - name: Resolve release version
+        id: release_version
+        uses: ./.github/actions/resolve-release-version
+
       - name: Calculate Build Number
         id: calculate_build_number
         run: |
@@ -143,7 +151,7 @@ jobs:
             --target-platform android-arm,android-arm64,android-x64 \
             --dart-define-from-file="dart_define.json" \
             -t "lib/main.dart" \
-            --build-name=$(grep 'version:' pubspec.yaml | cut -d ' ' -f 2 | cut -d '+' -f 1) \
+            --build-name="${{ steps.release_version.outputs.version }}" \
             --build-number="${{ steps.calculate_build_number.outputs.buildNumber }}"
 
       - name: flutter build apk
@@ -158,7 +166,7 @@ jobs:
             --target-platform android-arm,android-arm64,android-x64 \
             --dart-define-from-file="dart_define.json" \
             -t "lib/main.dart" \
-            --build-name=$(grep 'version:' pubspec.yaml | cut -d ' ' -f 2 | cut -d '+' -f 1) \
+            --build-name="${{ steps.release_version.outputs.version }}" \
             --build-number="${{ steps.calculate_build_number.outputs.buildNumber }}"
 
       - name: Get latest 10 commit messages

--- a/.github/workflows/deploy_prod_ios.yml
+++ b/.github/workflows/deploy_prod_ios.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: read
+
 jobs:
   build:
     runs-on: macos-26
@@ -80,6 +84,10 @@ jobs:
           TOTAL_COMMITS=$(($TOTAL_COMMITS + 10000))  # オフセットとして一律で 10000 を加算する。
           echo "buildNumber=$TOTAL_COMMITS" >> $GITHUB_OUTPUT
 
+      - name: Resolve release version
+        id: release_version
+        uses: ./.github/actions/resolve-release-version
+
       - name: flutter build ipa
         run: |
           flutter build ipa --release \
@@ -87,7 +95,7 @@ jobs:
             --export-options-plist=ios/ExportOptions.plist \
             --dart-define-from-file="dart_define.json" \
             -t "lib/main.dart" \
-            --build-name=$(grep 'version:' pubspec.yaml | cut -d ' ' -f 2 | cut -d '+' -f 1) \
+            --build-name="${{ steps.release_version.outputs.version }}" \
             --build-number="${{ steps.calculate_build_number.outputs.buildNumber }}"
 
       - name: Get latest 10 commit messages

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,39 @@
+name: Release Drafter
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, reopened, synchronize, edited]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update_release_draft:
+    name: Update Release Draft
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Update draft release
+        uses: release-drafter/release-drafter@v7
+        with:
+          config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  autolabel:
+    name: Autolabel PR
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Apply release labels
+        uses: release-drafter/release-drafter/autolabeler@v7
+        with:
+          config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-label-check.yml
+++ b/.github/workflows/release-label-check.yml
@@ -1,0 +1,46 @@
+name: Release Label Check
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize, labeled, unlabeled, edited]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  check_release_labels:
+    name: Check release labels
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Require one semver label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          labels="$(gh pr view "$PR_NUMBER" --repo "$REPOSITORY" --json labels --jq '.labels[].name')"
+
+          semver_count="$(printf '%s\n' "$labels" | grep -Ec '^semver:(major|minor|patch|none)$' || true)"
+          if [ "$semver_count" -ne 1 ]; then
+            echo "::error ::main向けPRには semver:major / semver:minor / semver:patch / semver:none のいずれか1つだけを付けてください。"
+            printf 'Current labels:\n%s\n' "$labels"
+            exit 1
+          fi
+
+          if printf '%s\n' "$labels" | grep -qx 'semver:none'; then
+            echo "semver:none is set. Release Drafter will exclude this PR from changelog/version resolution."
+            exit 0
+          fi
+
+          type_count="$(printf '%s\n' "$labels" | grep -Ec '^type:(feature|fix|docs|ci|chore|refactor|test|security|performance)$' || true)"
+          if [ "$type_count" -lt 1 ]; then
+            echo "::error ::main向けPRには release note 分類用の type:* ラベルを少なくとも1つ付けてください。"
+            printf 'Current labels:\n%s\n' "$labels"
+            exit 1
+          fi
+
+          echo "Release labels are valid."


### PR DESCRIPTION
## Summary
- Add Release Drafter config that groups release notes and resolves SemVer from PR labels.
- Add release label validation for PRs targeting main, requiring exactly one semver label and at least one release-note type label unless semver:none is used.
- Use the resolved Release Drafter version as Flutter build-name for prod Android and iOS store builds.
- Added/updated GitHub labels for semver:* and release-note type:* usage.

## Label rules for main <- dev PRs
- Required exactly one: semver:major, semver:minor, semver:patch, semver:none.
- Required at least one type label when not semver:none: type:feature, type:fix, type:docs, type:ci, type:chore, type:refactor, type:test, type:security, type:performance.
- Use breaking-change with semver:major for breaking releases.
- Use skip-changelog or semver:none to exclude non-release changes.

## Test Plan
- Parsed all added/changed YAML files with Ruby YAML.
- Ran bash syntax check on the resolved composite action script.
- Ran git diff --check and git diff --cached --check.
- Verified the required GitHub labels exist.

## Notes
- There are no existing GitHub releases or tags. Before the first main release, creating an initial v1.0.0 tag/release will make Release Drafter's baseline explicit. The CI resolver also guards against resolved versions lower than pubspec.yaml's current version.