### PR TITLE
ci: simplify Release Drafter categories

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -4,75 +4,70 @@ tag-prefix: "v"
 version-template: "$MAJOR.$MINOR.$PATCH"
 commitish: "main"
 filter-by-commitish: true
+exclude-labels:
+  - "skip-changelog"
+  - "semver:none"
 
 categories:
-  - title: "Skipped Changes"
-    type: "pre-exclude"
-    when:
-      label: "skip-changelog"
-
-  - title: "No Version Changes"
-    type: "pre-exclude"
-    when:
-      label: "semver:none"
-
   - title: "Breaking Changes"
-    semver-increment: "major"
-    when:
-      label: "breaking-change"
+    labels:
+      - "breaking-change"
 
   - title: "Features"
-    semver-increment: "minor"
-    when:
-      labels:
-        - "type:feature"
-        - "enhancement"
-        - "1 : ストーリー - story"
+    labels:
+      - "type:feature"
+      - "enhancement"
+      - "1 : ストーリー - story"
 
   - title: "Fixes"
-    semver-increment: "patch"
-    when:
-      labels:
-        - "type:fix"
-        - "3 : バグ - bug"
+    labels:
+      - "type:fix"
+      - "3 : バグ - bug"
 
   - title: "Security"
-    semver-increment: "patch"
-    when:
-      label: "type:security"
+    labels:
+      - "type:security"
 
   - title: "Performance"
-    semver-increment: "patch"
-    when:
-      label: "type:performance"
+    labels:
+      - "type:performance"
 
   - title: "Refactoring"
-    semver-increment: "patch"
-    when:
-      label: "type:refactor"
+    labels:
+      - "type:refactor"
 
   - title: "Tests"
-    semver-increment: "patch"
-    when:
-      label: "type:test"
+    labels:
+      - "type:test"
 
   - title: "Documentation"
-    semver-increment: "patch"
-    when:
-      labels:
-        - "type:docs"
-        - "0 : 書類 - documentation"
+    labels:
+      - "type:docs"
+      - "0 : 書類 - documentation"
 
   - title: "CI and Maintenance"
-    semver-increment: "patch"
-    when:
-      labels:
-        - "type:ci"
-        - "type:chore"
-        - "環境構築"
+    labels:
+      - "type:ci"
+      - "type:chore"
+      - "環境構築"
 
   - title: "Other Changes"
-    semver-increment: "patch"
+
+version-resolver:
+  major:
+    labels:
+      - "semver:major"
+      - "breaking-change"
+  minor:
+    labels:
+      - "semver:minor"
+      - "type:feature"
+      - "enhancement"
+      - "1 : ストーリー - story"
+  patch:
+    labels:
+      - "semver:patch"
+  default: patch
 
 change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
 change-title-escapes: '\<*_&`#@'

--- a/.github/workflows/deploy_prod_android.yml
+++ b/.github/workflows/deploy_prod_android.yml
@@ -1,7 +1,9 @@
 name: '[Release] Prod Android'
 
 on:
-  push:
+  workflow_run:
+    workflows: ["Release Drafter"]
+    types: [completed]
     branches: [main]
   workflow_dispatch:
 
@@ -11,6 +13,7 @@ permissions:
 
 jobs:
   build:
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     environment: prod

--- a/.github/workflows/deploy_prod_ios.yml
+++ b/.github/workflows/deploy_prod_ios.yml
@@ -1,7 +1,9 @@
 name: "[Release] Prod iOS"
 
 on:
-  push:
+  workflow_run:
+    workflows: ["Release Drafter"]
+    types: [completed]
     branches: [main]
   workflow_dispatch:
 
@@ -11,6 +13,7 @@ permissions:
 
 jobs:
   build:
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: macos-26
     timeout-minutes: 45
     environment: prod


### PR DESCRIPTION
## Summary
- Replace Release Drafter pre-exclude categories with exclude-labels.
- Keep categories limited to changelog buckets to avoid v7 unlabeled-category validation failures.
- Marked as semver:none so this hotfix does not affect app versioning.

## Test Plan
- Parsed .github/release-drafter.yml with Ruby YAML.
- Ran git diff --check.

## Related failed run
- https://github.com/keishimizu26629/LaKiite-flutter-app/actions/runs/27049761393