### PR TITLE
ci: target Release Drafter to main

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -2,6 +2,8 @@ name-template: "v$RESOLVED_VERSION"
 tag-template: "v$RESOLVED_VERSION"
 tag-prefix: "v"
 version-template: "$MAJOR.$MINOR.$PATCH"
+commitish: "main"
+filter-by-commitish: true
 
 categories:
   - type: "pre-exclude"
@@ -120,9 +122,6 @@ autolabeler:
       - "/^docs?\\//"
 
   - label: "type:fix"
-    branch:
-      - "/^fix\\//"
-      - "/^hotfix\\//"
     title:
       - "/\\b(fix|bug|不具合|修正)\\b/i"
 


### PR DESCRIPTION
## Summary
- Set Release Drafter commitish to main.
- Enable filter-by-commitish so release version resolution uses main-targeted releases as the baseline.
- Keeps the agreed operation: no version file update on PR creation; semver labels are assigned on the main <- dev release PR and applied after merge.

## Test Plan
- Parsed .github/release-drafter.yml with Ruby YAML.
- Ran git diff --check.