### PR TITLE
ci: guard prod deploy workflow runs

### DIFF
--- a/.github/workflows/deploy_prod_android.yml
+++ b/.github/workflows/deploy_prod_android.yml
@@ -13,7 +13,13 @@ permissions:
 
 jobs:
   build:
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'push' &&
+        github.event.workflow_run.head_branch == 'main'
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 45
     environment: prod

--- a/.github/workflows/deploy_prod_ios.yml
+++ b/.github/workflows/deploy_prod_ios.yml
@@ -13,7 +13,13 @@ permissions:
 
 jobs:
   build:
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'push' &&
+        github.event.workflow_run.head_branch == 'main'
+      )
     runs-on: macos-26
     timeout-minutes: 45
     environment: prod


### PR DESCRIPTION
## Summary
- restrict prod Android/iOS workflow_run jobs to successful Release Drafter runs from push events on main
- keep manual workflow_dispatch releases available

## Verification
- ruby YAML parse for prod Android/iOS workflows
- git diff --check

Refs #260