### PR TITLE
ci: fix Release Drafter category validation

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -6,11 +6,13 @@ commitish: "main"
 filter-by-commitish: true
 
 categories:
-  - type: "pre-exclude"
+  - title: "Skipped Changes"
+    type: "pre-exclude"
     when:
       label: "skip-changelog"
 
-  - type: "pre-exclude"
+  - title: "No Version Changes"
+    type: "pre-exclude"
     when:
       label: "semver:none"
 
@@ -72,24 +74,28 @@ categories:
   - title: "Other Changes"
     semver-increment: "patch"
 
-  - type: "version-resolver"
+  - title: "Major Version"
+    type: "version-resolver"
     semver-increment: "major"
     when:
       labels:
         - "semver:major"
         - "breaking-change"
 
-  - type: "version-resolver"
+  - title: "Minor Version"
+    type: "version-resolver"
     semver-increment: "minor"
     when:
       label: "semver:minor"
 
-  - type: "version-resolver"
+  - title: "Patch Version"
+    type: "version-resolver"
     semver-increment: "patch"
     when:
       label: "semver:patch"
 
-  - type: "version-resolver"
+  - title: "Default Version"
+    type: "version-resolver"
     semver-increment: "patch"
 
 change-template: "- $TITLE @$AUTHOR (#$NUMBER)"


### PR DESCRIPTION
## Summary
- Add titles to Release Drafter pre-exclude and version-resolver categories.
- Fixes Release Drafter v7 schema validation failures on main push.
- Marked as semver:none so this hotfix does not affect the app release version.

## Test Plan
- Parsed .github/release-drafter.yml with Ruby YAML.
- Ran git diff --check.

## Related failed runs
- https://github.com/keishimizu26629/LaKiite-flutter-app/actions/runs/27049216379
- https://github.com/keishimizu26629/LaKiite-flutter-app/actions/runs/27049216387