### PR TITLE
ci: remove Release Drafter fallback version category

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -94,10 +94,6 @@ categories:
     when:
       label: "semver:patch"
 
-  - title: "Default Version"
-    type: "version-resolver"
-    semver-increment: "patch"
-
 change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
 change-title-escapes: '\<*_&`#@'
 no-changes-template: "- No user-facing changes"


### PR DESCRIPTION
## Summary
- Remove the unlabeled fallback version-resolver category from Release Drafter config.
- Fixes Release Drafter v7 error: Multiple categories detected with no labels.
- SemVer labels are already required on main release PRs, so the fallback is unnecessary.

## Test Plan
- Parsed .github/release-drafter.yml with Ruby YAML.
- Ran git diff --check.

## Related failed run
- https://github.com/keishimizu26629/LaKiite-flutter-app/actions/runs/27049474890