### PR TITLE
ci: drop Release Drafter version resolver categories

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -74,30 +74,6 @@ categories:
   - title: "Other Changes"
     semver-increment: "patch"
 
-  - title: "Major Version"
-    type: "version-resolver"
-    semver-increment: "major"
-    when:
-      labels:
-        - "semver:major"
-        - "breaking-change"
-
-  - title: "Minor Version"
-    type: "version-resolver"
-    semver-increment: "minor"
-    when:
-      label: "semver:minor"
-
-  - title: "Patch Version"
-    type: "version-resolver"
-    semver-increment: "patch"
-    when:
-      label: "semver:patch"
-
-  - title: "Default Version"
-    type: "version-resolver"
-    semver-increment: "patch"
-
 change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
 change-title-escapes: '\<*_&`#@'
 no-changes-template: "- No user-facing changes"


### PR DESCRIPTION
## Summary
- Remove Release Drafter version-resolver categories because the current v7 validation treats them as unlabeled categories.
- Keep SemVer resolution through changelog categories: type:feature -> minor, other categorized changes -> patch, breaking-change -> major.

## Test Plan
- Parsed .github/release-drafter.yml with Ruby YAML.
- Ran git diff --check.