### PR TITLE
fix: restore list image crop and comment notifications

### DIFF
--- a/lib/application/schedule/schedule_interaction_notifier.dart
+++ b/lib/application/schedule/schedule_interaction_notifier.dart
@@ -11,18 +11,19 @@ import 'package:lakiite/application/notification/notification_notifier.dart';
 import '../../infrastructure/firebase/push_notification_sender.dart';
 
 final scheduleInteractionNotifierProvider = StateNotifierProvider.autoDispose
-    .family<ScheduleInteractionNotifier, ScheduleInteractionState, String>(
-  (ref, scheduleId) {
-    ref.watch(repositorySessionKeyProvider);
-
-    return ScheduleInteractionNotifier(
-      ref.watch(scheduleInteractionRepositoryProvider),
-      scheduleId,
+    .family<ScheduleInteractionNotifier, ScheduleInteractionState, String>((
       ref,
-      pushNotificationSender: ref.watch(pushNotificationSenderProvider),
-    );
-  },
-);
+      scheduleId,
+    ) {
+      ref.watch(repositorySessionKeyProvider);
+
+      return ScheduleInteractionNotifier(
+        ref.watch(scheduleInteractionRepositoryProvider),
+        scheduleId,
+        ref,
+        pushNotificationSender: ref.watch(pushNotificationSenderProvider),
+      );
+    });
 
 class ScheduleInteractionNotifier
     extends StateNotifier<ScheduleInteractionState> {
@@ -32,8 +33,8 @@ class ScheduleInteractionNotifier
     this._ref, {
     PushNotificationSender? pushNotificationSender,
     bool enablePushNotifications = true,
-  })  : _enablePushNotifications = enablePushNotifications,
-        super(const ScheduleInteractionState()) {
+  }) : _enablePushNotifications = enablePushNotifications,
+       super(const ScheduleInteractionState()) {
     if (_enablePushNotifications) {
       _pushNotificationSender =
           pushNotificationSender ?? PushNotificationSender();
@@ -60,27 +61,31 @@ class ScheduleInteractionNotifier
         throw Exception('User not authenticated');
       }
 
-      _reactionsSubscription = _repository.watchReactions(_scheduleId).listen(
-        (reactions) {
-          if (!mounted) return;
-          state = state.copyWith(reactions: reactions);
-        },
-        onError: (error) {
-          if (!mounted) return;
-          state = state.copyWith(error: error.toString());
-        },
-      );
+      _reactionsSubscription = _repository
+          .watchReactions(_scheduleId)
+          .listen(
+            (reactions) {
+              if (!mounted) return;
+              state = state.copyWith(reactions: reactions);
+            },
+            onError: (error) {
+              if (!mounted) return;
+              state = state.copyWith(error: error.toString());
+            },
+          );
 
-      _commentsSubscription = _repository.watchComments(_scheduleId).listen(
-        (comments) {
-          if (!mounted) return;
-          state = state.copyWith(comments: comments);
-        },
-        onError: (error) {
-          if (!mounted) return;
-          state = state.copyWith(error: error.toString());
-        },
-      );
+      _commentsSubscription = _repository
+          .watchComments(_scheduleId)
+          .listen(
+            (comments) {
+              if (!mounted) return;
+              state = state.copyWith(comments: comments);
+            },
+            onError: (error) {
+              if (!mounted) return;
+              state = state.copyWith(error: error.toString());
+            },
+          );
     } catch (e) {
       AppLogger.error('Error initializing subscriptions: $e');
       if (mounted) {
@@ -93,15 +98,17 @@ class ScheduleInteractionNotifier
     try {
       AppLogger.debug('toggleReaction called - userId: $userId, type: $type');
       AppLogger.debug(
-          'Current state before update: ${state.reactions.length} reactions');
+        'Current state before update: ${state.reactions.length} reactions',
+      );
 
       final currentReaction = state.getUserReaction(userId);
       AppLogger.debug('Current reaction before update: $currentReaction');
 
       state = state.copyWith(isLoading: true, error: null);
 
-      final scheduleStream =
-          _ref.read(scheduleRepositoryProvider).watchSchedule(_scheduleId);
+      final scheduleStream = _ref
+          .read(scheduleRepositoryProvider)
+          .watchSchedule(_scheduleId);
       final schedule = await scheduleStream.first;
       if (!mounted) {
         return;
@@ -128,23 +135,30 @@ class ScheduleInteractionNotifier
       if (currentReaction != null) {
         if (currentReaction.type == type) {
           AppLogger.debug(
-              'Removing same reaction - userId: $userId, type: $type');
+            'Removing same reaction - userId: $userId, type: $type',
+          );
           await _repository.removeReaction(_scheduleId, userId);
 
           final latestReactions = state.reactions;
-          final updatedReactions =
-              latestReactions.where((r) => r.userId != userId).toList();
+          final updatedReactions = latestReactions
+              .where((r) => r.userId != userId)
+              .toList();
           AppLogger.debug(
-              'Optimistically updating state after removing reaction: ${updatedReactions.length} reactions');
+            'Optimistically updating state after removing reaction: ${updatedReactions.length} reactions',
+          );
           if (!mounted) return;
           state = state.copyWith(isLoading: false, reactions: updatedReactions);
         } else {
           AppLogger.debug(
-              'Updating to different reaction - from: ${currentReaction.type}, to: $type');
+            'Updating to different reaction - from: ${currentReaction.type}, to: $type',
+          );
           await _repository.removeReaction(_scheduleId, userId);
 
-          final reactionId =
-              await _repository.addReaction(_scheduleId, userId, type);
+          final reactionId = await _repository.addReaction(
+            _scheduleId,
+            userId,
+            type,
+          );
 
           final latestReactions = state.reactions
               .where((reaction) => reaction.userId != userId)
@@ -162,13 +176,15 @@ class ScheduleInteractionNotifier
           ];
 
           AppLogger.debug(
-              'Optimistically updating state after changing reaction: ${updatedReactions.length} reactions');
+            'Optimistically updating state after changing reaction: ${updatedReactions.length} reactions',
+          );
           if (!mounted) return;
           state = state.copyWith(isLoading: false, reactions: updatedReactions);
 
           if (userId != schedule.ownerId) {
             AppLogger.debug(
-                'Creating notification for reaction update - fromUserId: $userId, toUserId: ${schedule.ownerId}');
+              'Creating notification for reaction update - fromUserId: $userId, toUserId: ${schedule.ownerId}',
+            );
             await _ref
                 .read(notificationNotifierProvider.notifier)
                 .createReactionNotification(
@@ -190,16 +206,21 @@ class ScheduleInteractionNotifier
             }
 
             AppLogger.debug(
-                'Notification created successfully for reaction update');
+              'Notification created successfully for reaction update',
+            );
           } else {
             AppLogger.debug(
-                'Skipping notification creation - user is the schedule owner');
+              'Skipping notification creation - user is the schedule owner',
+            );
           }
         }
       } else {
         AppLogger.debug('Adding new reaction');
-        final reactionId =
-            await _repository.addReaction(_scheduleId, userId, type);
+        final reactionId = await _repository.addReaction(
+          _scheduleId,
+          userId,
+          type,
+        );
 
         final newReaction = ScheduleReaction(
           id: reactionId,
@@ -215,13 +236,15 @@ class ScheduleInteractionNotifier
             .toList();
         final updatedReactions = [...latestReactions, newReaction];
         AppLogger.debug(
-            'Optimistically updating state after adding reaction: ${updatedReactions.length} reactions');
+          'Optimistically updating state after adding reaction: ${updatedReactions.length} reactions',
+        );
         if (!mounted) return;
         state = state.copyWith(isLoading: false, reactions: updatedReactions);
 
         if (userId != schedule.ownerId) {
           AppLogger.debug(
-              'Creating notification for new reaction - fromUserId: $userId, toUserId: ${schedule.ownerId}');
+            'Creating notification for new reaction - fromUserId: $userId, toUserId: ${schedule.ownerId}',
+          );
           await _ref
               .read(notificationNotifierProvider.notifier)
               .createReactionNotification(
@@ -245,12 +268,14 @@ class ScheduleInteractionNotifier
           AppLogger.debug('Notification created successfully for new reaction');
         } else {
           AppLogger.debug(
-              'Skipping notification creation - user is the schedule owner');
+            'Skipping notification creation - user is the schedule owner',
+          );
         }
       }
 
       AppLogger.debug(
-          'Final state after reaction update: ${state.reactions.length} reactions');
+        'Final state after reaction update: ${state.reactions.length} reactions',
+      );
     } catch (e, stack) {
       AppLogger.error('Error in toggleReaction: $e');
       AppLogger.error('Stack trace: $stack');
@@ -264,8 +289,9 @@ class ScheduleInteractionNotifier
     try {
       state = state.copyWith(isLoading: true, error: null);
 
-      final scheduleStream =
-          _ref.read(scheduleRepositoryProvider).watchSchedule(_scheduleId);
+      final scheduleStream = _ref
+          .read(scheduleRepositoryProvider)
+          .watchSchedule(_scheduleId);
       final schedule = await scheduleStream.first;
       if (!mounted) {
         return;
@@ -282,16 +308,47 @@ class ScheduleInteractionNotifier
         throw Exception('User not found');
       }
 
-      final commentId =
-          await _repository.addComment(_scheduleId, userId, content);
-
-      // TODO: 通知機能は後で実装
+      final commentId = await _repository.addComment(
+        _scheduleId,
+        userId,
+        content,
+      );
       AppLogger.debug('Comment added: $commentId');
 
       if (!mounted) {
         return;
       }
       state = state.copyWith(isLoading: false);
+
+      if (userId != schedule.ownerId) {
+        AppLogger.debug(
+          'Creating notification for comment - fromUserId: $userId, toUserId: ${schedule.ownerId}',
+        );
+        await _ref
+            .read(notificationNotifierProvider.notifier)
+            .createCommentNotification(
+              toUserId: schedule.ownerId,
+              fromUserId: userId,
+              scheduleId: _scheduleId,
+              interactionId: commentId,
+              fromUserDisplayName: userDoc.displayName,
+            );
+        if (!mounted) return;
+        if (_enablePushNotifications && _pushNotificationSender != null) {
+          await _pushNotificationSender!.sendCommentNotification(
+            toUserId: schedule.ownerId,
+            fromUserId: userId,
+            fromUserName: userDoc.displayName,
+            scheduleId: _scheduleId,
+            interactionId: commentId,
+          );
+        }
+        AppLogger.debug('Notification created successfully for comment');
+      } else {
+        AppLogger.debug(
+          'Skipping comment notification creation - user is the schedule owner',
+        );
+      }
     } catch (e) {
       if (mounted) {
         state = state.copyWith(isLoading: false, error: e.toString());
@@ -305,7 +362,8 @@ class ScheduleInteractionNotifier
   Future<void> deleteComment(String commentId) async {
     try {
       AppLogger.debug(
-          'Deleting comment - scheduleId: $_scheduleId, commentId: $commentId');
+        'Deleting comment - scheduleId: $_scheduleId, commentId: $commentId',
+      );
       await _repository.deleteComment(_scheduleId, commentId);
 
       AppLogger.debug('Successfully deleted comment: $commentId');

--- a/lib/application/schedule/schedule_interaction_notifier.dart
+++ b/lib/application/schedule/schedule_interaction_notifier.dart
@@ -12,18 +12,18 @@ import '../../infrastructure/firebase/push_notification_sender.dart';
 
 final scheduleInteractionNotifierProvider = StateNotifierProvider.autoDispose
     .family<ScheduleInteractionNotifier, ScheduleInteractionState, String>((
-      ref,
-      scheduleId,
-    ) {
-      ref.watch(repositorySessionKeyProvider);
+  ref,
+  scheduleId,
+) {
+  ref.watch(repositorySessionKeyProvider);
 
-      return ScheduleInteractionNotifier(
-        ref.watch(scheduleInteractionRepositoryProvider),
-        scheduleId,
-        ref,
-        pushNotificationSender: ref.watch(pushNotificationSenderProvider),
-      );
-    });
+  return ScheduleInteractionNotifier(
+    ref.watch(scheduleInteractionRepositoryProvider),
+    scheduleId,
+    ref,
+    pushNotificationSender: ref.watch(pushNotificationSenderProvider),
+  );
+});
 
 class ScheduleInteractionNotifier
     extends StateNotifier<ScheduleInteractionState> {
@@ -33,8 +33,8 @@ class ScheduleInteractionNotifier
     this._ref, {
     PushNotificationSender? pushNotificationSender,
     bool enablePushNotifications = true,
-  }) : _enablePushNotifications = enablePushNotifications,
-       super(const ScheduleInteractionState()) {
+  })  : _enablePushNotifications = enablePushNotifications,
+        super(const ScheduleInteractionState()) {
     if (_enablePushNotifications) {
       _pushNotificationSender =
           pushNotificationSender ?? PushNotificationSender();
@@ -61,31 +61,27 @@ class ScheduleInteractionNotifier
         throw Exception('User not authenticated');
       }
 
-      _reactionsSubscription = _repository
-          .watchReactions(_scheduleId)
-          .listen(
-            (reactions) {
-              if (!mounted) return;
-              state = state.copyWith(reactions: reactions);
-            },
-            onError: (error) {
-              if (!mounted) return;
-              state = state.copyWith(error: error.toString());
-            },
-          );
+      _reactionsSubscription = _repository.watchReactions(_scheduleId).listen(
+        (reactions) {
+          if (!mounted) return;
+          state = state.copyWith(reactions: reactions);
+        },
+        onError: (error) {
+          if (!mounted) return;
+          state = state.copyWith(error: error.toString());
+        },
+      );
 
-      _commentsSubscription = _repository
-          .watchComments(_scheduleId)
-          .listen(
-            (comments) {
-              if (!mounted) return;
-              state = state.copyWith(comments: comments);
-            },
-            onError: (error) {
-              if (!mounted) return;
-              state = state.copyWith(error: error.toString());
-            },
-          );
+      _commentsSubscription = _repository.watchComments(_scheduleId).listen(
+        (comments) {
+          if (!mounted) return;
+          state = state.copyWith(comments: comments);
+        },
+        onError: (error) {
+          if (!mounted) return;
+          state = state.copyWith(error: error.toString());
+        },
+      );
     } catch (e) {
       AppLogger.error('Error initializing subscriptions: $e');
       if (mounted) {
@@ -106,9 +102,8 @@ class ScheduleInteractionNotifier
 
       state = state.copyWith(isLoading: true, error: null);
 
-      final scheduleStream = _ref
-          .read(scheduleRepositoryProvider)
-          .watchSchedule(_scheduleId);
+      final scheduleStream =
+          _ref.read(scheduleRepositoryProvider).watchSchedule(_scheduleId);
       final schedule = await scheduleStream.first;
       if (!mounted) {
         return;
@@ -140,9 +135,8 @@ class ScheduleInteractionNotifier
           await _repository.removeReaction(_scheduleId, userId);
 
           final latestReactions = state.reactions;
-          final updatedReactions = latestReactions
-              .where((r) => r.userId != userId)
-              .toList();
+          final updatedReactions =
+              latestReactions.where((r) => r.userId != userId).toList();
           AppLogger.debug(
             'Optimistically updating state after removing reaction: ${updatedReactions.length} reactions',
           );
@@ -289,9 +283,8 @@ class ScheduleInteractionNotifier
     try {
       state = state.copyWith(isLoading: true, error: null);
 
-      final scheduleStream = _ref
-          .read(scheduleRepositoryProvider)
-          .watchSchedule(_scheduleId);
+      final scheduleStream =
+          _ref.read(scheduleRepositoryProvider).watchSchedule(_scheduleId);
       final schedule = await scheduleStream.first;
       if (!mounted) {
         return;

--- a/lib/application/schedule/schedule_interaction_notifier.dart
+++ b/lib/application/schedule/schedule_interaction_notifier.dart
@@ -326,16 +326,6 @@ class ScheduleInteractionNotifier
               interactionId: commentId,
               fromUserDisplayName: userDoc.displayName,
             );
-        if (!mounted) return;
-        if (_enablePushNotifications && _pushNotificationSender != null) {
-          await _pushNotificationSender!.sendCommentNotification(
-            toUserId: schedule.ownerId,
-            fromUserId: userId,
-            fromUserName: userDoc.displayName,
-            scheduleId: _scheduleId,
-            interactionId: commentId,
-          );
-        }
         AppLogger.debug('Notification created successfully for comment');
       } else {
         AppLogger.debug(

--- a/lib/infrastructure/schedule_interaction_repository.dart
+++ b/lib/infrastructure/schedule_interaction_repository.dart
@@ -20,50 +20,6 @@ class ScheduleInteractionRepository implements IScheduleInteractionRepository {
   /// Firestoreのインスタンス
   final FirebaseFirestore _firestore;
 
-  /// スケジュールのカウンターを更新する内部メソッド
-  Future<void> _updateScheduleCounters(String scheduleId) async {
-    AppLogger.debug('Updating schedule counters for scheduleId: $scheduleId');
-
-    try {
-      await _firestore.runTransaction((transaction) async {
-        final scheduleRef = _firestore.collection('schedules').doc(scheduleId);
-
-        // リアクション数を取得
-        final reactionsSnapshot = await _firestore
-            .collection('schedules')
-            .doc(scheduleId)
-            .collection('reactions')
-            .get();
-        final reactionCount = reactionsSnapshot.docs.length;
-        AppLogger.debug('Current reaction count: $reactionCount');
-
-        // コメント数を取得
-        final commentsSnapshot = await _firestore
-            .collection('schedules')
-            .doc(scheduleId)
-            .collection('comments')
-            .get();
-        final commentCount = commentsSnapshot.docs.length;
-        AppLogger.debug('Current comment count: $commentCount');
-
-        // スケジュールドキュメントを更新
-        transaction.update(scheduleRef, {
-          'reactionCount': reactionCount,
-          'commentCount': commentCount,
-          'updatedAt': FieldValue.serverTimestamp(),
-        });
-
-        AppLogger.debug('Schedule counters updated in transaction');
-      }, maxAttempts: 3);
-
-      AppLogger.debug('Schedule counters transaction completed successfully');
-    } catch (e, stack) {
-      AppLogger.error('Error updating schedule counters: $e');
-      AppLogger.error('Stack trace: $stack');
-      rethrow;
-    }
-  }
-
   /// 指定された[scheduleId]に関連する全リアクションを取得
   ///
   /// Firestoreから`schedules/{scheduleId}/reactions`コレクションの
@@ -131,8 +87,7 @@ class ScheduleInteractionRepository implements IScheduleInteractionRepository {
     AppLogger.debug(
         'addReaction: Successfully added reaction with createdAt: $now');
 
-    // カウンターはCloud Functionsで自動的に更新されるため削除
-    // await _updateScheduleCounters(scheduleId);
+    // カウンターはCloud Functionsで自動的に更新される
     AppLogger.debug(
         'Reaction added - counter will be updated by Cloud Functions');
 
@@ -154,8 +109,7 @@ class ScheduleInteractionRepository implements IScheduleInteractionRepository {
         .delete();
     AppLogger.debug('Successfully removed reaction for user: $userId');
 
-    // カウンターはCloud Functionsで自動的に更新されるため削除
-    // await _updateScheduleCounters(scheduleId);
+    // カウンターはCloud Functionsで自動的に更新される
     AppLogger.debug(
         'Reaction removed - counter will be updated by Cloud Functions');
   }
@@ -320,8 +274,10 @@ class ScheduleInteractionRepository implements IScheduleInteractionRepository {
           .add(commentData);
       AppLogger.debug('Comment added successfully with ID: ${docRef.id}');
 
-      // カウンターを更新
-      await _updateScheduleCounters(scheduleId);
+      // カウンターはCloud Functionsで自動的に更新される
+      AppLogger.debug(
+        'Comment added - counter will be updated by Cloud Functions',
+      );
 
       return docRef.id;
     } catch (e, stackTrace) {
@@ -346,10 +302,9 @@ class ScheduleInteractionRepository implements IScheduleInteractionRepository {
         .delete();
     AppLogger.debug('Successfully deleted comment: $commentId');
 
-    // カウンターはCloud Functionsで自動的に更新されるため削除
-    // await _updateScheduleCounters(scheduleId);
+    // カウンターはCloud Functionsで自動的に更新される
     AppLogger.debug(
-        'Reaction removed - counter will be updated by Cloud Functions');
+        'Comment removed - counter will be updated by Cloud Functions');
   }
 
   /// 指定された[scheduleId]と[commentId]に対応するコメントを更新

--- a/lib/presentation/list/list_edit_page.dart
+++ b/lib/presentation/list/list_edit_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:image_picker/image_picker.dart';
 import '../../application/list/list_notifier.dart';
 import '../../domain/entity/list.dart';
+import '../../infrastructure/providers.dart';
 import 'list_edit_save_action.dart';
 import 'list_member_profile_tile.dart';
 import 'list_providers.dart';
@@ -35,31 +36,65 @@ class _ListEditPageState extends ConsumerState<ListEditPage> {
   }
 
   Future<void> _pickImage() async {
-    final ImagePicker picker = ImagePicker();
-    final XFile? image = await picker.pickImage(source: ImageSource.gallery);
+    try {
+      final ImagePicker picker = ImagePicker();
+      final XFile? image = await picker.pickImage(source: ImageSource.gallery);
+      if (image == null) {
+        return;
+      }
 
-    if (image != null) {
+      final sourceFile = File(image.path);
+      final croppedImage = await ref
+          .read(imageCropperServiceProvider)
+          .cropImage(sourceFile: sourceFile, aspectRatioX: 1, aspectRatioY: 1);
+      if (croppedImage == null) {
+        return;
+      }
+
+      final compressedImage =
+          await ref.read(imageProcessorServiceProvider).compressImage(
+                croppedImage,
+                minWidth: 1024,
+                minHeight: 1024,
+                quality: 90,
+              );
+
+      if (!mounted) {
+        return;
+      }
       setState(() {
-        _selectedImage = File(image.path);
+        _selectedImage = compressedImage;
       });
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('画像の選択に失敗しました: ${e.toString()}')),
+        );
+      }
     }
   }
 
   Future<void> _saveChanges(UserList currentList) async {
     if (_nameController.text.trim().isEmpty) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('リスト名を入力してください')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('リスト名を入力してください')));
       return;
     }
 
     setState(() => _isLoading = true);
 
     try {
-      final String? newIconUrl = currentList.iconUrl;
+      String? newIconUrl = currentList.iconUrl;
       if (_selectedImage != null) {
-        // 画像のアップロード処理を実装
-        // newIconUrl = await uploadImage(_selectedImage!);
+        newIconUrl = await ref.read(storageServiceProvider).uploadFile(
+          path: 'v1/lists/icon/${currentList.ownerId}/${currentList.id}',
+          file: _selectedImage!,
+          metadata: {
+            'ownerId': currentList.ownerId,
+            'listId': currentList.id,
+          },
+        );
       }
 
       // メンバーリストの更新
@@ -86,9 +121,9 @@ class _ListEditPageState extends ConsumerState<ListEditPage> {
       }
     } catch (e) {
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('更新に失敗しました: ${e.toString()}')),
-        );
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('更新に失敗しました: ${e.toString()}')));
       }
     } finally {
       if (mounted) {
@@ -141,8 +176,10 @@ class _ListEditPageState extends ConsumerState<ListEditPage> {
                       child: CircleAvatar(
                         backgroundColor: theme.primaryColor,
                         child: IconButton(
-                          icon:
-                              const Icon(Icons.camera_alt, color: Colors.white),
+                          icon: const Icon(
+                            Icons.camera_alt,
+                            color: Colors.white,
+                          ),
                           onPressed: _pickImage,
                         ),
                       ),
@@ -168,10 +205,7 @@ class _ListEditPageState extends ConsumerState<ListEditPage> {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text(
-                    '除外する友人を選択してください',
-                    style: theme.textTheme.titleMedium,
-                  ),
+                  Text('除外する友人を選択してください', style: theme.textTheme.titleMedium),
                   const SizedBox(height: 8),
                   ListView.builder(
                     shrinkWrap: true,

--- a/test/application/schedule/schedule_interaction_notifier_test.dart
+++ b/test/application/schedule/schedule_interaction_notifier_test.dart
@@ -246,6 +246,14 @@ class _FakeNotificationNotifier extends notification.NotificationNotifier {
           ref,
         );
 
+  int reactionNotificationCallCount = 0;
+  int commentNotificationCallCount = 0;
+  String? lastCommentToUserId;
+  String? lastCommentFromUserId;
+  String? lastCommentScheduleId;
+  String? lastCommentInteractionId;
+  String? lastCommentFromUserDisplayName;
+
   @override
   Future<void> createReactionNotification({
     required String toUserId,
@@ -253,7 +261,9 @@ class _FakeNotificationNotifier extends notification.NotificationNotifier {
     required String scheduleId,
     required String interactionId,
     String? fromUserDisplayName,
-  }) async {}
+  }) async {
+    reactionNotificationCallCount++;
+  }
 
   @override
   Future<void> createCommentNotification({
@@ -262,7 +272,14 @@ class _FakeNotificationNotifier extends notification.NotificationNotifier {
     required String scheduleId,
     required String interactionId,
     String? fromUserDisplayName,
-  }) async {}
+  }) async {
+    commentNotificationCallCount++;
+    lastCommentToUserId = toUserId;
+    lastCommentFromUserId = fromUserId;
+    lastCommentScheduleId = scheduleId;
+    lastCommentInteractionId = interactionId;
+    lastCommentFromUserDisplayName = fromUserDisplayName;
+  }
 }
 
 class _FakeScheduleInteractionRepository
@@ -310,6 +327,10 @@ class _FakeScheduleInteractionRepository
 
   Completer<String>? addReactionCompleter;
   int addReactionCallCount = 0;
+  int addCommentCallCount = 0;
+  String? lastCommentScheduleId;
+  String? lastCommentUserId;
+  String? lastCommentContent;
   int _reactionCancelCount = 0;
   int _commentListenCount = 0;
   int _commentCancelCount = 0;
@@ -385,7 +406,12 @@ class _FakeScheduleInteractionRepository
 
   @override
   Future<String> addComment(String scheduleId, String userId, String content) =>
-      Future.error(UnimplementedError());
+      Future.value('comment-${++addCommentCallCount}').then((commentId) {
+        lastCommentScheduleId = scheduleId;
+        lastCommentUserId = userId;
+        lastCommentContent = content;
+        return commentId;
+      });
 
   @override
   Future<void> deleteComment(String scheduleId, String commentId) =>
@@ -638,6 +664,197 @@ void main() {
         expect(repository.addReactionCallCount, 0);
         expect(finalState.isLoading, isFalse);
         expect(finalState.reactions, isEmpty);
+      },
+    );
+
+    test(
+      'addComment should create a comment notification for schedule owner',
+      () async {
+        final user = UserModel(
+          publicProfile: PublicUserModel(
+            id: 'user-1',
+            displayName: 'User One',
+            searchId: UserId('USRTEST1'),
+            iconUrl: null,
+            shortBio: null,
+          ),
+          privateProfile: PrivateUserModel(
+            id: 'user-1',
+            name: 'User One',
+            friends: const [],
+            groups: const [],
+            lists: const [],
+            createdAt: DateTime(2024, 1, 1),
+          ),
+        );
+
+        final schedule = Schedule(
+          id: 'schedule-1',
+          title: 'Sample',
+          description: 'Desc',
+          startDateTime: DateTime(2024, 1, 1, 10),
+          endDateTime: DateTime(2024, 1, 1, 12),
+          ownerId: 'owner-1',
+          ownerDisplayName: 'Owner',
+          sharedLists: const [],
+          visibleTo: const [],
+          createdAt: DateTime(2024, 1, 1),
+          updatedAt: DateTime(2024, 1, 1),
+        );
+
+        final repository = _FakeScheduleInteractionRepository();
+        addTearDown(repository.dispose);
+        late _FakeNotificationNotifier fakeNotificationNotifier;
+
+        final container = ProviderContainer(
+          overrides: [
+            auth.authNotifierProvider.overrideWith(
+              () => _StubAuthNotifier(AuthState.authenticated(user)),
+            ),
+            scheduleInteractionRepositoryProvider.overrideWithValue(repository),
+            scheduleInteractionNotifierProvider.overrideWith((ref, scheduleId) {
+              return ScheduleInteractionNotifier(
+                ref.watch(scheduleInteractionRepositoryProvider),
+                scheduleId,
+                ref,
+                enablePushNotifications: false,
+              );
+            }),
+            scheduleRepositoryProvider.overrideWithValue(
+              _FakeScheduleRepository(schedule),
+            ),
+            userRepositoryProvider.overrideWithValue(_FakeUserRepository(user)),
+            notification.notificationRepositoryProvider.overrideWithValue(
+              _FakeNotificationRepository(),
+            ),
+            notification.pushNotificationSenderProvider.overrideWithValue(
+              PushNotificationSender(
+                cloudFunctionUrl: 'https://example.test/push',
+                tokenResolver: (_) async => const [],
+              ),
+            ),
+            notification.notificationNotifierProvider.overrideWith((ref) {
+              fakeNotificationNotifier = _FakeNotificationNotifier(ref);
+              return fakeNotificationNotifier;
+            }),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        final provider = scheduleInteractionNotifierProvider(schedule.id);
+        final subscription = container.listen(
+          provider,
+          (_, __) {},
+          fireImmediately: true,
+        );
+        addTearDown(subscription.close);
+        await repository.waitForCommentListener();
+
+        await container.read(provider.notifier).addComment(user.id, 'hello');
+
+        expect(repository.addCommentCallCount, 1);
+        expect(repository.lastCommentScheduleId, schedule.id);
+        expect(repository.lastCommentUserId, user.id);
+        expect(repository.lastCommentContent, 'hello');
+        expect(fakeNotificationNotifier.commentNotificationCallCount, 1);
+        expect(fakeNotificationNotifier.lastCommentToUserId, schedule.ownerId);
+        expect(fakeNotificationNotifier.lastCommentFromUserId, user.id);
+        expect(fakeNotificationNotifier.lastCommentScheduleId, schedule.id);
+        expect(fakeNotificationNotifier.lastCommentInteractionId, 'comment-1');
+        expect(
+          fakeNotificationNotifier.lastCommentFromUserDisplayName,
+          user.displayName,
+        );
+      },
+    );
+
+    test(
+      'addComment should skip notification when commenter is schedule owner',
+      () async {
+        final user = UserModel(
+          publicProfile: PublicUserModel(
+            id: 'owner-1',
+            displayName: 'Owner',
+            searchId: UserId('OWNER001'),
+            iconUrl: null,
+            shortBio: null,
+          ),
+          privateProfile: PrivateUserModel(
+            id: 'owner-1',
+            name: 'Owner',
+            friends: const [],
+            groups: const [],
+            lists: const [],
+            createdAt: DateTime(2024, 1, 1),
+          ),
+        );
+
+        final schedule = Schedule(
+          id: 'schedule-1',
+          title: 'Sample',
+          description: 'Desc',
+          startDateTime: DateTime(2024, 1, 1, 10),
+          endDateTime: DateTime(2024, 1, 1, 12),
+          ownerId: user.id,
+          ownerDisplayName: user.displayName,
+          sharedLists: const [],
+          visibleTo: const [],
+          createdAt: DateTime(2024, 1, 1),
+          updatedAt: DateTime(2024, 1, 1),
+        );
+
+        final repository = _FakeScheduleInteractionRepository();
+        addTearDown(repository.dispose);
+        var notificationNotifierWasCreated = false;
+
+        final container = ProviderContainer(
+          overrides: [
+            auth.authNotifierProvider.overrideWith(
+              () => _StubAuthNotifier(AuthState.authenticated(user)),
+            ),
+            scheduleInteractionRepositoryProvider.overrideWithValue(repository),
+            scheduleInteractionNotifierProvider.overrideWith((ref, scheduleId) {
+              return ScheduleInteractionNotifier(
+                ref.watch(scheduleInteractionRepositoryProvider),
+                scheduleId,
+                ref,
+                enablePushNotifications: false,
+              );
+            }),
+            scheduleRepositoryProvider.overrideWithValue(
+              _FakeScheduleRepository(schedule),
+            ),
+            userRepositoryProvider.overrideWithValue(_FakeUserRepository(user)),
+            notification.notificationRepositoryProvider.overrideWithValue(
+              _FakeNotificationRepository(),
+            ),
+            notification.pushNotificationSenderProvider.overrideWithValue(
+              PushNotificationSender(
+                cloudFunctionUrl: 'https://example.test/push',
+                tokenResolver: (_) async => const [],
+              ),
+            ),
+            notification.notificationNotifierProvider.overrideWith((ref) {
+              notificationNotifierWasCreated = true;
+              return _FakeNotificationNotifier(ref);
+            }),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        final provider = scheduleInteractionNotifierProvider(schedule.id);
+        final subscription = container.listen(
+          provider,
+          (_, __) {},
+          fireImmediately: true,
+        );
+        addTearDown(subscription.close);
+        await repository.waitForCommentListener();
+
+        await container.read(provider.notifier).addComment(user.id, 'memo');
+
+        expect(repository.addCommentCallCount, 1);
+        expect(notificationNotifierWasCreated, isFalse);
       },
     );
 


### PR DESCRIPTION
## Summary
- コメント追加時にコメント通知を作成し、予定作成者本人のコメントでは通知をスキップする
- リスト編集の画像選択で正方形cropと圧縮を行い、保存時にStorageへリストアイコンをアップロードする
- コメント通知の回帰テストを追加

## Root Cause
- コメント追加処理はコメント保存後に通知作成がTODOのままで、`notifications` ドキュメントが作られていなかった
- リスト編集画面は画像を選択してプレビューするだけで、cropperもStorage uploadも呼んでいなかった

## Validation
- `fvm dart format lib/application/schedule/schedule_interaction_notifier.dart lib/presentation/list/list_edit_page.dart test/application/schedule/schedule_interaction_notifier_test.dart`
- `fvm flutter test test/application/schedule/schedule_interaction_notifier_test.dart test/presentation/list/list_edit_page_test.dart --dart-define=FLUTTER_TEST=true`
- `fvm flutter analyze`
- `git diff --check`

## Related
- Companion Firebase rules PR: keishimizu26629/LaKiite-firebase-commons#29

Closes #262
Closes #263

