### PR TITLE
feat: schedules の詳細をE2EEで暗号化する

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -37,6 +37,9 @@ Web公開用のファイル（プライバシーポリシー、利用規約な�
 - プッシュ通知
 - AdMob広告統合
 
+### 機能仕様
+- [予定暗号化 Firestore フィールド](./schedule-encryption-fields.md)
+
 ## 🔗 関連リンク
 
 - [Web公開ファイル](/web/) - GitHub Pages用ファイル

--- a/docs/schedule-encryption-fields.md
+++ b/docs/schedule-encryption-fields.md
@@ -1,0 +1,267 @@
+# 予定暗号化 Firestore フィールド
+
+更新日: 2026-06-11
+
+## 対象読者
+
+- 予定・コメントの暗号化実装を触る開発者
+- Firestore 上の schedule / comment ドキュメントを調査する開発者
+- 移行期間中の `pending` / `migration` フィールドの意味を確認したい運用者
+
+## 目的
+
+暗号化された予定とコメントの Firestore フィールドについて、どの値が何を意味し、復号や公開範囲制御にどう使われるかを整理する。
+
+実データの暗号文、URL、秘密値はこのドキュメントには載せない。ここでは構造と意味だけを扱う。
+
+## 全体像
+
+予定は、本文と鍵を分けて保存する。
+
+- `encryptedPayload`: 予定本文を暗号化したもの
+- `encryptedKeys`: ユーザーごとに暗号化した予定鍵
+- `migrationEncryptedKeys`: 移行期間用の公開鍵で暗号化した予定鍵
+- `pendingEncryptedRecipients`: まだ公開鍵がなく、後から公開対象に昇格するユーザー
+
+コメントは、親予定の予定鍵を使ってコメント本文だけを暗号化する。コメントごとの `encryptedKeys` は持たない。
+
+## 用語
+
+### ユーザー鍵
+
+ユーザー単位の X25519 鍵ペア。
+
+- 公開鍵は `users/{uid}/encryption/current.publicKey` に保存される。
+- 秘密鍵は端末ローカルに保存される。
+- バックアップ設定済みの場合、秘密鍵はパスワード由来鍵で暗号化され、`encryptedPrivateKeyBackup` として Firestore に保存される。
+
+### 予定鍵
+
+予定ごとに生成される 32 byte の AES-GCM 鍵。予定本文とコメント本文の暗号化に使う。
+
+予定鍵自体は平文保存しない。閲覧可能なユーザーごとに、そのユーザーの公開鍵で暗号化して `encryptedKeys.{uid}` に保存する。
+
+### 移行用鍵
+
+公開鍵をまだ持っていないユーザーがいる移行期間のための共通鍵ペア。
+
+- 公開鍵は `encryptionMigration/current` に保存される。
+- 秘密鍵は Secret Manager の `SCHEDULE_MIGRATION_PRIVATE_KEY` に保存される。
+- クライアントは移行用公開鍵だけを読み、予定鍵を `migrationEncryptedKeys` に保存する。
+- Functions は移行用秘密鍵で予定鍵を復号し、後から公開鍵が作られたユーザー向けに `encryptedKeys.{uid}` を作る。
+
+## schedules/{scheduleId}
+
+### 通常フィールド
+
+| フィールド | 型 | 意味 |
+| --- | --- | --- |
+| `ownerId` | string | 予定作成者の UID。 |
+| `ownerDisplayName` | string | 予定作成時点の作成者表示名。 |
+| `ownerPhotoUrl` | string/null | 予定作成時点の作成者アイコン URL。 |
+| `startDateTime` | string | 開始日時。現行 mapper では ISO 8601 string として保存する。 |
+| `endDateTime` | string | 終了日時。現行 mapper では ISO 8601 string として保存する。 |
+| `isAllDay` | boolean | 終日予定かどうか。 |
+| `sharedLists` | array<string> | 予定を公開するリスト ID。 |
+| `visibleTo` | array<string> | Firestore Rules とクエリで参照する閲覧可能ユーザー UID。クライアント作成・更新時は owner のみを初期値として送り、Functions が `sharedLists` からサーバー側で再計算する。暗号化予定では「復号可能なユーザー」だけを入れる。 |
+| `reactionCount` | int | リアクション数のキャッシュ。Functions で更新される。 |
+| `commentCount` | int | コメント数のキャッシュ。Functions で更新される。 |
+| `createdAt` | string | 作成日時。現行 mapper では ISO 8601 string として保存する。 |
+| `updatedAt` | string/timestamp | 更新日時。クライアント作成時は ISO 8601 string、Functions 更新時は server timestamp になることがある。 |
+
+### 暗号化フラグ
+
+| フィールド | 型 | 意味 |
+| --- | --- | --- |
+| `encrypted` | boolean | `true` の場合、この予定の `title` / `description` / `location` は平文フィールドではなく `encryptedPayload` から復号する。 |
+| `encryptionVersion` | int | 予定暗号化スキーマのバージョン。現行は `1`。 |
+
+`encrypted != true` の既存予定は後方互換として平文の `title` / `description` / `location` を読む。
+
+### encryptedPayload
+
+予定本文を予定鍵で AES-GCM 暗号化した payload。
+
+暗号化前の JSON は次の形。
+
+```json
+{
+  "title": "予定タイトル",
+  "description": "説明",
+  "location": "場所またはnull"
+}
+```
+
+Firestore 上の構造。
+
+| フィールド | 型 | 意味 |
+| --- | --- | --- |
+| `encryptedPayload.algorithm` | string | 本文暗号化方式。現行は `AES-GCM`。 |
+| `encryptedPayload.cipherText` | string | 暗号化された本文 JSON。Base64 URL エンコード。 |
+| `encryptedPayload.nonce` | string | AES-GCM nonce。Base64 URL エンコード。 |
+| `encryptedPayload.mac` | string | AES-GCM authentication tag。Base64 URL エンコード。 |
+
+クライアントは `encryptedKeys.{currentUserId}` から予定鍵を復号し、その予定鍵で `encryptedPayload` を復号する。
+
+### encryptedKeys
+
+予定鍵をユーザーごとの公開鍵で暗号化した map。
+
+キーは UID。値は `ScheduleEncryptedKey`。
+
+```json
+{
+  "{uid}": {
+    "algorithm": "X25519+AES-GCM",
+    "encryptedScheduleKey": "...",
+    "ephemeralPublicKey": "...",
+    "keyVersion": 1,
+    "mac": "...",
+    "nonce": "..."
+  }
+}
+```
+
+| フィールド | 型 | 意味 |
+| --- | --- | --- |
+| `encryptedKeys.{uid}.algorithm` | string | 予定鍵のラップ方式。現行は `X25519+AES-GCM`。 |
+| `encryptedKeys.{uid}.encryptedScheduleKey` | string | 対象ユーザー向けに暗号化された予定鍵。 |
+| `encryptedKeys.{uid}.ephemeralPublicKey` | string | 鍵交換に使う一時公開鍵。 |
+| `encryptedKeys.{uid}.keyVersion` | int | 対象ユーザーの公開鍵バージョン。現行は `1`。 |
+| `encryptedKeys.{uid}.nonce` | string | 予定鍵ラップ用 AES-GCM nonce。 |
+| `encryptedKeys.{uid}.mac` | string | 予定鍵ラップ用 AES-GCM authentication tag。 |
+
+`encryptedKeys.{currentUserId}` がない暗号化予定は、そのユーザーの端末では復号できない。クライアントは壊れた予定として表示せず、基本的に一覧から除外する。
+
+### migrationEncryptedKeys
+
+移行用公開鍵で暗号化した予定鍵。
+
+公開先リストに公開鍵を持っていないユーザーがいる場合、またはリスト公開予定の場合に保存される。これにより、後から対象ユーザーの公開鍵が作られたときに Functions が `encryptedKeys.{uid}` を作れる。
+
+```json
+{
+  "schedule-migration-v1": {
+    "algorithm": "X25519+AES-GCM",
+    "encryptedScheduleKey": "...",
+    "ephemeralPublicKey": "...",
+    "keyVersion": 1,
+    "mac": "...",
+    "nonce": "..."
+  }
+}
+```
+
+| フィールド | 型 | 意味 |
+| --- | --- | --- |
+| `migrationEncryptedKeys.{keyId}` | map | 移行用鍵 ID ごとに暗号化した予定鍵。現行 keyId は `schedule-migration-v1`。 |
+| `migrationEncryptedKeys.{keyId}.*` | map | 構造は `encryptedKeys.{uid}` と同じ。宛先がユーザー公開鍵ではなく移行用公開鍵になる。 |
+
+`migrationEncryptedKeys` はユーザー端末で予定を復号するためのものではない。Functions が pending ユーザーを後から復号可能にするために使う。
+
+### pendingEncryptedRecipientIds
+
+公開予定だったが、作成時点で公開鍵がなかったユーザー UID の配列。
+
+Functions は `array-contains` クエリでこのフィールドを検索し、対象ユーザーの公開鍵が作られたときに `encryptedKeys.{uid}` と `visibleTo` を更新する。
+
+### pendingEncryptedRecipients
+
+`pendingEncryptedRecipientIds` の詳細 map。
+
+```json
+{
+  "{uid}": {
+    "reason": "missingPublicKey",
+    "migrationKeyId": "schedule-migration-v1",
+    "sharedListIds": ["{listId}"]
+  }
+}
+```
+
+| フィールド | 型 | 意味 |
+| --- | --- | --- |
+| `pendingEncryptedRecipients.{uid}.reason` | string | pending 理由。現行は `missingPublicKey`。 |
+| `pendingEncryptedRecipients.{uid}.migrationKeyId` | string | 対応する `migrationEncryptedKeys` の keyId。 |
+| `pendingEncryptedRecipients.{uid}.sharedListIds` | array<string> | このユーザーが pending になった共有リスト ID。 |
+
+公開鍵が作られて Functions が成功すると、対象 UID は `pendingEncryptedRecipientIds` と `pendingEncryptedRecipients` から削除され、`visibleTo` と `encryptedKeys` に追加される。
+
+## schedules/{scheduleId}/comments/{commentId}
+
+コメントは親予定の予定鍵で本文だけを暗号化する。コメント doc には `encryptedKeys` を持たない。
+
+### 通常フィールド
+
+| フィールド | 型 | 意味 |
+| --- | --- | --- |
+| `userId` | string | コメント投稿者 UID。 |
+| `userDisplayName` | string/null | コメント作成時点の投稿者表示名。 |
+| `userPhotoUrl` | string/null | コメント作成時点の投稿者アイコン URL。 |
+| `createdAt` | timestamp | コメント作成日時。 |
+| `updatedAt` | timestamp | コメント更新日時。 |
+| `isEdited` | boolean | 編集済みかどうか。 |
+
+### 暗号化コメント
+
+| フィールド | 型 | 意味 |
+| --- | --- | --- |
+| `encrypted` | boolean | `true` の場合、本文は `encryptedContent` から復号する。 |
+| `encryptedContent.algorithm` | string | コメント本文の暗号化方式。現行は `AES-GCM`。 |
+| `encryptedContent.cipherText` | string | 暗号化されたコメント本文。Base64 URL エンコード。 |
+| `encryptedContent.nonce` | string | AES-GCM nonce。Base64 URL エンコード。 |
+| `encryptedContent.mac` | string | AES-GCM authentication tag。Base64 URL エンコード。 |
+
+復号手順は次の通り。
+
+1. 親予定 `schedules/{scheduleId}` を読む。
+2. `encryptedKeys.{currentUserId}` から予定鍵を復号する。
+3. 復号した予定鍵でコメントの `encryptedContent` を復号する。
+
+### 後方互換
+
+`encrypted != true` のコメントは平文の `content` を読む。
+
+暗号化予定でも、クライアントが親予定の予定鍵を取得できない場合は、コメント本文も復号できない。この場合は UI 上で `コメントを復号できません` にフォールバックする。
+
+## 公開先追加時の挙動
+
+### 予定作成時
+
+1. クライアントが予定鍵を生成する。
+2. `title` / `description` / `location` を `encryptedPayload` に暗号化する。
+3. クライアントは `visibleTo` に owner だけを入れる。
+4. クライアントは `encryptedKeys` に owner 向けの予定鍵だけを入れる。
+5. `sharedLists` がある暗号化予定では、移行用公開鍵で予定鍵を暗号化して `migrationEncryptedKeys` を保存する。
+6. Functions の schedule trigger が `sharedLists` を読み、owner が所有するリストの members を公開意図として再計算する。
+7. 公開鍵があるユーザーは `encryptedKeys` と `visibleTo` に追加される。
+8. 公開鍵がないユーザーは `pendingEncryptedRecipientIds` と `pendingEncryptedRecipients` に入る。
+
+クライアントから他人の UID を `visibleTo` や `encryptedKeys` に直接入れる書き込みは Security Rules で拒否する。
+
+### ユーザーの公開鍵が後から作られた時
+
+`users/{uid}/encryption/current` が作成・更新されると、Functions の `onUserEncryptionKeyWritten` が走る。
+
+1. `pendingEncryptedRecipientIds` に対象 UID を含む予定を検索する。
+2. `migrationEncryptedKeys.{migrationKeyId}` と Secret Manager の移行用秘密鍵で予定鍵を復号する。
+3. 対象 UID の公開鍵で予定鍵を再暗号化する。
+4. `encryptedKeys.{uid}` を追加する。
+5. `visibleTo` に UID を追加する。
+6. pending から UID を削除する。
+
+### リストにメンバーが後から追加された時
+
+Functions 側でリストの意図上の公開先を再計算する。
+
+- 追加メンバーに公開鍵があり、`migrationEncryptedKeys` がある場合は `encryptedKeys.{uid}` と `visibleTo` を追加する。
+- 公開鍵がない、または移行用鍵で再ラップできない場合は pending に入れる。
+
+## 注意点
+
+- `sharedLists` が公開意図の正で、`visibleTo` はサーバー生成の派生データ。
+- `visibleTo` は「本来公開したい全員」ではなく、「現時点で復号可能な公開先」を表す。
+- 本来公開したいがまだ復号できないユーザーは pending に入る。
+- `sharedLists` はリスト公開の意図を残すためのフィールドで、復号可否そのものは `encryptedKeys` で決まる。
+- `migrationEncryptedKeys` がない古い暗号化予定は、公開鍵がないユーザーや後から追加されたユーザーにサーバー側で予定鍵を再配布できない。
+- コメントは親予定の予定鍵に依存する。親予定を復号できないユーザーはコメントも復号できない。

--- a/docs/schedule-encryption-fields.md
+++ b/docs/schedule-encryption-fields.md
@@ -139,6 +139,10 @@ Firestore 上の構造。
 
 公開先リストに公開鍵を持っていないユーザーがいる場合、またはリスト公開予定の場合に保存される。これにより、後から対象ユーザーの公開鍵が作られたときに Functions が `encryptedKeys.{uid}` を作れる。
 
+`migrationEncryptedKeys` は暗号化予定に必ず入るフィールドではない。通常の復号は `encryptedKeys.{uid}` で行う。`migrationEncryptedKeys` は、移行期間中に公開鍵未発行ユーザーが共有先に含まれる、またはリスト公開で未発行ユーザーが含まれる可能性がある予定の救済用として保存する。
+
+公開鍵がすでに発行されているユーザーには `encryptedKeys.{uid}` が作られる。公開鍵がまだないユーザーは `pendingEncryptedRecipients` に入り、後から公開鍵が作られたときに Functions が `migrationEncryptedKeys` から予定鍵を復号し、そのユーザー向けの `encryptedKeys.{uid}` を追加する。
+
 ```json
 {
   "schedule-migration-v1": {
@@ -168,6 +172,10 @@ Functions は `array-contains` クエリでこのフィールドを検索し、�
 ### pendingEncryptedRecipients
 
 `pendingEncryptedRecipientIds` の詳細 map。
+
+`pendingEncryptedRecipients` も暗号化予定に必ず入るフィールドではない。作成・更新時点で共有先に公開鍵未発行ユーザーがいる場合だけ、そのユーザーごとの pending 状態を記録する。公開鍵があるユーザーは `encryptedKeys.{uid}` に入り、pending には入らない。
+
+このフィールドはユーザー端末の復号には使わない。Functions が公開鍵作成後の補完対象、pending 理由、対応する移行用鍵、対象リストを判断するために使う。
 
 ```json
 {

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1299,6 +1299,9 @@ PODS:
     - Flutter
   - flutter_native_splash (2.4.3):
     - Flutter
+  - flutter_secure_storage_darwin (10.0.0):
+    - Flutter
+    - FlutterMacOS
   - Google-Mobile-Ads-SDK (11.13.0):
     - GoogleUserMessagingPlatform (>= 1.1)
   - google_mobile_ads (5.3.1):
@@ -1459,6 +1462,9 @@ PODS:
   - nanopb/encode (3.30910.0)
   - package_info_plus (0.4.5):
     - Flutter
+  - path_provider_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
   - patrol (0.0.1):
     - CocoaAsyncSocket (~> 7.6)
     - Flutter
@@ -1491,12 +1497,14 @@ DEPENDENCIES:
   - flutter_image_compress_common (from `.symlinks/plugins/flutter_image_compress_common/ios`)
   - flutter_local_notifications (from `.symlinks/plugins/flutter_local_notifications/ios`)
   - flutter_native_splash (from `.symlinks/plugins/flutter_native_splash/ios`)
+  - flutter_secure_storage_darwin (from `.symlinks/plugins/flutter_secure_storage_darwin/darwin`)
   - google_mobile_ads (from `.symlinks/plugins/google_mobile_ads/ios`)
   - image_cropper (from `.symlinks/plugins/image_cropper/ios`)
   - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
   - integration_test (from `.symlinks/plugins/integration_test/ios`)
   - mobile_scanner (from `.symlinks/plugins/mobile_scanner/darwin`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
+  - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
   - patrol (from `.symlinks/plugins/patrol/darwin`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
@@ -1556,6 +1564,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_local_notifications/ios"
   flutter_native_splash:
     :path: ".symlinks/plugins/flutter_native_splash/ios"
+  flutter_secure_storage_darwin:
+    :path: ".symlinks/plugins/flutter_secure_storage_darwin/darwin"
   google_mobile_ads:
     :path: ".symlinks/plugins/google_mobile_ads/ios"
   image_cropper:
@@ -1568,6 +1578,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/mobile_scanner/darwin"
   package_info_plus:
     :path: ".symlinks/plugins/package_info_plus/ios"
+  path_provider_foundation:
+    :path: ".symlinks/plugins/path_provider_foundation/darwin"
   patrol:
     :path: ".symlinks/plugins/patrol/darwin"
   shared_preferences_foundation:
@@ -1603,6 +1615,7 @@ SPEC CHECKSUMS:
   flutter_image_compress_common: 1697a328fd72bfb335507c6bca1a65fa5ad87df1
   flutter_local_notifications: a5a732f069baa862e728d839dd2ebb904737effb
   flutter_native_splash: 6cad9122ea0fad137d23137dd14b937f3e90b145
+  flutter_secure_storage_darwin: acdb3f316ed05a3e68f856e0353b133eec373a23
   Google-Mobile-Ads-SDK: 14f57f2dc33532a24db288897e26494640810407
   google_mobile_ads: 16ad301354fa6a7ea55770c6254bd4339bf8558b
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
@@ -1620,6 +1633,7 @@ SPEC CHECKSUMS:
   mobile_scanner: 9157936403f5a0644ca3779a38ff8404c5434a93
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
+  path_provider_foundation: bb55f6dbba17d0dccd6737fe6f7f34fbd0376880
   patrol: cea8074f183a2a4232d0ebd10569ae05149ada42
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   RecaptchaInterop: 11e0b637842dfb48308d242afc3f448062325aba

--- a/lib/app/di/providers.dart
+++ b/lib/app/di/providers.dart
@@ -146,7 +146,6 @@ final userManagerProvider = Provider<IUserManager>((ref) {
 final scheduleManagerProvider = Provider<IScheduleManager>((ref) {
   return ScheduleManager(
     ref.watch(scheduleRepositoryProvider),
-    ref.watch(friendListRepositoryProvider),
     ref.watch(userRepositoryProvider),
     ref.watch(scheduleInteractionRepositoryProvider),
   );

--- a/lib/app/di/providers.dart
+++ b/lib/app/di/providers.dart
@@ -15,6 +15,7 @@ import 'package:lakiite/domain/service/schedule_manager.dart';
 import 'package:lakiite/domain/service/user_manager.dart';
 import 'package:lakiite/infrastructure/friend_list_repository.dart';
 import 'package:lakiite/infrastructure/display_list_repository.dart';
+import 'package:lakiite/infrastructure/encryption/schedule_encryption_service.dart';
 import 'package:lakiite/infrastructure/list_repository.dart';
 import 'package:lakiite/infrastructure/notification_repository.dart';
 import 'package:lakiite/infrastructure/repository/reaction_repository_impl.dart';
@@ -27,6 +28,11 @@ typedef ScheduleRepositoryFactory = IScheduleRepository Function();
 
 /// Firebase認証インスタンスを提供するプロバイダー。
 final firebaseAuthProvider = Provider((ref) => FirebaseAuth.instance);
+
+final scheduleEncryptionServiceProvider =
+    Provider<ScheduleEncryptionService>((ref) {
+  return ScheduleEncryptionService();
+});
 
 /// Firebase 認証状態の変化を監視し、repository のセッション境界を提供する。
 final repositorySessionKeyProvider = StreamProvider.autoDispose<String?>((ref) {

--- a/lib/app/di/providers.dart
+++ b/lib/app/di/providers.dart
@@ -5,6 +5,7 @@ import 'package:lakiite/domain/interfaces/i_friend_list_repository.dart';
 import 'package:lakiite/domain/interfaces/i_display_list_repository.dart';
 import 'package:lakiite/domain/interfaces/i_list_repository.dart';
 import 'package:lakiite/domain/interfaces/i_notification_repository.dart';
+import 'package:lakiite/domain/interfaces/i_schedule_access_grant_repository.dart';
 import 'package:lakiite/domain/interfaces/i_schedule_interaction_repository.dart';
 import 'package:lakiite/domain/interfaces/i_schedule_repository.dart';
 import 'package:lakiite/domain/interfaces/i_user_repository.dart';
@@ -97,8 +98,14 @@ final reactionRepositoryProvider = Provider<ReactionRepository>((ref) {
 
 /// リスト管理サービスのプロバイダー。
 final listManagerProvider = Provider<IListManager>((ref) {
+  final scheduleRepository = ref.watch(scheduleRepositoryProvider);
+  final scheduleAccessGrantRepository =
+      scheduleRepository is IScheduleAccessGrantRepository
+          ? scheduleRepository as IScheduleAccessGrantRepository
+          : null;
   return ListManager(
     ref.watch(listRepositoryProvider),
+    scheduleAccessGrantRepository: scheduleAccessGrantRepository,
   );
 });
 

--- a/lib/app/di/providers.dart
+++ b/lib/app/di/providers.dart
@@ -98,16 +98,36 @@ final reactionRepositoryProvider = Provider<ReactionRepository>((ref) {
 
 /// リスト管理サービスのプロバイダー。
 final listManagerProvider = Provider<IListManager>((ref) {
-  final scheduleRepository = ref.watch(scheduleRepositoryProvider);
-  final scheduleAccessGrantRepository =
-      scheduleRepository is IScheduleAccessGrantRepository
-          ? scheduleRepository as IScheduleAccessGrantRepository
-          : null;
   return ListManager(
     ref.watch(listRepositoryProvider),
-    scheduleAccessGrantRepository: scheduleAccessGrantRepository,
+    scheduleAccessGrantRepository: _LazyScheduleAccessGrantRepository(ref),
   );
 });
+
+class _LazyScheduleAccessGrantRepository
+    implements IScheduleAccessGrantRepository {
+  _LazyScheduleAccessGrantRepository(this._ref);
+
+  final Ref _ref;
+
+  @override
+  Future<void> grantListSchedulesAccessToUser({
+    required String listId,
+    required String userId,
+  }) async {
+    final scheduleRepository = _ref.read(scheduleRepositoryProvider);
+    if (scheduleRepository is! IScheduleAccessGrantRepository) {
+      return;
+    }
+
+    final scheduleAccessGrantRepository =
+        scheduleRepository as IScheduleAccessGrantRepository;
+    await scheduleAccessGrantRepository.grantListSchedulesAccessToUser(
+      listId: listId,
+      userId: userId,
+    );
+  }
+}
 
 /// ユーザー管理サービスのプロバイダー。
 final userManagerProvider = Provider<IUserManager>((ref) {

--- a/lib/app/di/providers.dart
+++ b/lib/app/di/providers.dart
@@ -9,6 +9,7 @@ import 'package:lakiite/domain/interfaces/i_schedule_access_grant_repository.dar
 import 'package:lakiite/domain/interfaces/i_schedule_interaction_repository.dart';
 import 'package:lakiite/domain/interfaces/i_schedule_repository.dart';
 import 'package:lakiite/domain/interfaces/i_user_repository.dart';
+import 'package:lakiite/domain/entity/list.dart';
 import 'package:lakiite/domain/repository/reaction_repository.dart';
 import 'package:lakiite/domain/service/list_manager.dart';
 import 'package:lakiite/domain/service/schedule_manager.dart';
@@ -131,6 +132,24 @@ class _LazyScheduleAccessGrantRepository
     await scheduleAccessGrantRepository.grantListSchedulesAccessToUser(
       listId: listId,
       userId: userId,
+    );
+  }
+
+  @override
+  Future<void> syncListSchedulesAccess({
+    required UserList beforeList,
+    required UserList afterList,
+  }) async {
+    final scheduleRepository = _ref.read(scheduleRepositoryProvider);
+    if (scheduleRepository is! IScheduleAccessGrantRepository) {
+      return;
+    }
+
+    final scheduleAccessGrantRepository =
+        scheduleRepository as IScheduleAccessGrantRepository;
+    await scheduleAccessGrantRepository.syncListSchedulesAccess(
+      beforeList: beforeList,
+      afterList: afterList,
     );
   }
 }

--- a/lib/application/schedule/schedule_interaction_notifier.dart
+++ b/lib/application/schedule/schedule_interaction_notifier.dart
@@ -366,7 +366,7 @@ class ScheduleInteractionNotifier
     try {
       AppLogger.debug('======= コメント更新処理開始 =======');
       AppLogger.debug('スケジュールID: $_scheduleId, コメントID: $commentId');
-      AppLogger.debug('更新内容: $content');
+      AppLogger.debug('コメント更新内容を受け付けました');
 
       // 現在のユーザーIDを確認
       final authState = await _ref.read(authNotifierProvider.future);

--- a/lib/config/router/app_router.dart
+++ b/lib/config/router/app_router.dart
@@ -10,6 +10,7 @@ import '../../presentation/settings/edit_name_page.dart';
 import '../../presentation/settings/edit_search_id_page.dart';
 import '../../presentation/settings/legal_info_page.dart';
 import '../../presentation/settings/schedule_digest_settings_page.dart';
+import '../../presentation/settings/schedule_key_backup_page.dart';
 import '../../presentation/settings/settings_page.dart';
 import '../../presentation/settings/account_deletion_webview_page.dart';
 import '../../presentation/signup/signup.dart';
@@ -113,6 +114,10 @@ final routerProvider = Provider<GoRouter>((ref) {
           GoRoute(
             path: ScheduleDigestSettingsPage.path,
             builder: (context, state) => const ScheduleDigestSettingsPage(),
+          ),
+          GoRoute(
+            path: ScheduleKeyBackupPage.path,
+            builder: (context, state) => const ScheduleKeyBackupPage(),
           ),
           GoRoute(
             path: 'how-to-use',

--- a/lib/domain/entity/schedule_encryption.dart
+++ b/lib/domain/entity/schedule_encryption.dart
@@ -1,0 +1,127 @@
+class SchedulePlainDetails {
+  const SchedulePlainDetails({
+    required this.title,
+    required this.description,
+    this.location,
+  });
+
+  factory SchedulePlainDetails.fromJson(Map<String, dynamic> json) {
+    return SchedulePlainDetails(
+      title: json['title'] as String? ?? '',
+      description: json['description'] as String? ?? '',
+      location: json['location'] as String?,
+    );
+  }
+
+  final String title;
+  final String description;
+  final String? location;
+
+  Map<String, dynamic> toJson() => {
+        'title': title,
+        'description': description,
+        'location': location,
+      };
+}
+
+class ScheduleEncryptedPayload {
+  const ScheduleEncryptedPayload({
+    required this.cipherText,
+    required this.nonce,
+    required this.mac,
+    required this.algorithm,
+  });
+
+  factory ScheduleEncryptedPayload.fromJson(Map<String, dynamic> json) {
+    return ScheduleEncryptedPayload(
+      cipherText: json['cipherText'] as String,
+      nonce: json['nonce'] as String,
+      mac: json['mac'] as String,
+      algorithm: json['algorithm'] as String? ?? 'AES-GCM',
+    );
+  }
+
+  final String cipherText;
+  final String nonce;
+  final String mac;
+  final String algorithm;
+
+  Map<String, dynamic> toJson() => {
+        'cipherText': cipherText,
+        'nonce': nonce,
+        'mac': mac,
+        'algorithm': algorithm,
+      };
+}
+
+class ScheduleEncryptedKey {
+  const ScheduleEncryptedKey({
+    required this.encryptedScheduleKey,
+    required this.nonce,
+    required this.mac,
+    required this.ephemeralPublicKey,
+    required this.algorithm,
+    required this.keyVersion,
+  });
+
+  factory ScheduleEncryptedKey.fromJson(Map<String, dynamic> json) {
+    return ScheduleEncryptedKey(
+      encryptedScheduleKey: json['encryptedScheduleKey'] as String,
+      nonce: json['nonce'] as String,
+      mac: json['mac'] as String,
+      ephemeralPublicKey: json['ephemeralPublicKey'] as String,
+      algorithm: json['algorithm'] as String? ?? 'X25519+AES-GCM',
+      keyVersion: json['keyVersion'] as int? ?? 1,
+    );
+  }
+
+  final String encryptedScheduleKey;
+  final String nonce;
+  final String mac;
+  final String ephemeralPublicKey;
+  final String algorithm;
+  final int keyVersion;
+
+  Map<String, dynamic> toJson() => {
+        'encryptedScheduleKey': encryptedScheduleKey,
+        'nonce': nonce,
+        'mac': mac,
+        'ephemeralPublicKey': ephemeralPublicKey,
+        'algorithm': algorithm,
+        'keyVersion': keyVersion,
+      };
+}
+
+class ScheduleUserPublicKey {
+  const ScheduleUserPublicKey({
+    required this.uid,
+    required this.publicKey,
+    required this.keyVersion,
+  });
+
+  final String uid;
+  final String publicKey;
+  final int keyVersion;
+}
+
+class ScheduleEncryptionException implements Exception {
+  const ScheduleEncryptionException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => 'ScheduleEncryptionException: $message';
+}
+
+class MissingLocalPrivateKeyException extends ScheduleEncryptionException {
+  const MissingLocalPrivateKeyException(String uid)
+      : super('Local private key is missing for user $uid');
+}
+
+class MissingRecipientPublicKeyException extends ScheduleEncryptionException {
+  MissingRecipientPublicKeyException(List<String> userIds)
+      : missingUserIds = userIds,
+        super('Recipient public keys are missing: ${userIds.join(', ')}');
+
+  final List<String> missingUserIds;
+}

--- a/lib/domain/entity/schedule_encryption.dart
+++ b/lib/domain/entity/schedule_encryption.dart
@@ -235,6 +235,19 @@ class MissingLocalPrivateKeyException extends ScheduleEncryptionException {
       : super('Local private key is missing for user $uid');
 }
 
+class LocalPrivateKeyMismatchException extends ScheduleEncryptionException {
+  const LocalPrivateKeyMismatchException(String uid)
+      : super(
+            'Local private key does not match the current public key for $uid');
+}
+
+class RestoredPrivateKeyMismatchException extends ScheduleEncryptionException {
+  const RestoredPrivateKeyMismatchException(String uid)
+      : super(
+          'Restored private key does not match the current public key for $uid',
+        );
+}
+
 class MissingRecipientPublicKeyException extends ScheduleEncryptionException {
   MissingRecipientPublicKeyException(List<String> userIds)
       : missingUserIds = userIds,

--- a/lib/domain/entity/schedule_encryption.dart
+++ b/lib/domain/entity/schedule_encryption.dart
@@ -92,6 +92,56 @@ class ScheduleEncryptedKey {
       };
 }
 
+class SchedulePrivateKeyBackup {
+  const SchedulePrivateKeyBackup({
+    required this.cipherText,
+    required this.nonce,
+    required this.mac,
+    required this.algorithm,
+    required this.kdf,
+    required this.kdfIterations,
+    required this.salt,
+    required this.keyVersion,
+    required this.version,
+  });
+
+  factory SchedulePrivateKeyBackup.fromJson(Map<String, dynamic> json) {
+    return SchedulePrivateKeyBackup(
+      cipherText: json['cipherText'] as String,
+      nonce: json['nonce'] as String,
+      mac: json['mac'] as String,
+      algorithm: json['algorithm'] as String? ?? 'AES-GCM',
+      kdf: json['kdf'] as String? ?? 'PBKDF2-HMAC-SHA256',
+      kdfIterations: json['kdfIterations'] as int? ?? 210000,
+      salt: json['salt'] as String,
+      keyVersion: json['keyVersion'] as int? ?? 1,
+      version: json['version'] as int? ?? 1,
+    );
+  }
+
+  final String cipherText;
+  final String nonce;
+  final String mac;
+  final String algorithm;
+  final String kdf;
+  final int kdfIterations;
+  final String salt;
+  final int keyVersion;
+  final int version;
+
+  Map<String, dynamic> toJson() => {
+        'cipherText': cipherText,
+        'nonce': nonce,
+        'mac': mac,
+        'algorithm': algorithm,
+        'kdf': kdf,
+        'kdfIterations': kdfIterations,
+        'salt': salt,
+        'keyVersion': keyVersion,
+        'version': version,
+      };
+}
+
 class ScheduleUserPublicKey {
   const ScheduleUserPublicKey({
     required this.uid,
@@ -102,6 +152,13 @@ class ScheduleUserPublicKey {
   final String uid;
   final String publicKey;
   final int keyVersion;
+}
+
+enum SchedulePrivateKeySetupStatus {
+  ready,
+  notStarted,
+  restoreAvailable,
+  backupMissing,
 }
 
 class ScheduleEncryptionException implements Exception {

--- a/lib/domain/entity/schedule_encryption.dart
+++ b/lib/domain/entity/schedule_encryption.dart
@@ -154,6 +154,66 @@ class ScheduleUserPublicKey {
   final int keyVersion;
 }
 
+class ScheduleMigrationPublicKey {
+  const ScheduleMigrationPublicKey({
+    required this.keyId,
+    required this.publicKey,
+    required this.keyVersion,
+  });
+
+  factory ScheduleMigrationPublicKey.fromJson(Map<String, dynamic> json) {
+    return ScheduleMigrationPublicKey(
+      keyId: json['keyId'] as String,
+      publicKey: json['publicKey'] as String,
+      keyVersion: json['keyVersion'] as int? ?? 1,
+    );
+  }
+
+  final String keyId;
+  final String publicKey;
+  final int keyVersion;
+}
+
+class SchedulePendingEncryptedRecipient {
+  const SchedulePendingEncryptedRecipient({
+    required this.reason,
+    required this.migrationKeyId,
+    required this.sharedListIds,
+  });
+
+  factory SchedulePendingEncryptedRecipient.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return SchedulePendingEncryptedRecipient(
+      reason: json['reason'] as String? ?? 'missingPublicKey',
+      migrationKeyId: json['migrationKeyId'] as String,
+      sharedListIds: List<String>.from(json['sharedListIds'] as List? ?? []),
+    );
+  }
+
+  final String reason;
+  final String migrationKeyId;
+  final List<String> sharedListIds;
+
+  Map<String, dynamic> toJson() => {
+        'reason': reason,
+        'migrationKeyId': migrationKeyId,
+        'sharedListIds': sharedListIds,
+      };
+}
+
+class ScheduleRecipientEncryptionPlan {
+  const ScheduleRecipientEncryptionPlan({
+    required this.publicKeysByUserId,
+    required this.readyUserIds,
+    required this.missingUserIds,
+  });
+
+  final Map<String, ScheduleUserPublicKey> publicKeysByUserId;
+  final List<String> readyUserIds;
+  final List<String> missingUserIds;
+}
+
 enum SchedulePrivateKeySetupStatus {
   ready,
   notStarted,

--- a/lib/domain/interfaces/i_schedule_access_grant_repository.dart
+++ b/lib/domain/interfaces/i_schedule_access_grant_repository.dart
@@ -1,0 +1,6 @@
+abstract class IScheduleAccessGrantRepository {
+  Future<void> grantListSchedulesAccessToUser({
+    required String listId,
+    required String userId,
+  });
+}

--- a/lib/domain/interfaces/i_schedule_access_grant_repository.dart
+++ b/lib/domain/interfaces/i_schedule_access_grant_repository.dart
@@ -1,6 +1,13 @@
+import 'package:lakiite/domain/entity/list.dart';
+
 abstract class IScheduleAccessGrantRepository {
   Future<void> grantListSchedulesAccessToUser({
     required String listId,
     required String userId,
+  });
+
+  Future<void> syncListSchedulesAccess({
+    required UserList beforeList,
+    required UserList afterList,
   });
 }

--- a/lib/domain/service/list_manager.dart
+++ b/lib/domain/service/list_manager.dart
@@ -78,7 +78,14 @@ class ListManager implements IListManager {
 
   @override
   Future<void> updateList(UserList list) async {
+    final beforeList = await _listRepository.getList(list.id);
     await _listRepository.updateList(list);
+    if (beforeList != null) {
+      await _scheduleAccessGrantRepository?.syncListSchedulesAccess(
+        beforeList: beforeList,
+        afterList: list,
+      );
+    }
   }
 
   @override
@@ -93,15 +100,31 @@ class ListManager implements IListManager {
 
   @override
   Future<void> addMember(String listId, String userId) async {
+    final beforeList = await _listRepository.getList(listId);
     await _listRepository.addMember(listId, userId);
-    await _scheduleAccessGrantRepository?.grantListSchedulesAccessToUser(
-      listId: listId,
-      userId: userId,
-    );
+    if (beforeList != null) {
+      final afterList = beforeList.copyWith(
+        memberIds: {...beforeList.memberIds, userId}.toList(),
+      );
+      await _scheduleAccessGrantRepository?.syncListSchedulesAccess(
+        beforeList: beforeList,
+        afterList: afterList,
+      );
+    }
   }
 
   @override
   Future<void> removeMember(String listId, String userId) async {
+    final beforeList = await _listRepository.getList(listId);
     await _listRepository.removeMember(listId, userId);
+    if (beforeList != null) {
+      final afterList = beforeList.copyWith(
+        memberIds: beforeList.memberIds.where((id) => id != userId).toList(),
+      );
+      await _scheduleAccessGrantRepository?.syncListSchedulesAccess(
+        beforeList: beforeList,
+        afterList: afterList,
+      );
+    }
   }
 }

--- a/lib/domain/service/list_manager.dart
+++ b/lib/domain/service/list_manager.dart
@@ -1,5 +1,6 @@
 import 'package:lakiite/domain/entity/list.dart';
 import 'package:lakiite/domain/interfaces/i_list_repository.dart';
+import 'package:lakiite/domain/interfaces/i_schedule_access_grant_repository.dart';
 
 /// リスト関連のビジネスロジックを集約するManager
 ///
@@ -40,8 +41,13 @@ abstract class IListManager {
 }
 
 class ListManager implements IListManager {
-  ListManager(this._listRepository);
+  ListManager(
+    this._listRepository, {
+    IScheduleAccessGrantRepository? scheduleAccessGrantRepository,
+  }) : _scheduleAccessGrantRepository = scheduleAccessGrantRepository;
+
   final IListRepository _listRepository;
+  final IScheduleAccessGrantRepository? _scheduleAccessGrantRepository;
 
   @override
   Future<List<UserList>> getAuthenticatedUserLists(String userId) async {
@@ -88,6 +94,10 @@ class ListManager implements IListManager {
   @override
   Future<void> addMember(String listId, String userId) async {
     await _listRepository.addMember(listId, userId);
+    await _scheduleAccessGrantRepository?.grantListSchedulesAccessToUser(
+      listId: listId,
+      userId: userId,
+    );
   }
 
   @override

--- a/lib/domain/service/schedule_manager.dart
+++ b/lib/domain/service/schedule_manager.dart
@@ -1,6 +1,5 @@
 import 'package:lakiite/domain/entity/schedule.dart';
 import 'package:lakiite/domain/interfaces/i_schedule_repository.dart';
-import 'package:lakiite/domain/interfaces/i_friend_list_repository.dart';
 import 'package:lakiite/domain/interfaces/i_user_repository.dart';
 import 'package:lakiite/domain/interfaces/i_schedule_interaction_repository.dart';
 import 'package:lakiite/utils/logger.dart';
@@ -9,14 +8,14 @@ import 'package:lakiite/utils/logger.dart';
 ///
 /// 責務:
 /// - スケジュール作成時のビジネスルール適用
-/// - 可視対象ユーザーの計算
+/// - サーバー正規化前の可視対象ユーザー初期値の設定
 /// - スケジュールのエンリッチメント（リアクション数・コメント数）
 /// - バリデーション
 abstract class IScheduleManager {
   /// スケジュールを作成する
   ///
   /// ビジネスルール:
-  /// 1. 共有リストのメンバーを可視対象に追加
+  /// 1. owner を可視対象の初期値として設定
   /// 2. ユーザー情報（表示名、アイコン）を取得して設定
   /// 3. 作成日時・更新日時を設定
   ///
@@ -29,7 +28,7 @@ abstract class IScheduleManager {
   /// スケジュールを更新する
   ///
   /// ビジネスルール:
-  /// 1. 共有リストのメンバーを可視対象に追加
+  /// 1. owner を可視対象の初期値として設定
   /// 2. 更新日時を設定
   ///
   /// [schedule] 更新するスケジュール
@@ -76,12 +75,10 @@ abstract class IScheduleManager {
 class ScheduleManager implements IScheduleManager {
   ScheduleManager(
     this._scheduleRepository,
-    this._friendListRepository,
     this._userRepository,
     this._interactionRepository,
   );
   final IScheduleRepository _scheduleRepository;
-  final IFriendListRepository _friendListRepository;
   final IUserRepository _userRepository;
   final IScheduleInteractionRepository _interactionRepository;
 
@@ -237,25 +234,10 @@ class ScheduleManager implements IScheduleManager {
 
   /// 可視対象ユーザーを計算
   Future<List<String>> _calculateVisibleUsers(Schedule schedule) async {
-    final Set<String> visibleTo = {...schedule.visibleTo};
-
-    // 共有リストのメンバーを追加
-    for (final listId in schedule.sharedLists) {
-      try {
-        final memberIds = await _friendListRepository.getListMemberIds(listId);
-        if (memberIds != null) {
-          visibleTo.addAll(memberIds);
-          AppLogger.debug(
-              'ScheduleManager: Added ${memberIds.length} members from list $listId');
-        }
-      } catch (e) {
-        AppLogger.warning(
-            'ScheduleManager: Error getting members for list $listId - $e');
-        // エラーが発生しても処理を継続
-      }
-    }
-
-    return visibleTo.toList();
+    // visibleTo は検索用の派生データとして Cloud Functions が正規化する。
+    // クライアントは owner のみを初期値として送り、リストメンバー展開は
+    // サーバー側で sharedLists から再計算する。
+    return [schedule.ownerId];
   }
 
   /// スケジュールリストのエンリッチメント

--- a/lib/domain/service/schedule_recipient_diff_calculator.dart
+++ b/lib/domain/service/schedule_recipient_diff_calculator.dart
@@ -1,0 +1,62 @@
+class ScheduleRecipientDiff {
+  const ScheduleRecipientDiff({
+    required this.beforeRecipientIds,
+    required this.afterRecipientIds,
+    required this.addedUserIds,
+    required this.removedUserIds,
+  });
+
+  final Set<String> beforeRecipientIds;
+  final Set<String> afterRecipientIds;
+  final Set<String> addedUserIds;
+  final Set<String> removedUserIds;
+
+  bool get requiresRekey => removedUserIds.isNotEmpty;
+
+  bool get requiresRewrap => removedUserIds.isEmpty && addedUserIds.isNotEmpty;
+
+  bool get hasNoKeyChange => addedUserIds.isEmpty && removedUserIds.isEmpty;
+}
+
+class ScheduleRecipientDiffCalculator {
+  const ScheduleRecipientDiffCalculator._();
+
+  static ScheduleRecipientDiff calculate({
+    required String ownerId,
+    required Iterable<String> beforeSharedListIds,
+    required Iterable<String> afterSharedListIds,
+    required Map<String, Iterable<String>> membersByListId,
+    Map<String, Iterable<String>>? afterMembersByListId,
+  }) {
+    final beforeRecipientIds = _expandRecipientIds(
+      ownerId: ownerId,
+      sharedListIds: beforeSharedListIds,
+      membersByListId: membersByListId,
+    );
+    final afterRecipientIds = _expandRecipientIds(
+      ownerId: ownerId,
+      sharedListIds: afterSharedListIds,
+      membersByListId: afterMembersByListId ?? membersByListId,
+    );
+
+    return ScheduleRecipientDiff(
+      beforeRecipientIds: beforeRecipientIds,
+      afterRecipientIds: afterRecipientIds,
+      addedUserIds: afterRecipientIds.difference(beforeRecipientIds),
+      removedUserIds: beforeRecipientIds.difference(afterRecipientIds),
+    );
+  }
+
+  static Set<String> _expandRecipientIds({
+    required String ownerId,
+    required Iterable<String> sharedListIds,
+    required Map<String, Iterable<String>> membersByListId,
+  }) {
+    return {
+      if (ownerId.isNotEmpty) ownerId,
+      for (final listId in sharedListIds)
+        for (final memberId in membersByListId[listId] ?? const <String>[])
+          if (memberId.isNotEmpty) memberId,
+    };
+  }
+}

--- a/lib/infrastructure/display_list_repository.dart
+++ b/lib/infrastructure/display_list_repository.dart
@@ -44,7 +44,7 @@ class DisplayListRepository implements IDisplayListRepository {
       id: doc.id,
       name: data['name'] as String? ?? '',
       ownerId: data['ownerId'] as String? ?? doc.reference.parent.parent!.id,
-      colorKey: data['colorKey'] as String? ?? 'blue',
+      colorKey: data['colorKey'] as String? ?? 'red',
       memberIds: List<String>.from(data['memberIds'] as List? ?? []),
       createdAt: parseDateTime(data['createdAt']),
       updatedAt: parseDateTime(data['updatedAt']),

--- a/lib/infrastructure/encryption/schedule_cipher.dart
+++ b/lib/infrastructure/encryption/schedule_cipher.dart
@@ -60,6 +60,37 @@ class ScheduleCipher {
     return SchedulePlainDetails.fromJson(json);
   }
 
+  Future<ScheduleEncryptedPayload> encryptText({
+    required String text,
+    required SecretKey scheduleKey,
+  }) async {
+    final secretBox = await _aesGcm.encrypt(
+      utf8.encode(text),
+      secretKey: scheduleKey,
+    );
+    return ScheduleEncryptedPayload(
+      cipherText: _encode(secretBox.cipherText),
+      nonce: _encode(secretBox.nonce),
+      mac: _encode(secretBox.mac.bytes),
+      algorithm: payloadAlgorithm,
+    );
+  }
+
+  Future<String> decryptText({
+    required ScheduleEncryptedPayload payload,
+    required SecretKey scheduleKey,
+  }) async {
+    final clearText = await _aesGcm.decrypt(
+      SecretBox(
+        _decode(payload.cipherText),
+        nonce: _decode(payload.nonce),
+        mac: Mac(_decode(payload.mac)),
+      ),
+      secretKey: scheduleKey,
+    );
+    return utf8.decode(clearText);
+  }
+
   Future<ScheduleEncryptedKey> encryptScheduleKey({
     required SecretKeyData scheduleKey,
     required SimplePublicKey recipientPublicKey,

--- a/lib/infrastructure/encryption/schedule_cipher.dart
+++ b/lib/infrastructure/encryption/schedule_cipher.dart
@@ -1,0 +1,142 @@
+import 'dart:convert';
+
+import 'package:cryptography/cryptography.dart';
+
+import '../../domain/entity/schedule_encryption.dart';
+
+class ScheduleCipher {
+  ScheduleCipher({
+    AesGcm? aesGcm,
+    X25519? keyExchange,
+  })  : _aesGcm = aesGcm ?? AesGcm.with256bits(),
+        _keyExchange = keyExchange ?? X25519();
+
+  static const payloadAlgorithm = 'AES-GCM';
+  static const encryptedKeyAlgorithm = 'X25519+AES-GCM';
+
+  final AesGcm _aesGcm;
+  final X25519 _keyExchange;
+
+  Future<SimpleKeyPairData> newUserKeyPair() async {
+    final keyPair = await _keyExchange.newKeyPair();
+    final keyPairData = await keyPair.extract();
+    final publicKey = await keyPair.extractPublicKey();
+    return SimpleKeyPairData(
+      keyPairData.bytes,
+      publicKey: publicKey,
+      type: KeyPairType.x25519,
+    );
+  }
+
+  SecretKeyData newScheduleKey() => SecretKeyData.random(length: 32);
+
+  Future<ScheduleEncryptedPayload> encryptDetails({
+    required SchedulePlainDetails details,
+    required SecretKey scheduleKey,
+  }) async {
+    final clearText = utf8.encode(jsonEncode(details.toJson()));
+    final secretBox = await _aesGcm.encrypt(clearText, secretKey: scheduleKey);
+    return ScheduleEncryptedPayload(
+      cipherText: _encode(secretBox.cipherText),
+      nonce: _encode(secretBox.nonce),
+      mac: _encode(secretBox.mac.bytes),
+      algorithm: payloadAlgorithm,
+    );
+  }
+
+  Future<SchedulePlainDetails> decryptDetails({
+    required ScheduleEncryptedPayload payload,
+    required SecretKey scheduleKey,
+  }) async {
+    final clearText = await _aesGcm.decrypt(
+      SecretBox(
+        _decode(payload.cipherText),
+        nonce: _decode(payload.nonce),
+        mac: Mac(_decode(payload.mac)),
+      ),
+      secretKey: scheduleKey,
+    );
+    final json = jsonDecode(utf8.decode(clearText)) as Map<String, dynamic>;
+    return SchedulePlainDetails.fromJson(json);
+  }
+
+  Future<ScheduleEncryptedKey> encryptScheduleKey({
+    required SecretKeyData scheduleKey,
+    required SimplePublicKey recipientPublicKey,
+    required int keyVersion,
+  }) async {
+    final ephemeralKeyPair = await _keyExchange.newKeyPair();
+    final sharedSecret = await _keyExchange.sharedSecretKey(
+      keyPair: ephemeralKeyPair,
+      remotePublicKey: recipientPublicKey,
+    );
+    final scheduleKeyBytes = await scheduleKey.extractBytes();
+    final secretBox = await _aesGcm.encrypt(
+      scheduleKeyBytes,
+      secretKey: sharedSecret,
+    );
+    final ephemeralPublicKey = await ephemeralKeyPair.extractPublicKey();
+
+    return ScheduleEncryptedKey(
+      encryptedScheduleKey: _encode(secretBox.cipherText),
+      nonce: _encode(secretBox.nonce),
+      mac: _encode(secretBox.mac.bytes),
+      ephemeralPublicKey: _encode(ephemeralPublicKey.bytes),
+      algorithm: encryptedKeyAlgorithm,
+      keyVersion: keyVersion,
+    );
+  }
+
+  Future<SecretKeyData> decryptScheduleKey({
+    required ScheduleEncryptedKey encryptedKey,
+    required SimpleKeyPairData privateKey,
+  }) async {
+    final sharedSecret = await _keyExchange.sharedSecretKey(
+      keyPair: privateKey,
+      remotePublicKey: SimplePublicKey(
+        _decode(encryptedKey.ephemeralPublicKey),
+        type: KeyPairType.x25519,
+      ),
+    );
+    final scheduleKeyBytes = await _aesGcm.decrypt(
+      SecretBox(
+        _decode(encryptedKey.encryptedScheduleKey),
+        nonce: _decode(encryptedKey.nonce),
+        mac: Mac(_decode(encryptedKey.mac)),
+      ),
+      secretKey: sharedSecret,
+    );
+    return SecretKeyData(scheduleKeyBytes);
+  }
+
+  SimplePublicKey publicKeyFromBase64(String value) {
+    return SimplePublicKey(_decode(value), type: KeyPairType.x25519);
+  }
+
+  String publicKeyToBase64(SimplePublicKey publicKey) =>
+      _encode(publicKey.bytes);
+
+  String privateKeyToJson(SimpleKeyPairData keyPair) {
+    return jsonEncode({
+      'privateKey': _encode(keyPair.bytes),
+      'publicKey': _encode(keyPair.publicKey.bytes),
+      'type': 'x25519',
+    });
+  }
+
+  SimpleKeyPairData privateKeyFromJson(String value) {
+    final json = jsonDecode(value) as Map<String, dynamic>;
+    return SimpleKeyPairData(
+      _decode(json['privateKey'] as String),
+      publicKey: SimplePublicKey(
+        _decode(json['publicKey'] as String),
+        type: KeyPairType.x25519,
+      ),
+      type: KeyPairType.x25519,
+    );
+  }
+
+  String _encode(List<int> bytes) => base64UrlEncode(bytes);
+
+  List<int> _decode(String value) => base64Url.decode(value);
+}

--- a/lib/infrastructure/encryption/schedule_cipher.dart
+++ b/lib/infrastructure/encryption/schedule_cipher.dart
@@ -13,6 +13,8 @@ class ScheduleCipher {
 
   static const payloadAlgorithm = 'AES-GCM';
   static const encryptedKeyAlgorithm = 'X25519+AES-GCM';
+  static const privateKeyBackupKdf = 'PBKDF2-HMAC-SHA256';
+  static const privateKeyBackupIterations = 210000;
 
   final AesGcm _aesGcm;
   final X25519 _keyExchange;
@@ -91,6 +93,54 @@ class ScheduleCipher {
     return utf8.decode(clearText);
   }
 
+  Future<SchedulePrivateKeyBackup> encryptPrivateKeyBackup({
+    required SimpleKeyPairData keyPair,
+    required String password,
+    required int keyVersion,
+  }) async {
+    final salt = SecretKeyData.random(length: 16).bytes;
+    final backupKey = await _derivePrivateKeyBackupKey(
+      password: password,
+      salt: salt,
+      iterations: privateKeyBackupIterations,
+    );
+    final secretBox = await _aesGcm.encrypt(
+      utf8.encode(privateKeyToJson(keyPair)),
+      secretKey: backupKey,
+    );
+    return SchedulePrivateKeyBackup(
+      cipherText: _encode(secretBox.cipherText),
+      nonce: _encode(secretBox.nonce),
+      mac: _encode(secretBox.mac.bytes),
+      algorithm: payloadAlgorithm,
+      kdf: privateKeyBackupKdf,
+      kdfIterations: privateKeyBackupIterations,
+      salt: _encode(salt),
+      keyVersion: keyVersion,
+      version: 1,
+    );
+  }
+
+  Future<SimpleKeyPairData> decryptPrivateKeyBackup({
+    required SchedulePrivateKeyBackup backup,
+    required String password,
+  }) async {
+    final backupKey = await _derivePrivateKeyBackupKey(
+      password: password,
+      salt: _decode(backup.salt),
+      iterations: backup.kdfIterations,
+    );
+    final clearText = await _aesGcm.decrypt(
+      SecretBox(
+        _decode(backup.cipherText),
+        nonce: _decode(backup.nonce),
+        mac: Mac(_decode(backup.mac)),
+      ),
+      secretKey: backupKey,
+    );
+    return privateKeyFromJson(utf8.decode(clearText));
+  }
+
   Future<ScheduleEncryptedKey> encryptScheduleKey({
     required SecretKeyData scheduleKey,
     required SimplePublicKey recipientPublicKey,
@@ -164,6 +214,22 @@ class ScheduleCipher {
         type: KeyPairType.x25519,
       ),
       type: KeyPairType.x25519,
+    );
+  }
+
+  Future<SecretKey> _derivePrivateKeyBackupKey({
+    required String password,
+    required List<int> salt,
+    required int iterations,
+  }) {
+    final pbkdf2 = Pbkdf2(
+      macAlgorithm: Hmac.sha256(),
+      iterations: iterations,
+      bits: 256,
+    );
+    return pbkdf2.deriveKey(
+      secretKey: SecretKey(utf8.encode(password)),
+      nonce: salt,
     );
   }
 

--- a/lib/infrastructure/encryption/schedule_cipher.dart
+++ b/lib/infrastructure/encryption/schedule_cipher.dart
@@ -197,6 +197,13 @@ class ScheduleCipher {
   String publicKeyToBase64(SimplePublicKey publicKey) =>
       _encode(publicKey.bytes);
 
+  bool publicKeyMatchesPrivateKey({
+    required SimpleKeyPairData privateKey,
+    required String publicKey,
+  }) {
+    return publicKeyToBase64(privateKey.publicKey) == publicKey;
+  }
+
   String privateKeyToJson(SimpleKeyPairData keyPair) {
     return jsonEncode({
       'privateKey': _encode(keyPair.bytes),

--- a/lib/infrastructure/encryption/schedule_encryption_service.dart
+++ b/lib/infrastructure/encryption/schedule_encryption_service.dart
@@ -7,6 +7,16 @@ import '../mapper/schedule_mapper.dart';
 import 'schedule_cipher.dart';
 import 'schedule_private_key_store.dart';
 
+class ScheduleRekeyEncryptionResult {
+  const ScheduleRekeyEncryptionResult({
+    required this.scheduleData,
+    required this.scheduleKey,
+  });
+
+  final Map<String, dynamic> scheduleData;
+  final SecretKeyData scheduleKey;
+}
+
 class ScheduleEncryptionService {
   ScheduleEncryptionService({
     FirebaseFirestore? firestore,
@@ -208,7 +218,39 @@ class ScheduleEncryptionService {
       currentUserKey: currentUserKey,
       existingDoc: existingDoc,
     );
+    return _toEncryptedFirestoreDataWithScheduleKey(
+      schedule: schedule,
+      currentUserId: currentUserId,
+      scheduleKey: scheduleKey,
+      existingDoc: existingDoc,
+    );
+  }
 
+  Future<ScheduleRekeyEncryptionResult> toRekeyedFirestoreData({
+    required Schedule schedule,
+    required String currentUserId,
+    DocumentSnapshot? existingDoc,
+  }) async {
+    await ensureCurrentUserKey(currentUserId);
+    final scheduleKey = _cipher.newScheduleKey();
+    final data = await _toEncryptedFirestoreDataWithScheduleKey(
+      schedule: schedule,
+      currentUserId: currentUserId,
+      scheduleKey: scheduleKey,
+      existingDoc: existingDoc,
+    );
+    return ScheduleRekeyEncryptionResult(
+      scheduleData: data,
+      scheduleKey: scheduleKey,
+    );
+  }
+
+  Future<Map<String, dynamic>> _toEncryptedFirestoreDataWithScheduleKey({
+    required Schedule schedule,
+    required String currentUserId,
+    required SecretKeyData scheduleKey,
+    DocumentSnapshot? existingDoc,
+  }) async {
     final details = SchedulePlainDetails(
       title: schedule.title,
       description: schedule.description,
@@ -336,6 +378,20 @@ class ScheduleEncryptionService {
       return {'content': content};
     }
 
+    final payload = await _cipher.encryptText(
+      text: content,
+      scheduleKey: scheduleKey,
+    );
+    return {
+      'encrypted': true,
+      'encryptedContent': payload.toJson(),
+    };
+  }
+
+  Future<Map<String, dynamic>> toEncryptedCommentContentDataWithScheduleKey({
+    required SecretKeyData scheduleKey,
+    required String content,
+  }) async {
     final payload = await _cipher.encryptText(
       text: content,
       scheduleKey: scheduleKey,

--- a/lib/infrastructure/encryption/schedule_encryption_service.dart
+++ b/lib/infrastructure/encryption/schedule_encryption_service.dart
@@ -1,0 +1,261 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:cryptography/cryptography.dart';
+
+import '../../domain/entity/schedule.dart';
+import '../../domain/entity/schedule_encryption.dart';
+import '../mapper/schedule_mapper.dart';
+import 'schedule_cipher.dart';
+import 'schedule_private_key_store.dart';
+
+class ScheduleEncryptionService {
+  ScheduleEncryptionService({
+    FirebaseFirestore? firestore,
+    ScheduleCipher? cipher,
+    SchedulePrivateKeyStore? privateKeyStore,
+  })  : _firestore = firestore ?? FirebaseFirestore.instance,
+        _cipher = cipher ?? ScheduleCipher(),
+        _privateKeyStore = privateKeyStore ?? SchedulePrivateKeyStore();
+
+  static const encryptionVersion = 1;
+  static const currentKeyVersion = 1;
+
+  final FirebaseFirestore _firestore;
+  final ScheduleCipher _cipher;
+  final SchedulePrivateKeyStore _privateKeyStore;
+
+  Future<void> tryEnsureCurrentUserKey(String uid) async {
+    try {
+      await ensureCurrentUserKey(uid);
+    } on MissingLocalPrivateKeyException {
+      // Phase 2 の復元導線が入るまで、読み込み自体は継続する。
+    }
+  }
+
+  Future<SimpleKeyPairData> ensureCurrentUserKey(String uid) async {
+    final publicKeyRef = _publicKeyRef(uid);
+    final publicKeyDoc = await publicKeyRef.get();
+
+    if (publicKeyDoc.exists) {
+      final data = publicKeyDoc.data() as Map<String, dynamic>;
+      final keyVersion = data['keyVersion'] as int? ?? currentKeyVersion;
+      final localKey = await _privateKeyStore.read(
+        uid: uid,
+        keyVersion: keyVersion,
+      );
+      if (localKey == null) {
+        throw MissingLocalPrivateKeyException(uid);
+      }
+      return localKey;
+    }
+
+    final existingLocalKey = await _privateKeyStore.read(
+      uid: uid,
+      keyVersion: currentKeyVersion,
+    );
+    if (existingLocalKey != null) {
+      await _savePublicKey(uid: uid, keyPair: existingLocalKey);
+      return existingLocalKey;
+    }
+
+    final keyPair = await _cipher.newUserKeyPair();
+    await _privateKeyStore.write(
+      uid: uid,
+      keyVersion: currentKeyVersion,
+      keyPair: keyPair,
+    );
+    await _savePublicKey(uid: uid, keyPair: keyPair);
+    return keyPair;
+  }
+
+  Future<Map<String, dynamic>> toEncryptedFirestoreData({
+    required Schedule schedule,
+    required String currentUserId,
+    DocumentSnapshot? existingDoc,
+  }) async {
+    final currentUserKey = await ensureCurrentUserKey(currentUserId);
+    final scheduleKey = await _resolveScheduleKey(
+      currentUserId: currentUserId,
+      currentUserKey: currentUserKey,
+      existingDoc: existingDoc,
+    );
+
+    final details = SchedulePlainDetails(
+      title: schedule.title,
+      description: schedule.description,
+      location: schedule.location,
+    );
+    final payload = await _cipher.encryptDetails(
+      details: details,
+      scheduleKey: scheduleKey,
+    );
+    final encryptedKeys = await _encryptScheduleKeyForViewers(
+      scheduleKey: scheduleKey,
+      viewerIds: schedule.visibleTo,
+    );
+
+    final data = ScheduleMapper.toFirestore(schedule);
+    data
+      ..remove('title')
+      ..remove('description')
+      ..remove('location')
+      ..['encrypted'] = true
+      ..['encryptionVersion'] = encryptionVersion
+      ..['encryptedPayload'] = payload.toJson()
+      ..['encryptedKeys'] = encryptedKeys.map(
+        (uid, encryptedKey) => MapEntry(uid, encryptedKey.toJson()),
+      );
+    return data;
+  }
+
+  Future<SchedulePlainDetails?> decryptDetailsForCurrentUser({
+    required DocumentSnapshot doc,
+    required String currentUserId,
+  }) async {
+    final data = doc.data() as Map<String, dynamic>?;
+    if (data == null || data['encrypted'] != true) return null;
+
+    final scheduleKey = await _decryptScheduleKeyFromData(
+      data: data,
+      currentUserId: currentUserId,
+    );
+    final payload = ScheduleEncryptedPayload.fromJson(
+      Map<String, dynamic>.from(data['encryptedPayload'] as Map),
+    );
+    return _cipher.decryptDetails(
+      payload: payload,
+      scheduleKey: scheduleKey,
+    );
+  }
+
+  Future<ScheduleEncryptedKey?> encryptedScheduleKeyForAdditionalViewer({
+    required DocumentSnapshot doc,
+    required String currentUserId,
+    required String viewerId,
+  }) async {
+    final data = doc.data() as Map<String, dynamic>?;
+    if (data == null || data['encrypted'] != true) return null;
+
+    final scheduleKey = await _decryptScheduleKeyFromData(
+      data: data,
+      currentUserId: currentUserId,
+    );
+    final publicKey = (await _fetchPublicKeys({viewerId})).single;
+    return _cipher.encryptScheduleKey(
+      scheduleKey: scheduleKey,
+      recipientPublicKey: _cipher.publicKeyFromBase64(publicKey.publicKey),
+      keyVersion: publicKey.keyVersion,
+    );
+  }
+
+  Future<void> _savePublicKey({
+    required String uid,
+    required SimpleKeyPairData keyPair,
+  }) async {
+    await _publicKeyRef(uid).set({
+      'publicKey': _cipher.publicKeyToBase64(keyPair.publicKey),
+      'keyVersion': currentKeyVersion,
+      'algorithm': 'X25519',
+      'createdAt': FieldValue.serverTimestamp(),
+      'updatedAt': FieldValue.serverTimestamp(),
+    }, SetOptions(merge: true));
+  }
+
+  Future<SecretKeyData> _resolveScheduleKey({
+    required String currentUserId,
+    required SimpleKeyPairData currentUserKey,
+    required DocumentSnapshot? existingDoc,
+  }) async {
+    final existingData = existingDoc?.data() as Map<String, dynamic>?;
+    if (existingData == null || existingData['encrypted'] != true) {
+      return _cipher.newScheduleKey();
+    }
+
+    final encryptedKeys = existingData['encryptedKeys'] as Map?;
+    final encryptedKeyJson = encryptedKeys?[currentUserId];
+    if (encryptedKeyJson == null) {
+      throw const ScheduleEncryptionException(
+        'Encrypted schedule key for current user is missing',
+      );
+    }
+    return _cipher.decryptScheduleKey(
+      encryptedKey: ScheduleEncryptedKey.fromJson(
+        Map<String, dynamic>.from(encryptedKeyJson as Map),
+      ),
+      privateKey: currentUserKey,
+    );
+  }
+
+  Future<SecretKeyData> _decryptScheduleKeyFromData({
+    required Map<String, dynamic> data,
+    required String currentUserId,
+  }) async {
+    final encryptedKeys = data['encryptedKeys'] as Map?;
+    final encryptedKeyJson = encryptedKeys?[currentUserId];
+    if (encryptedKeyJson == null) {
+      throw const ScheduleEncryptionException(
+        'Encrypted schedule key for current user is missing',
+      );
+    }
+
+    final encryptedKey = ScheduleEncryptedKey.fromJson(
+      Map<String, dynamic>.from(encryptedKeyJson as Map),
+    );
+    final privateKey = await _privateKeyStore.read(
+      uid: currentUserId,
+      keyVersion: encryptedKey.keyVersion,
+    );
+    if (privateKey == null) {
+      throw MissingLocalPrivateKeyException(currentUserId);
+    }
+    return _cipher.decryptScheduleKey(
+      encryptedKey: encryptedKey,
+      privateKey: privateKey,
+    );
+  }
+
+  Future<Map<String, ScheduleEncryptedKey>> _encryptScheduleKeyForViewers({
+    required SecretKeyData scheduleKey,
+    required Iterable<String> viewerIds,
+  }) async {
+    final publicKeys = await _fetchPublicKeys(viewerIds.toSet());
+    final entries = await Future.wait(publicKeys.map((publicKey) async {
+      final encryptedKey = await _cipher.encryptScheduleKey(
+        scheduleKey: scheduleKey,
+        recipientPublicKey: _cipher.publicKeyFromBase64(publicKey.publicKey),
+        keyVersion: publicKey.keyVersion,
+      );
+      return MapEntry(publicKey.uid, encryptedKey);
+    }));
+    return Map.fromEntries(entries);
+  }
+
+  Future<List<ScheduleUserPublicKey>> _fetchPublicKeys(
+    Set<String> viewerIds,
+  ) async {
+    final results = await Future.wait(viewerIds.map((uid) async {
+      final doc = await _publicKeyRef(uid).get();
+      if (!doc.exists) return null;
+      final data = doc.data() as Map<String, dynamic>;
+      return ScheduleUserPublicKey(
+        uid: uid,
+        publicKey: data['publicKey'] as String,
+        keyVersion: data['keyVersion'] as int? ?? currentKeyVersion,
+      );
+    }));
+    final publicKeys = results.whereType<ScheduleUserPublicKey>().toList();
+    final foundUserIds = publicKeys.map((key) => key.uid).toSet();
+    final missingUserIds = viewerIds.difference(foundUserIds).toList();
+    if (missingUserIds.isNotEmpty) {
+      throw MissingRecipientPublicKeyException(missingUserIds);
+    }
+    return publicKeys;
+  }
+
+  DocumentReference _publicKeyRef(String uid) {
+    return _firestore
+        .collection('users')
+        .doc(uid)
+        .collection('encryption')
+        .doc('current');
+  }
+}

--- a/lib/infrastructure/encryption/schedule_encryption_service.dart
+++ b/lib/infrastructure/encryption/schedule_encryption_service.dart
@@ -27,8 +27,31 @@ class ScheduleEncryptionService {
     try {
       await ensureCurrentUserKey(uid);
     } on MissingLocalPrivateKeyException {
-      // Phase 2 の復元導線が入るまで、読み込み自体は継続する。
+      // 復元導線はログイン後のガードで扱う。読み込み自体は継続する。
     }
+  }
+
+  Future<SchedulePrivateKeySetupStatus> currentUserPrivateKeyStatus(
+    String uid,
+  ) async {
+    final publicKeyDoc = await _publicKeyRef(uid).get();
+    if (!publicKeyDoc.exists) {
+      return SchedulePrivateKeySetupStatus.notStarted;
+    }
+
+    final data = publicKeyDoc.data() as Map<String, dynamic>;
+    final keyVersion = data['keyVersion'] as int? ?? currentKeyVersion;
+    final localKey = await _privateKeyStore.read(
+      uid: uid,
+      keyVersion: keyVersion,
+    );
+    if (localKey != null) {
+      return SchedulePrivateKeySetupStatus.ready;
+    }
+
+    return _privateKeyBackupFromData(data) == null
+        ? SchedulePrivateKeySetupStatus.backupMissing
+        : SchedulePrivateKeySetupStatus.restoreAvailable;
   }
 
   Future<SimpleKeyPairData> ensureCurrentUserKey(String uid) async {
@@ -65,6 +88,61 @@ class ScheduleEncryptionService {
     );
     await _savePublicKey(uid: uid, keyPair: keyPair);
     return keyPair;
+  }
+
+  Future<void> createPrivateKeyBackup({
+    required String uid,
+    required String password,
+  }) async {
+    final keyPair = await ensureCurrentUserKey(uid);
+    final backup = await _cipher.encryptPrivateKeyBackup(
+      keyPair: keyPair,
+      password: password,
+      keyVersion: currentKeyVersion,
+    );
+
+    await _publicKeyRef(uid).set({
+      'encryptedPrivateKeyBackup': backup.toJson(),
+      'updatedAt': FieldValue.serverTimestamp(),
+    }, SetOptions(merge: true));
+  }
+
+  Future<void> restorePrivateKeyFromBackup({
+    required String uid,
+    required String password,
+  }) async {
+    final publicKeyDoc = await _publicKeyRef(uid).get();
+    if (!publicKeyDoc.exists) {
+      throw const ScheduleEncryptionException(
+        'Private key backup is missing',
+      );
+    }
+
+    final data = publicKeyDoc.data() as Map<String, dynamic>;
+    final backup = _privateKeyBackupFromData(data);
+    if (backup == null) {
+      throw const ScheduleEncryptionException(
+        'Private key backup is missing',
+      );
+    }
+
+    final keyPair = await _cipher.decryptPrivateKeyBackup(
+      backup: backup,
+      password: password,
+    );
+    final expectedPublicKey = data['publicKey'] as String?;
+    if (expectedPublicKey != null &&
+        expectedPublicKey != _cipher.publicKeyToBase64(keyPair.publicKey)) {
+      throw const ScheduleEncryptionException(
+        'Restored private key does not match the current public key',
+      );
+    }
+
+    await _privateKeyStore.write(
+      uid: uid,
+      keyVersion: backup.keyVersion,
+      keyPair: keyPair,
+    );
   }
 
   Future<Map<String, dynamic>> toEncryptedFirestoreData({
@@ -318,5 +396,15 @@ class ScheduleEncryptionService {
         .doc(uid)
         .collection('encryption')
         .doc('current');
+  }
+
+  SchedulePrivateKeyBackup? _privateKeyBackupFromData(
+    Map<String, dynamic> data,
+  ) {
+    final backupJson = data['encryptedPrivateKeyBackup'];
+    if (backupJson is! Map) return null;
+    return SchedulePrivateKeyBackup.fromJson(
+      Map<String, dynamic>.from(backupJson),
+    );
   }
 }

--- a/lib/infrastructure/encryption/schedule_encryption_service.dart
+++ b/lib/infrastructure/encryption/schedule_encryption_service.dart
@@ -12,16 +12,18 @@ class ScheduleEncryptionService {
     FirebaseFirestore? firestore,
     ScheduleCipher? cipher,
     SchedulePrivateKeyStore? privateKeyStore,
-  })  : _firestore = firestore ?? FirebaseFirestore.instance,
+  })  : _firestore = firestore,
         _cipher = cipher ?? ScheduleCipher(),
         _privateKeyStore = privateKeyStore ?? SchedulePrivateKeyStore();
 
   static const encryptionVersion = 1;
   static const currentKeyVersion = 1;
 
-  final FirebaseFirestore _firestore;
+  final FirebaseFirestore? _firestore;
   final ScheduleCipher _cipher;
   final SchedulePrivateKeyStore _privateKeyStore;
+
+  FirebaseFirestore get _db => _firestore ?? FirebaseFirestore.instance;
 
   Future<void> tryEnsureCurrentUserKey(String uid) async {
     try {
@@ -391,7 +393,7 @@ class ScheduleEncryptionService {
   }
 
   DocumentReference _publicKeyRef(String uid) {
-    return _firestore
+    return _db
         .collection('users')
         .doc(uid)
         .collection('encryption')

--- a/lib/infrastructure/encryption/schedule_encryption_service.dart
+++ b/lib/infrastructure/encryption/schedule_encryption_service.dart
@@ -97,7 +97,12 @@ class ScheduleEncryptionService {
       uid: uid,
       keyVersion: keyVersion,
     );
-    if (localKey != null) {
+    final publicKey = data['publicKey'] as String?;
+    if (localKey != null &&
+        _localPrivateKeyMatchesPublicKey(
+          localKey: localKey,
+          publicKey: publicKey,
+        )) {
       return SchedulePrivateKeySetupStatus.ready;
     }
 
@@ -129,6 +134,13 @@ class ScheduleEncryptionService {
       );
       if (localKey == null) {
         throw MissingLocalPrivateKeyException(uid);
+      }
+      final publicKey = data['publicKey'] as String?;
+      if (!_localPrivateKeyMatchesPublicKey(
+        localKey: localKey,
+        publicKey: publicKey,
+      )) {
+        throw LocalPrivateKeyMismatchException(uid);
       }
       return localKey;
     }
@@ -194,10 +206,11 @@ class ScheduleEncryptionService {
     );
     final expectedPublicKey = data['publicKey'] as String?;
     if (expectedPublicKey != null &&
-        expectedPublicKey != _cipher.publicKeyToBase64(keyPair.publicKey)) {
-      throw const ScheduleEncryptionException(
-        'Restored private key does not match the current public key',
-      );
+        !_cipher.publicKeyMatchesPrivateKey(
+          privateKey: keyPair,
+          publicKey: expectedPublicKey,
+        )) {
+      throw RestoredPrivateKeyMismatchException(uid);
     }
 
     await _privateKeyStore.write(
@@ -564,5 +577,16 @@ class ScheduleEncryptionService {
     return SchedulePrivateKeyBackup.fromJson(
       Map<String, dynamic>.from(backupJson),
     );
+  }
+
+  bool _localPrivateKeyMatchesPublicKey({
+    required SimpleKeyPairData localKey,
+    required String? publicKey,
+  }) {
+    return publicKey == null ||
+        _cipher.publicKeyMatchesPrivateKey(
+          privateKey: localKey,
+          publicKey: publicKey,
+        );
   }
 }

--- a/lib/infrastructure/encryption/schedule_encryption_service.dart
+++ b/lib/infrastructure/encryption/schedule_encryption_service.dart
@@ -96,6 +96,16 @@ class ScheduleEncryptionService {
         : SchedulePrivateKeySetupStatus.restoreAvailable;
   }
 
+  Future<bool> hasPrivateKeyBackup(String uid) async {
+    final publicKeyDoc = await _publicKeyRef(uid).get();
+    if (!publicKeyDoc.exists) {
+      return false;
+    }
+
+    final data = publicKeyDoc.data() as Map<String, dynamic>;
+    return _privateKeyBackupFromData(data) != null;
+  }
+
   Future<SimpleKeyPairData> ensureCurrentUserKey(String uid) async {
     final publicKeyRef = _publicKeyRef(uid);
     final publicKeyDoc = await publicKeyRef.get();

--- a/lib/infrastructure/encryption/schedule_encryption_service.dart
+++ b/lib/infrastructure/encryption/schedule_encryption_service.dart
@@ -147,6 +147,67 @@ class ScheduleEncryptionService {
     );
   }
 
+  Future<Map<String, dynamic>> toEncryptedCommentContentData({
+    required DocumentSnapshot scheduleDoc,
+    required String currentUserId,
+    required String content,
+  }) async {
+    final scheduleKey = await scheduleKeyForCurrentUser(
+      scheduleDoc: scheduleDoc,
+      currentUserId: currentUserId,
+    );
+    if (scheduleKey == null) {
+      return {'content': content};
+    }
+
+    final payload = await _cipher.encryptText(
+      text: content,
+      scheduleKey: scheduleKey,
+    );
+    return {
+      'encrypted': true,
+      'encryptedContent': payload.toJson(),
+    };
+  }
+
+  Future<String> decryptCommentContentForCurrentUser({
+    required DocumentSnapshot scheduleDoc,
+    required String currentUserId,
+    required Map<String, dynamic> commentData,
+  }) async {
+    if (commentData['encrypted'] != true) {
+      return commentData['content'] as String? ?? '';
+    }
+
+    final scheduleKey = await scheduleKeyForCurrentUser(
+      scheduleDoc: scheduleDoc,
+      currentUserId: currentUserId,
+    );
+    if (scheduleKey == null) {
+      throw const ScheduleEncryptionException(
+        'Parent schedule is not encrypted',
+      );
+    }
+
+    final payload = ScheduleEncryptedPayload.fromJson(
+      Map<String, dynamic>.from(commentData['encryptedContent'] as Map),
+    );
+    return _cipher.decryptText(payload: payload, scheduleKey: scheduleKey);
+  }
+
+  Future<SecretKeyData?> scheduleKeyForCurrentUser({
+    required DocumentSnapshot scheduleDoc,
+    required String currentUserId,
+  }) async {
+    final data = scheduleDoc.data() as Map<String, dynamic>?;
+    if (data == null || data['encrypted'] != true) return null;
+
+    return _decryptScheduleKeyFromData(
+      data: data,
+      currentUserId: currentUserId,
+    );
+  }
+
   Future<void> _savePublicKey({
     required String uid,
     required SimpleKeyPairData keyPair,

--- a/lib/infrastructure/encryption/schedule_encryption_service.dart
+++ b/lib/infrastructure/encryption/schedule_encryption_service.dart
@@ -18,12 +18,52 @@ class ScheduleEncryptionService {
 
   static const encryptionVersion = 1;
   static const currentKeyVersion = 1;
+  static const migrationPublicKeyCollection = 'encryptionMigration';
+  static const migrationPublicKeyDoc = 'current';
 
   final FirebaseFirestore? _firestore;
   final ScheduleCipher _cipher;
   final SchedulePrivateKeyStore _privateKeyStore;
 
   FirebaseFirestore get _db => _firestore ?? FirebaseFirestore.instance;
+
+  static ScheduleRecipientEncryptionPlan planRecipientEncryption({
+    required Iterable<String> viewerIds,
+    required Iterable<ScheduleUserPublicKey> publicKeys,
+  }) {
+    final uniqueViewerIds = <String>{
+      for (final viewerId in viewerIds)
+        if (viewerId.isNotEmpty) viewerId,
+    }.toList();
+    final publicKeysByUserId = <String, ScheduleUserPublicKey>{
+      for (final publicKey in publicKeys) publicKey.uid: publicKey,
+    };
+    final readyUserIds = <String>[];
+    final missingUserIds = <String>[];
+
+    for (final viewerId in uniqueViewerIds) {
+      if (publicKeysByUserId.containsKey(viewerId)) {
+        readyUserIds.add(viewerId);
+      } else {
+        missingUserIds.add(viewerId);
+      }
+    }
+
+    return ScheduleRecipientEncryptionPlan(
+      publicKeysByUserId: publicKeysByUserId,
+      readyUserIds: readyUserIds,
+      missingUserIds: missingUserIds,
+    );
+  }
+
+  static bool canDecryptScheduleData(
+    Map<String, dynamic>? data, {
+    required String currentUserId,
+  }) {
+    if (data == null || data['encrypted'] != true) return true;
+    final encryptedKeys = data['encryptedKeys'];
+    return encryptedKeys is Map && encryptedKeys[currentUserId] != null;
+  }
 
   Future<void> tryEnsureCurrentUserKey(String uid) async {
     try {
@@ -168,12 +208,33 @@ class ScheduleEncryptionService {
       details: details,
       scheduleKey: scheduleKey,
     );
-    final encryptedKeys = await _encryptScheduleKeyForViewers(
+    final viewerIds = <String>{currentUserId, ...schedule.visibleTo};
+    final publicKeys = await _fetchAvailablePublicKeys(viewerIds);
+    final recipientPlan = planRecipientEncryption(
+      viewerIds: viewerIds,
+      publicKeys: publicKeys,
+    );
+    final encryptedKeys = await _encryptScheduleKeyForPublicKeys(
       scheduleKey: scheduleKey,
-      viewerIds: schedule.visibleTo,
+      publicKeys: recipientPlan.publicKeysByUserId.values,
     );
 
-    final data = ScheduleMapper.toFirestore(schedule);
+    final migrationPublicKey = schedule.sharedLists.isNotEmpty ||
+            recipientPlan.missingUserIds.isNotEmpty
+        ? await _fetchMigrationPublicKey()
+        : null;
+    final migrationEncryptedKey = migrationPublicKey == null
+        ? null
+        : await _cipher.encryptScheduleKey(
+            scheduleKey: scheduleKey,
+            recipientPublicKey:
+                _cipher.publicKeyFromBase64(migrationPublicKey.publicKey),
+            keyVersion: migrationPublicKey.keyVersion,
+          );
+
+    final data = ScheduleMapper.toFirestore(
+      schedule.copyWith(visibleTo: recipientPlan.readyUserIds),
+    );
     data
       ..remove('title')
       ..remove('description')
@@ -184,6 +245,29 @@ class ScheduleEncryptionService {
       ..['encryptedKeys'] = encryptedKeys.map(
         (uid, encryptedKey) => MapEntry(uid, encryptedKey.toJson()),
       );
+    if (migrationEncryptedKey != null && migrationPublicKey != null) {
+      data['migrationEncryptedKeys'] = {
+        migrationPublicKey.keyId: migrationEncryptedKey.toJson(),
+      };
+    } else if (existingDoc != null) {
+      data['migrationEncryptedKeys'] = FieldValue.delete();
+    }
+
+    if (recipientPlan.missingUserIds.isNotEmpty && migrationPublicKey != null) {
+      final pendingRecipients = {
+        for (final userId in recipientPlan.missingUserIds)
+          userId: SchedulePendingEncryptedRecipient(
+            reason: 'missingPublicKey',
+            migrationKeyId: migrationPublicKey.keyId,
+            sharedListIds: schedule.sharedLists,
+          ).toJson(),
+      };
+      data['pendingEncryptedRecipients'] = pendingRecipients;
+      data['pendingEncryptedRecipientIds'] = recipientPlan.missingUserIds;
+    } else if (existingDoc != null) {
+      data['pendingEncryptedRecipients'] = FieldValue.delete();
+      data['pendingEncryptedRecipientIds'] = FieldValue.delete();
+    }
     return data;
   }
 
@@ -219,7 +303,9 @@ class ScheduleEncryptionService {
       data: data,
       currentUserId: currentUserId,
     );
-    final publicKey = (await _fetchPublicKeys({viewerId})).single;
+    final publicKeys = await _fetchAvailablePublicKeys({viewerId});
+    if (publicKeys.isEmpty) return null;
+    final publicKey = publicKeys.single;
     return _cipher.encryptScheduleKey(
       scheduleKey: scheduleKey,
       recipientPublicKey: _cipher.publicKeyFromBase64(publicKey.publicKey),
@@ -354,11 +440,10 @@ class ScheduleEncryptionService {
     );
   }
 
-  Future<Map<String, ScheduleEncryptedKey>> _encryptScheduleKeyForViewers({
+  Future<Map<String, ScheduleEncryptedKey>> _encryptScheduleKeyForPublicKeys({
     required SecretKeyData scheduleKey,
-    required Iterable<String> viewerIds,
+    required Iterable<ScheduleUserPublicKey> publicKeys,
   }) async {
-    final publicKeys = await _fetchPublicKeys(viewerIds.toSet());
     final entries = await Future.wait(publicKeys.map((publicKey) async {
       final encryptedKey = await _cipher.encryptScheduleKey(
         scheduleKey: scheduleKey,
@@ -370,7 +455,7 @@ class ScheduleEncryptionService {
     return Map.fromEntries(entries);
   }
 
-  Future<List<ScheduleUserPublicKey>> _fetchPublicKeys(
+  Future<List<ScheduleUserPublicKey>> _fetchAvailablePublicKeys(
     Set<String> viewerIds,
   ) async {
     final results = await Future.wait(viewerIds.map((uid) async {
@@ -383,13 +468,18 @@ class ScheduleEncryptionService {
         keyVersion: data['keyVersion'] as int? ?? currentKeyVersion,
       );
     }));
-    final publicKeys = results.whereType<ScheduleUserPublicKey>().toList();
-    final foundUserIds = publicKeys.map((key) => key.uid).toSet();
-    final missingUserIds = viewerIds.difference(foundUserIds).toList();
-    if (missingUserIds.isNotEmpty) {
-      throw MissingRecipientPublicKeyException(missingUserIds);
-    }
-    return publicKeys;
+    return results.whereType<ScheduleUserPublicKey>().toList();
+  }
+
+  Future<ScheduleMigrationPublicKey?> _fetchMigrationPublicKey() async {
+    final doc = await _db
+        .collection(migrationPublicKeyCollection)
+        .doc(migrationPublicKeyDoc)
+        .get();
+    if (!doc.exists) return null;
+    final data = doc.data();
+    if (data == null || data['enabled'] == false) return null;
+    return ScheduleMigrationPublicKey.fromJson(data);
   }
 
   DocumentReference _publicKeyRef(String uid) {

--- a/lib/infrastructure/encryption/schedule_private_key_store.dart
+++ b/lib/infrastructure/encryption/schedule_private_key_store.dart
@@ -1,0 +1,51 @@
+import 'package:cryptography/cryptography.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+import 'schedule_cipher.dart';
+
+class SchedulePrivateKeyStore {
+  SchedulePrivateKeyStore({
+    FlutterSecureStorage? secureStorage,
+    ScheduleCipher? cipher,
+  })  : _secureStorage = secureStorage ?? const FlutterSecureStorage(),
+        _cipher = cipher ?? ScheduleCipher();
+
+  final FlutterSecureStorage _secureStorage;
+  final ScheduleCipher _cipher;
+
+  Future<SimpleKeyPairData?> read({
+    required String uid,
+    required int keyVersion,
+  }) async {
+    final value = await _secureStorage.read(
+      key: _key(uid: uid, keyVersion: keyVersion),
+    );
+    if (value == null) return null;
+    return _cipher.privateKeyFromJson(value);
+  }
+
+  Future<void> write({
+    required String uid,
+    required int keyVersion,
+    required SimpleKeyPairData keyPair,
+  }) {
+    return _secureStorage.write(
+      key: _key(uid: uid, keyVersion: keyVersion),
+      value: _cipher.privateKeyToJson(keyPair),
+    );
+  }
+
+  Future<void> delete({
+    required String uid,
+    required int keyVersion,
+  }) {
+    return _secureStorage.delete(key: _key(uid: uid, keyVersion: keyVersion));
+  }
+
+  String _key({
+    required String uid,
+    required int keyVersion,
+  }) {
+    return 'lakiite.encryption.privateKey.$uid.$keyVersion';
+  }
+}

--- a/lib/infrastructure/firebase/push_notification_sender.dart
+++ b/lib/infrastructure/firebase/push_notification_sender.dart
@@ -121,19 +121,12 @@ class PushNotificationSender {
     required String interactionId,
     String? commentContent,
   }) async {
-    final commentPreview = commentContent != null && commentContent.isNotEmpty
-        ? (commentContent.length > 50
-            ? '${commentContent.substring(0, 47)}...'
-            : commentContent)
-        : '';
-
     return _sendNotification(
       logContext: 'コメント通知',
       toUserId: toUserId,
       notificationBody: {
         'title': '新しいコメント',
-        'body':
-            '$fromUserNameさんがあなたの投稿にコメントしました${commentPreview.isNotEmpty ? ': $commentPreview' : ''}',
+        'body': '$fromUserNameさんがあなたの投稿にコメントしました',
       },
       data: {
         'type': 'comment',
@@ -142,7 +135,7 @@ class PushNotificationSender {
         'fromUserName': fromUserName,
         'scheduleId': scheduleId,
         'interactionId': interactionId,
-        'commentContent': commentContent ?? '',
+        'commentContent': '',
         'timestamp': DateTime.now().millisecondsSinceEpoch.toString(),
       },
     );

--- a/lib/infrastructure/firebase/push_notification_service.dart
+++ b/lib/infrastructure/firebase/push_notification_service.dart
@@ -672,7 +672,6 @@ class PushNotificationService {
     AppLogger.info('💬 コメントメッセージを処理中');
     AppLogger.info('💬 送信元ユーザーID: ${data['fromUserId']}');
     AppLogger.info('💬 スケジュールID: ${data['scheduleId']}');
-    AppLogger.info('💬 コメント内容: ${data['commentText']}');
     AppLogger.info('💬 データ詳細: $data');
   }
 

--- a/lib/infrastructure/mapper/schedule_mapper.dart
+++ b/lib/infrastructure/mapper/schedule_mapper.dart
@@ -1,16 +1,37 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import '../../domain/entity/schedule.dart';
+import '../../domain/entity/schedule_encryption.dart';
 
 /// スケジュールのドメインモデルとFirestoreデータの変換を担当するマッパー
 class ScheduleMapper {
   /// FirestoreのドキュメントからScheduleエンティティを生成
-  static Schedule fromFirestore(DocumentSnapshot doc) {
+  static Schedule fromFirestore(
+    DocumentSnapshot doc, {
+    SchedulePlainDetails? decryptedDetails,
+  }) {
     final data = doc.data() as Map<String, dynamic>;
+    return fromFirestoreData(
+      doc.id,
+      data,
+      decryptedDetails: decryptedDetails,
+    );
+  }
+
+  static Schedule fromFirestoreData(
+    String id,
+    Map<String, dynamic> data, {
+    SchedulePlainDetails? decryptedDetails,
+  }) {
+    final isEncrypted = data['encrypted'] == true;
     return Schedule(
-      id: doc.id,
-      title: data['title'] as String,
-      description: data['description'] as String,
-      location: data['location'] as String?,
+      id: id,
+      title: decryptedDetails?.title ??
+          (data['title'] as String?) ??
+          (isEncrypted ? '予定を復号できません' : ''),
+      description: decryptedDetails?.description ??
+          (data['description'] as String?) ??
+          '',
+      location: decryptedDetails?.location ?? (data['location'] as String?),
       startDateTime: _parseDateTime(data['startDateTime']),
       endDateTime: _parseDateTime(data['endDateTime']),
       isAllDay: data['isAllDay'] as bool? ?? false,

--- a/lib/infrastructure/schedule_interaction_repository.dart
+++ b/lib/infrastructure/schedule_interaction_repository.dart
@@ -4,6 +4,7 @@ import 'package:lakiite/domain/entity/schedule_comment.dart';
 import 'package:lakiite/domain/interfaces/i_schedule_interaction_repository.dart';
 import '../utils/logger.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'encryption/schedule_encryption_service.dart';
 
 /// スケジュールの相互作用（リアクション・コメント）に関するデータアクセスを管理
 ///
@@ -14,11 +15,16 @@ class ScheduleInteractionRepository implements IScheduleInteractionRepository {
   ///
   /// [firestore]が指定されない場合は、デフォルトのインスタンスを使用します。
   /// テスト時にモックの[FirebaseFirestore]インスタンスを注入できます。
-  ScheduleInteractionRepository({FirebaseFirestore? firestore})
-      : _firestore = firestore ?? FirebaseFirestore.instance;
+  ScheduleInteractionRepository({
+    FirebaseFirestore? firestore,
+    ScheduleEncryptionService? encryptionService,
+  })  : _firestore = firestore ?? FirebaseFirestore.instance,
+        _encryptionService = encryptionService ??
+            ScheduleEncryptionService(firestore: firestore);
 
   /// Firestoreのインスタンス
   final FirebaseFirestore _firestore;
+  final ScheduleEncryptionService _encryptionService;
 
   /// 指定された[scheduleId]に関連する全リアクションを取得
   ///
@@ -195,6 +201,8 @@ class ScheduleInteractionRepository implements IScheduleInteractionRepository {
   /// コメントは作成日時の降順でソートされ、[ScheduleComment]のリストとして返されます。
   @override
   Future<List<ScheduleComment>> getComments(String scheduleId) async {
+    final scheduleDoc = await _scheduleDoc(scheduleId).get();
+    final currentUserId = await _getCurrentUserId();
     final snapshot = await _firestore
         .collection('schedules')
         .doc(scheduleId)
@@ -202,40 +210,15 @@ class ScheduleInteractionRepository implements IScheduleInteractionRepository {
         .orderBy('createdAt', descending: true)
         .get();
 
-    // すべてのコメントフィールドの詳細をログ出力
-    AppLogger.debug('========= コメントデータ詳細 =========');
     AppLogger.debug('スケジュールID: $scheduleId, 取得コメント数: ${snapshot.docs.length}');
 
-    // 各コメントのデータ構造を詳細に記録
-    for (final doc in snapshot.docs) {
-      final data = doc.data();
-      AppLogger.debug('コメントID: ${doc.id}');
-      AppLogger.debug('フィールド一覧: ${data.keys.join(", ")}');
-      AppLogger.debug('contentフィールドの有無: ${data.containsKey("content")}');
-      AppLogger.debug('textフィールドの有無: ${data.containsKey("text")}');
-      if (data.containsKey('content')) {
-        AppLogger.debug('content値: ${data["content"]}');
-      }
-      if (data.containsKey('text')) {
-        AppLogger.debug('text値: ${data["text"]}');
-      }
-    }
-    AppLogger.debug('===================================');
-
-    final comments = snapshot.docs.map((doc) {
-      try {
-        final data = {...doc.data(), 'id': doc.id};
-        AppLogger.debug('Comment Data from Firestore: $data');
-        final comment = ScheduleComment.fromJson(data);
-        AppLogger.debug('Converted Comment: $comment');
-        return comment;
-      } catch (e, stackTrace) {
-        AppLogger.error('Error converting comment: $e');
-        AppLogger.error('Stack trace: $stackTrace');
-        rethrow;
-      }
-    }).toList();
-    return comments;
+    return Future.wait(snapshot.docs.map(
+      (doc) => _commentFromDoc(
+        scheduleDoc: scheduleDoc,
+        currentUserId: currentUserId,
+        doc: doc,
+      ),
+    ));
   }
 
   /// 指定された[scheduleId]のスケジュールに新しいコメントを追加
@@ -256,16 +239,23 @@ class ScheduleInteractionRepository implements IScheduleInteractionRepository {
       AppLogger.debug('User data fetched: $userData');
 
       final now = Timestamp.now();
+      final scheduleDoc = await _scheduleDoc(scheduleId).get();
+      final contentData =
+          await _encryptionService.toEncryptedCommentContentData(
+        scheduleDoc: scheduleDoc,
+        currentUserId: userId,
+        content: content,
+      );
       final commentData = {
         'userId': userId,
-        'content': content,
+        ...contentData,
         'createdAt': now,
         'updatedAt': now, // createdAtと同じ値に設定
         'isEdited': false, // 初期値としてfalseを設定
         'userDisplayName': userData?['displayName'],
         'userPhotoUrl': userData?['iconUrl'],
       };
-      AppLogger.debug('Comment data to save: $commentData');
+      AppLogger.debug('Comment data prepared for save');
 
       final docRef = await _firestore
           .collection('schedules')
@@ -353,17 +343,6 @@ class ScheduleInteractionRepository implements IScheduleInteractionRepository {
 
       // 更新するデータを準備 - セキュリティルールを満たすために必要最小限のフィールドのみ含める
       // セキュリティルールでは ['content', 'updatedAt', 'isEdited'] のみが許可されている
-      final now = Timestamp.now();
-      final updateData = {
-        'content': content,
-        'isEdited': true,
-        'updatedAt': now,
-      };
-
-      AppLogger.debug('更新データ: $updateData');
-      AppLogger.debug(
-          '更新データの型: updatedAt=${updateData['updatedAt']?.runtimeType}, isEdited=${updateData['isEdited']?.runtimeType}');
-
       // 現在のユーザーIDを取得して権限チェック
       final currentUserId = await _getCurrentUserId();
       final commentUserId = existingData?['userId'];
@@ -371,10 +350,34 @@ class ScheduleInteractionRepository implements IScheduleInteractionRepository {
       AppLogger.debug('現在のユーザーID: $currentUserId');
       AppLogger.debug('コメント所有者ID: $commentUserId');
 
+      if (currentUserId == null) {
+        throw Exception('ユーザーが認証されていません');
+      }
+
       if (currentUserId != commentUserId) {
         AppLogger.error('権限エラー: コメント所有者ではありません');
         throw Exception('このコメントを編集する権限がありません');
       }
+
+      final scheduleDoc = await _scheduleDoc(scheduleId).get();
+      final now = Timestamp.now();
+      final contentData =
+          await _encryptionService.toEncryptedCommentContentData(
+        scheduleDoc: scheduleDoc,
+        currentUserId: currentUserId,
+        content: content,
+      );
+      final updateData = {
+        ...contentData,
+        'isEdited': true,
+        'updatedAt': now,
+      };
+      if (contentData['encrypted'] == true) {
+        updateData['content'] = FieldValue.delete();
+      }
+
+      AppLogger.debug(
+          '更新データの型: updatedAt=${updateData['updatedAt']?.runtimeType}, isEdited=${updateData['isEdited']?.runtimeType}');
 
       try {
         await _firestore
@@ -394,8 +397,6 @@ class ScheduleInteractionRepository implements IScheduleInteractionRepository {
           AppLogger.error('ユーザーID: $currentUserId');
           AppLogger.error('コメント所有者ID: $commentUserId');
 
-          // 更新データの詳細をログ出力
-          AppLogger.error('更新データの詳細: $updateData');
           AppLogger.error('更新対象フィールド: ${updateData.keys.join(", ")}');
 
           // ドキュメントデータを再度取得して確認
@@ -448,22 +449,18 @@ class ScheduleInteractionRepository implements IScheduleInteractionRepository {
         .collection('comments')
         .orderBy('createdAt', descending: true)
         .snapshots()
-        .map((snapshot) {
+        .asyncMap((snapshot) async {
+      final scheduleDoc = await _scheduleDoc(scheduleId).get();
+      final currentUserId = await _getCurrentUserId();
       AppLogger.debug(
           'Received comment snapshot with ${snapshot.docs.length} documents');
-      final comments = snapshot.docs.map((doc) {
-        try {
-          final data = {...doc.data(), 'id': doc.id};
-          AppLogger.debug('Comment Data from Firestore (Watch): $data');
-          final comment = ScheduleComment.fromJson(data);
-          AppLogger.debug('Converted Comment (Watch): $comment');
-          return comment;
-        } catch (e, stackTrace) {
-          AppLogger.error('Error converting comment: $e');
-          AppLogger.error('Stack trace: $stackTrace');
-          rethrow;
-        }
-      }).toList();
+      final comments = await Future.wait(snapshot.docs.map(
+        (doc) => _commentFromDoc(
+          scheduleDoc: scheduleDoc,
+          currentUserId: currentUserId,
+          doc: doc,
+        ),
+      ));
       AppLogger.debug('Converted ${comments.length} comments');
       return comments;
     });
@@ -511,5 +508,39 @@ class ScheduleInteractionRepository implements IScheduleInteractionRepository {
   Future<String?> _getCurrentUserId() async {
     final auth = FirebaseAuth.instance;
     return auth.currentUser?.uid;
+  }
+
+  DocumentReference<Map<String, dynamic>> _scheduleDoc(String scheduleId) {
+    return _firestore.collection('schedules').doc(scheduleId);
+  }
+
+  Future<ScheduleComment> _commentFromDoc({
+    required DocumentSnapshot scheduleDoc,
+    required String? currentUserId,
+    required QueryDocumentSnapshot<Map<String, dynamic>> doc,
+  }) async {
+    try {
+      final data = {...doc.data(), 'id': doc.id};
+      if (data['encrypted'] == true && currentUserId != null) {
+        data['content'] =
+            await _encryptionService.decryptCommentContentForCurrentUser(
+          scheduleDoc: scheduleDoc,
+          currentUserId: currentUserId,
+          commentData: data,
+        );
+      } else if (data['encrypted'] == true) {
+        data['content'] = 'コメントを復号できません';
+      }
+
+      return ScheduleComment.fromJson(data);
+    } catch (e, stackTrace) {
+      AppLogger.error('Error converting comment: $e');
+      AppLogger.error('Stack trace: $stackTrace');
+      return ScheduleComment.fromJson({
+        ...doc.data(),
+        'id': doc.id,
+        'content': 'コメントを復号できません',
+      });
+    }
   }
 }

--- a/lib/infrastructure/schedule_interaction_repository.dart
+++ b/lib/infrastructure/schedule_interaction_repository.dart
@@ -341,8 +341,6 @@ class ScheduleInteractionRepository implements IScheduleInteractionRepository {
       AppLogger.debug(
           '既存コメントのisEdited: $isEditedValue (${isEditedValue?.runtimeType})');
 
-      // 更新するデータを準備 - セキュリティルールを満たすために必要最小限のフィールドのみ含める
-      // セキュリティルールでは ['content', 'updatedAt', 'isEdited'] のみが許可されている
       // 現在のユーザーIDを取得して権限チェック
       final currentUserId = await _getCurrentUserId();
       final commentUserId = existingData?['userId'];

--- a/lib/infrastructure/schedule_repository.dart
+++ b/lib/infrastructure/schedule_repository.dart
@@ -1,8 +1,10 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import '../domain/entity/list.dart';
 import '../domain/entity/schedule.dart';
 import '../domain/interfaces/i_schedule_access_grant_repository.dart';
 import '../domain/interfaces/i_schedule_repository.dart';
+import '../domain/service/schedule_recipient_diff_calculator.dart';
 import '../domain/value/schedule_month_range.dart';
 import '../utils/logger.dart';
 import 'encryption/schedule_encryption_service.dart';
@@ -218,11 +220,43 @@ class ScheduleRepository
 
       final docRef = _firestore.collection('schedules').doc(schedule.id);
       final existingDoc = await docRef.get();
+      final currentUserId = _auth.currentUser!.uid;
+      final existingData = existingDoc.data();
+      final beforeSharedListIds = List<String>.from(
+        existingData?['sharedLists'] as List? ?? [],
+      );
+      final afterSharedListIds = schedule.sharedLists;
+      final membersByListId = await _currentMembersByListId({
+        ...beforeSharedListIds,
+        ...afterSharedListIds,
+      });
+      final recipientDiff = ScheduleRecipientDiffCalculator.calculate(
+        ownerId: currentUserId,
+        beforeSharedListIds: beforeSharedListIds,
+        afterSharedListIds: afterSharedListIds,
+        membersByListId: membersByListId,
+      );
+
+      if (existingDoc.exists && recipientDiff.requiresRekey) {
+        await _rekeyScheduleForRecipients(
+          doc: existingDoc,
+          recipientIds: recipientDiff.afterRecipientIds,
+          currentUserId: currentUserId,
+          scheduleOverride: schedule,
+        );
+        invalidateScheduleCache(schedule.id);
+        return;
+      }
+
+      final scheduleForEncryption = schedule.copyWith(
+        visibleTo: recipientDiff.afterRecipientIds.toList(),
+      );
       final data = await _encryptionService.toEncryptedFirestoreData(
-        schedule: schedule,
-        currentUserId: _auth.currentUser!.uid,
+        schedule: scheduleForEncryption,
+        currentUserId: currentUserId,
         existingDoc: existingDoc.exists ? existingDoc : null,
       );
+      data['visibleTo'] = [currentUserId];
 
       await docRef.update(data);
       invalidateScheduleCache(schedule.id);
@@ -251,7 +285,6 @@ class ScheduleRepository
       if (visibleTo.contains(userId)) continue;
 
       final updates = <String, dynamic>{
-        'visibleTo': FieldValue.arrayUnion([userId]),
         'updatedAt': DateTime.now().toIso8601String(),
       };
 
@@ -262,18 +295,221 @@ class ScheduleRepository
           currentUserId: _auth.currentUser!.uid,
           viewerId: userId,
         );
-        if (encryptedKey != null) {
-          final encryptedKeys = Map<String, dynamic>.from(
-            data['encryptedKeys'] as Map? ?? {},
-          );
-          encryptedKeys[userId] = encryptedKey.toJson();
-          updates['encryptedKeys'] = encryptedKeys;
+        if (encryptedKey == null) {
+          continue;
         }
+        final encryptedKeys = Map<String, dynamic>.from(
+          data['encryptedKeys'] as Map? ?? {},
+        );
+        encryptedKeys[userId] = encryptedKey.toJson();
+        updates['encryptedKeys'] = encryptedKeys;
       }
+      updates['visibleTo'] = FieldValue.arrayUnion([userId]);
 
       await doc.reference.update(updates);
       invalidateScheduleCache(doc.id);
     }
+  }
+
+  @override
+  Future<void> syncListSchedulesAccess({
+    required UserList beforeList,
+    required UserList afterList,
+  }) async {
+    await _ensureAuthenticated();
+    final currentUserId = _auth.currentUser!.uid;
+    if (beforeList.ownerId != currentUserId ||
+        afterList.ownerId != currentUserId) {
+      return;
+    }
+
+    final today = DateTime.now();
+    final todayIso =
+        DateTime(today.year, today.month, today.day).toIso8601String();
+    final snapshot = await _firestore
+        .collection('schedules')
+        .where('ownerId', isEqualTo: currentUserId)
+        .where('startDateTime', isGreaterThanOrEqualTo: todayIso)
+        .get();
+
+    for (final doc in snapshot.docs) {
+      final data = doc.data();
+      if (data['encrypted'] != true) {
+        continue;
+      }
+
+      final sharedListIds =
+          List<String>.from(data['sharedLists'] as List? ?? []);
+      if (!sharedListIds.contains(afterList.id)) {
+        continue;
+      }
+
+      final beforeMembersByListId = await _membersByListId(
+        sharedListIds,
+        changedList: beforeList,
+      );
+      final afterMembersByListId = await _membersByListId(
+        sharedListIds,
+        changedList: afterList,
+      );
+      final diff = ScheduleRecipientDiffCalculator.calculate(
+        ownerId: currentUserId,
+        beforeSharedListIds: sharedListIds,
+        afterSharedListIds: sharedListIds,
+        membersByListId: beforeMembersByListId,
+        afterMembersByListId: afterMembersByListId,
+      );
+
+      if (diff.hasNoKeyChange) {
+        continue;
+      }
+
+      if (diff.requiresRekey) {
+        await _rekeyScheduleForRecipients(
+          doc: doc,
+          recipientIds: diff.afterRecipientIds,
+          currentUserId: currentUserId,
+        );
+      } else if (diff.requiresRewrap) {
+        await _rewrapScheduleForAddedRecipients(
+          doc: doc,
+          addedUserIds: diff.addedUserIds,
+          currentUserId: currentUserId,
+        );
+      }
+
+      invalidateScheduleCache(doc.id);
+    }
+  }
+
+  Future<Map<String, Iterable<String>>> _membersByListId(
+    Iterable<String> listIds, {
+    required UserList changedList,
+  }) async {
+    final entries = await Future.wait(listIds.map((listId) async {
+      if (listId == changedList.id) {
+        return MapEntry(listId, changedList.memberIds);
+      }
+
+      final doc = await _firestore.collection('lists').doc(listId).get();
+      final data = doc.data();
+      return MapEntry(
+        listId,
+        List<String>.from(data?['memberIds'] as List? ?? []),
+      );
+    }));
+    return Map.fromEntries(entries);
+  }
+
+  Future<Map<String, Iterable<String>>> _currentMembersByListId(
+    Iterable<String> listIds,
+  ) async {
+    final entries = await Future.wait(listIds.map((listId) async {
+      final doc = await _firestore.collection('lists').doc(listId).get();
+      final data = doc.data();
+      return MapEntry(
+        listId,
+        List<String>.from(data?['memberIds'] as List? ?? []),
+      );
+    }));
+    return Map.fromEntries(entries);
+  }
+
+  Future<void> _rewrapScheduleForAddedRecipients({
+    required QueryDocumentSnapshot<Map<String, dynamic>> doc,
+    required Set<String> addedUserIds,
+    required String currentUserId,
+  }) async {
+    final data = doc.data();
+    final encryptedKeys = Map<String, dynamic>.from(
+      data['encryptedKeys'] as Map? ?? {},
+    );
+
+    for (final userId in addedUserIds) {
+      if (userId == currentUserId || encryptedKeys.containsKey(userId)) {
+        continue;
+      }
+
+      final encryptedKey =
+          await _encryptionService.encryptedScheduleKeyForAdditionalViewer(
+        doc: doc,
+        currentUserId: currentUserId,
+        viewerId: userId,
+      );
+      if (encryptedKey != null) {
+        encryptedKeys[userId] = encryptedKey.toJson();
+      }
+    }
+
+    await doc.reference.update({
+      'encryptedKeys': encryptedKeys,
+      'visibleTo': [currentUserId],
+      'updatedAt': DateTime.now().toIso8601String(),
+    });
+  }
+
+  Future<void> _rekeyScheduleForRecipients({
+    required DocumentSnapshot<Map<String, dynamic>> doc,
+    required Set<String> recipientIds,
+    required String currentUserId,
+    Schedule? scheduleOverride,
+  }) async {
+    final schedule =
+        (scheduleOverride ?? await _decryptedSchedule(doc)).copyWith(
+      visibleTo: recipientIds.toList(),
+      updatedAt: DateTime.now(),
+    );
+    final commentSnapshot = await doc.reference.collection('comments').get();
+    final decryptedComments = await Future.wait(
+      commentSnapshot.docs.map((commentDoc) async {
+        final commentData = commentDoc.data();
+        final content = commentData['encrypted'] == true
+            ? await _encryptionService.decryptCommentContentForCurrentUser(
+                scheduleDoc: doc,
+                currentUserId: currentUserId,
+                commentData: commentData,
+              )
+            : commentData['content'] as String? ?? '';
+        return MapEntry(commentDoc.reference, content);
+      }),
+    );
+
+    final rekeyed = await _encryptionService.toRekeyedFirestoreData(
+      schedule: schedule,
+      currentUserId: currentUserId,
+      existingDoc: doc,
+    );
+    rekeyed.scheduleData['visibleTo'] = [currentUserId];
+
+    final batch = _firestore.batch();
+    batch.update(doc.reference, rekeyed.scheduleData);
+    for (final comment in decryptedComments) {
+      final contentData =
+          await _encryptionService.toEncryptedCommentContentDataWithScheduleKey(
+        scheduleKey: rekeyed.scheduleKey,
+        content: comment.value,
+      );
+      batch.update(comment.key, {
+        ...contentData,
+        'content': FieldValue.delete(),
+      });
+    }
+    await batch.commit();
+  }
+
+  Future<Schedule> _decryptedSchedule(
+    DocumentSnapshot<Map<String, dynamic>> doc,
+  ) async {
+    final currentUserId = _auth.currentUser!.uid;
+    final decryptedDetails =
+        await _encryptionService.decryptDetailsForCurrentUser(
+      doc: doc,
+      currentUserId: currentUserId,
+    );
+    return ScheduleMapper.fromFirestore(
+      doc,
+      decryptedDetails: decryptedDetails,
+    );
   }
 
   @override

--- a/lib/infrastructure/schedule_repository.dart
+++ b/lib/infrastructure/schedule_repository.dart
@@ -92,6 +92,24 @@ class ScheduleRepository
     }
   }
 
+  Future<Schedule?> _enrichScheduleIfDisplayable(DocumentSnapshot doc) async {
+    await _ensureAuthenticated();
+
+    final data = doc.data() as Map<String, dynamic>?;
+    final currentUserId = _auth.currentUser!.uid;
+    if (!ScheduleEncryptionService.canDecryptScheduleData(
+      data,
+      currentUserId: currentUserId,
+    )) {
+      AppLogger.debug(
+        'Skipping encrypted schedule without key for current user: ${doc.id}',
+      );
+      return null;
+    }
+
+    return _enrichSchedule(doc);
+  }
+
   // キャッシュをクリア（必要に応じて呼び出す）
   void clearCache() {
     _enrichmentCache.clear();
@@ -118,9 +136,10 @@ class ScheduleRepository
           .get();
     });
 
-    final schedules =
-        await Future.wait(snapshot.docs.map((doc) => _enrichSchedule(doc)));
-    return schedules;
+    final schedules = await Future.wait(
+      snapshot.docs.map((doc) => _enrichScheduleIfDisplayable(doc)),
+    );
+    return schedules.whereType<Schedule>().toList();
   }
 
   @override
@@ -151,9 +170,10 @@ class ScheduleRepository
           .get();
     });
 
-    final schedules =
-        await Future.wait(snapshot.docs.map((doc) => _enrichSchedule(doc)));
-    return schedules;
+    final schedules = await Future.wait(
+      snapshot.docs.map((doc) => _enrichScheduleIfDisplayable(doc)),
+    );
+    return schedules.whereType<Schedule>().toList();
   }
 
   @override
@@ -281,9 +301,10 @@ class ScheduleRepository
         .orderBy('startDateTime', descending: false)
         .snapshots()
         .asyncMap((snapshot) async {
-      final schedules =
-          await Future.wait(snapshot.docs.map((doc) => _enrichSchedule(doc)));
-      return schedules;
+      final schedules = await Future.wait(
+        snapshot.docs.map((doc) => _enrichScheduleIfDisplayable(doc)),
+      );
+      return schedules.whereType<Schedule>().toList();
     });
   }
 
@@ -312,9 +333,9 @@ class ScheduleRepository
       await for (final snapshot in stream) {
         try {
           final schedules = await Future.wait(
-            snapshot.docs.map((doc) => _enrichSchedule(doc)),
+            snapshot.docs.map((doc) => _enrichScheduleIfDisplayable(doc)),
           );
-          yield schedules;
+          yield schedules.whereType<Schedule>().toList();
         } catch (e) {
           AppLogger.error('Error processing schedule snapshot: $e');
           // エラーが発生した場合は空のリストを返す
@@ -357,13 +378,14 @@ class ScheduleRepository
           final cachedSchedules = (await Future.wait(
             cachedSnapshot.docs.map((doc) async {
               try {
-                return await _enrichSchedule(doc);
+                return await _enrichScheduleIfDisplayable(doc);
               } catch (e) {
-                // エンリッチ中のエラーは無視してマッピングのみを行う
-                return ScheduleMapper.fromFirestore(doc);
+                AppLogger.error('Error enriching cached schedule: $e');
+                return null;
               }
             }),
           ))
+              .whereType<Schedule>()
               .where(range.overlaps)
               .toList();
 
@@ -427,16 +449,15 @@ class ScheduleRepository
       final batchResults = await Future.wait(
         batch.map((doc) async {
           try {
-            return await _enrichSchedule(doc);
+            return await _enrichScheduleIfDisplayable(doc);
           } catch (e) {
-            // エラー時はベーシックな情報だけでスケジュールを作成
             AppLogger.error('Error enriching schedule in batch: $e');
-            return ScheduleMapper.fromFirestore(doc);
+            return null;
           }
         }),
       );
 
-      results.addAll(batchResults);
+      results.addAll(batchResults.whereType<Schedule>());
     }
 
     return results;

--- a/lib/infrastructure/schedule_repository.dart
+++ b/lib/infrastructure/schedule_repository.dart
@@ -1,18 +1,28 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import '../domain/entity/schedule.dart';
+import '../domain/interfaces/i_schedule_access_grant_repository.dart';
 import '../domain/interfaces/i_schedule_repository.dart';
 import '../domain/value/schedule_month_range.dart';
 import '../utils/logger.dart';
+import 'encryption/schedule_encryption_service.dart';
 import 'mapper/schedule_mapper.dart';
 import 'schedule_enrichment_cache.dart';
 
-class ScheduleRepository implements IScheduleRepository {
-  ScheduleRepository()
-      : _firestore = FirebaseFirestore.instance,
-        _auth = FirebaseAuth.instance;
+class ScheduleRepository
+    implements IScheduleRepository, IScheduleAccessGrantRepository {
+  ScheduleRepository({
+    FirebaseFirestore? firestore,
+    FirebaseAuth? auth,
+    ScheduleEncryptionService? encryptionService,
+  })  : _firestore = firestore ?? FirebaseFirestore.instance,
+        _auth = auth ?? FirebaseAuth.instance,
+        _encryptionService = encryptionService ??
+            ScheduleEncryptionService(firestore: firestore);
+
   final FirebaseFirestore _firestore;
   final FirebaseAuth _auth;
+  final ScheduleEncryptionService _encryptionService;
 
   final ScheduleEnrichmentCache _enrichmentCache = ScheduleEnrichmentCache();
 
@@ -25,6 +35,9 @@ class ScheduleRepository implements IScheduleRepository {
         throw Exception('User not authenticated');
       }
     }
+
+    final uid = _auth.currentUser!.uid;
+    await _encryptionService.tryEnsureCurrentUserKey(uid);
   }
 
   // リアクション数とコメント数を一括で取得（バッチ処理）
@@ -57,23 +70,24 @@ class ScheduleRepository implements IScheduleRepository {
     await _ensureAuthenticated();
 
     try {
-      // 基本的なスケジュール情報を取得
-      final schedule = ScheduleMapper.fromFirestore(doc);
+      final currentUserId = _auth.currentUser!.uid;
+      final decryptedDetails = await _encryptionService
+          .decryptDetailsForCurrentUser(doc: doc, currentUserId: currentUserId);
 
-      // リアクション数とコメント数を一括取得
+      final schedule = ScheduleMapper.fromFirestore(
+        doc,
+        decryptedDetails: decryptedDetails,
+      );
+
       final (reactionCount, commentCount) =
           await _fetchInteractionCounts(doc.reference);
 
-      // リアクション数とコメント数を更新したスケジュールを作成
-      final enrichedSchedule = schedule.copyWith(
+      return schedule.copyWith(
         reactionCount: reactionCount,
         commentCount: commentCount,
       );
-
-      return enrichedSchedule;
     } catch (e) {
       AppLogger.error('Error enriching schedule: $e');
-      // エラーが発生した場合でも基本的なスケジュール情報は返す
       return ScheduleMapper.fromFirestore(doc);
     }
   }
@@ -145,40 +159,27 @@ class ScheduleRepository implements IScheduleRepository {
   @override
   Future<Schedule> createSchedule(Schedule schedule) async {
     try {
-      AppLogger.debug('ScheduleRepository: Starting schedule creation');
-      AppLogger.debug('Schedule details:');
-      AppLogger.debug('Title: ${schedule.title}');
-      AppLogger.debug('Description: ${schedule.description}');
-      AppLogger.debug('Location: ${schedule.location}');
-      AppLogger.debug('StartDateTime: ${schedule.startDateTime}');
-      AppLogger.debug('EndDateTime: ${schedule.endDateTime}');
+      await _ensureAuthenticated();
+      AppLogger.debug(
+          'ScheduleRepository: Starting encrypted schedule creation');
       AppLogger.debug('OwnerId: ${schedule.ownerId}');
-      AppLogger.debug('OwnerDisplayName: ${schedule.ownerDisplayName}');
-      AppLogger.debug('OwnerPhotoUrl: ${schedule.ownerPhotoUrl}');
       AppLogger.debug('SharedLists: ${schedule.sharedLists}');
       AppLogger.debug('VisibleTo: ${schedule.visibleTo}');
-      AppLogger.debug('CreatedAt: ${schedule.createdAt}');
-      AppLogger.debug('UpdatedAt: ${schedule.updatedAt}');
 
-      // スケジュールをそのままFirestoreに保存
-      final data = ScheduleMapper.toFirestore(schedule);
-      AppLogger.debug('Prepared Firestore data:');
-      AppLogger.debug(data.toString());
+      final data = await _encryptionService.toEncryptedFirestoreData(
+        schedule: schedule,
+        currentUserId: _auth.currentUser!.uid,
+      );
 
-      AppLogger.debug('Attempting to create document in Firestore');
       final docRef = await _firestore.collection('schedules').add(data);
-      AppLogger.debug('Document created with ID: ${docRef.id}');
-
-      AppLogger.debug('Fetching created document');
       final doc = await docRef.get();
       if (!doc.exists) {
         AppLogger.error('Created document does not exist: ${docRef.id}');
         throw Exception('Created document not found');
       }
 
-      AppLogger.debug('Enriching schedule data');
       final enrichedSchedule = await _enrichSchedule(doc);
-      AppLogger.debug('Schedule creation completed successfully');
+      AppLogger.debug('Encrypted schedule creation completed successfully');
       return enrichedSchedule;
     } catch (e, stackTrace) {
       AppLogger.error('Error creating schedule', e, stackTrace);
@@ -189,28 +190,69 @@ class ScheduleRepository implements IScheduleRepository {
   @override
   Future<void> updateSchedule(Schedule schedule) async {
     try {
-      AppLogger.debug('Starting schedule update for ID: ${schedule.id}');
-      AppLogger.debug('Current schedule details:');
-      AppLogger.debug('Title: ${schedule.title}');
-      AppLogger.debug('Description: ${schedule.description}');
-      AppLogger.debug('Location: ${schedule.location}');
-      AppLogger.debug('StartDateTime: ${schedule.startDateTime}');
-      AppLogger.debug('EndDateTime: ${schedule.endDateTime}');
+      await _ensureAuthenticated();
+      AppLogger.debug(
+          'Starting encrypted schedule update for ID: ${schedule.id}');
       AppLogger.debug('SharedLists: ${schedule.sharedLists}');
       AppLogger.debug('VisibleTo: ${schedule.visibleTo}');
 
-      // 作成時と同じFirestore保存形式に揃えて更新する
-      final data = ScheduleMapper.toFirestore(schedule);
-      AppLogger.debug('Prepared update data:');
-      AppLogger.debug(data.toString());
+      final docRef = _firestore.collection('schedules').doc(schedule.id);
+      final existingDoc = await docRef.get();
+      final data = await _encryptionService.toEncryptedFirestoreData(
+        schedule: schedule,
+        currentUserId: _auth.currentUser!.uid,
+        existingDoc: existingDoc.exists ? existingDoc : null,
+      );
 
-      AppLogger.debug('Attempting to update document in Firestore');
-      await _firestore.collection('schedules').doc(schedule.id).update(data);
+      await docRef.update(data);
       invalidateScheduleCache(schedule.id);
-      AppLogger.debug('Schedule update completed successfully');
+      AppLogger.debug('Encrypted schedule update completed successfully');
     } catch (e, stackTrace) {
       AppLogger.error('Error updating schedule', e, stackTrace);
       rethrow;
+    }
+  }
+
+  @override
+  Future<void> grantListSchedulesAccessToUser({
+    required String listId,
+    required String userId,
+  }) async {
+    await _ensureAuthenticated();
+
+    final snapshot = await _firestore
+        .collection('schedules')
+        .where('sharedLists', arrayContains: listId)
+        .get();
+
+    for (final doc in snapshot.docs) {
+      final data = doc.data();
+      final visibleTo = List<String>.from(data['visibleTo'] as List? ?? []);
+      if (visibleTo.contains(userId)) continue;
+
+      final updates = <String, dynamic>{
+        'visibleTo': FieldValue.arrayUnion([userId]),
+        'updatedAt': DateTime.now().toIso8601String(),
+      };
+
+      if (data['encrypted'] == true) {
+        final encryptedKey =
+            await _encryptionService.encryptedScheduleKeyForAdditionalViewer(
+          doc: doc,
+          currentUserId: _auth.currentUser!.uid,
+          viewerId: userId,
+        );
+        if (encryptedKey != null) {
+          final encryptedKeys = Map<String, dynamic>.from(
+            data['encryptedKeys'] as Map? ?? {},
+          );
+          encryptedKeys[userId] = encryptedKey.toJson();
+          updates['encryptedKeys'] = encryptedKeys;
+        }
+      }
+
+      await doc.reference.update(updates);
+      invalidateScheduleCache(doc.id);
     }
   }
 

--- a/lib/presentation/bottom_navigation/bottom_navigation.dart
+++ b/lib/presentation/bottom_navigation/bottom_navigation.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../home/home_page.dart';
 import '../friend/friend_list_page.dart';
+import '../encryption/schedule_private_key_gate.dart';
 import '../list/list_page.dart';
 import '../my_page/my_page.dart';
 import '../widgets/auth_dependent_builder.dart';
@@ -22,7 +23,10 @@ class _BottomNavigationPageState extends ConsumerState<BottomNavigationPage> {
   @override
   Widget build(BuildContext context) {
     return AuthDependentBuilder(
-      onAuthenticated: (_) => const _AuthenticatedBottomNavigationShell(),
+      onAuthenticated: (userId) => SchedulePrivateKeyGate(
+        userId: userId,
+        child: const _AuthenticatedBottomNavigationShell(),
+      ),
       onLoading: (_) =>
           const Scaffold(body: Center(child: CircularProgressIndicator())),
       onUnauthenticated: (_) => const Scaffold(body: SizedBox.shrink()),

--- a/lib/presentation/bottom_navigation/bottom_navigation.dart
+++ b/lib/presentation/bottom_navigation/bottom_navigation.dart
@@ -9,6 +9,7 @@ import '../my_page/my_page.dart';
 import '../widgets/auth_dependent_builder.dart';
 import '../../infrastructure/how_to_use_prompt_preferences.dart';
 import '../../infrastructure/notification_navigation_service.dart';
+import 'package:lakiite/app/di/providers.dart';
 
 class BottomNavigationPage extends ConsumerStatefulWidget {
   const BottomNavigationPage({super.key});
@@ -22,9 +23,12 @@ class BottomNavigationPage extends ConsumerStatefulWidget {
 class _BottomNavigationPageState extends ConsumerState<BottomNavigationPage> {
   @override
   Widget build(BuildContext context) {
+    final encryptionService = ref.watch(scheduleEncryptionServiceProvider);
+
     return AuthDependentBuilder(
       onAuthenticated: (userId) => SchedulePrivateKeyGate(
         userId: userId,
+        encryptionService: encryptionService,
         child: const _AuthenticatedBottomNavigationShell(),
       ),
       onLoading: (_) =>

--- a/lib/presentation/encryption/schedule_private_key_gate.dart
+++ b/lib/presentation/encryption/schedule_private_key_gate.dart
@@ -1,0 +1,278 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../app/di/providers.dart';
+import '../../application/auth/auth_notifier.dart';
+import '../../domain/entity/schedule_encryption.dart';
+import '../login/login_page.dart';
+
+class SchedulePrivateKeyGate extends ConsumerStatefulWidget {
+  const SchedulePrivateKeyGate({
+    super.key,
+    required this.userId,
+    required this.child,
+  });
+
+  final String userId;
+  final Widget child;
+
+  @override
+  ConsumerState<SchedulePrivateKeyGate> createState() =>
+      _SchedulePrivateKeyGateState();
+}
+
+class _SchedulePrivateKeyGateState
+    extends ConsumerState<SchedulePrivateKeyGate> {
+  late Future<SchedulePrivateKeySetupStatus> _statusFuture;
+  bool _showRestoreForm = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _statusFuture = _loadStatus();
+  }
+
+  @override
+  void didUpdateWidget(covariant SchedulePrivateKeyGate oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.userId != widget.userId) {
+      _showRestoreForm = false;
+      _statusFuture = _loadStatus();
+    }
+  }
+
+  Future<SchedulePrivateKeySetupStatus> _loadStatus() {
+    return ref
+        .read(scheduleEncryptionServiceProvider)
+        .currentUserPrivateKeyStatus(widget.userId);
+  }
+
+  Future<void> _signOutToLogin() async {
+    await ref.read(authNotifierProvider.notifier).signOut();
+    if (mounted) {
+      context.go(LoginPage.path);
+    }
+  }
+
+  void _reloadStatus() {
+    setState(() {
+      _showRestoreForm = false;
+      _statusFuture = _loadStatus();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<SchedulePrivateKeySetupStatus>(
+      future: _statusFuture,
+      builder: (context, snapshot) {
+        if (snapshot.connectionState != ConnectionState.done) {
+          return const Scaffold(
+            body: Center(child: CircularProgressIndicator()),
+          );
+        }
+
+        if (snapshot.hasError) {
+          return _KeyGateMessageScaffold(
+            title: '暗号化キーを確認できません',
+            message: '通信状況を確認してから、もう一度ログインしてください。',
+            actionLabel: 'ログイン画面へ',
+            onAction: _signOutToLogin,
+          );
+        }
+
+        switch (snapshot.data) {
+          case SchedulePrivateKeySetupStatus.ready:
+          case SchedulePrivateKeySetupStatus.notStarted:
+            return widget.child;
+          case SchedulePrivateKeySetupStatus.restoreAvailable:
+            if (_showRestoreForm) {
+              return _PrivateKeyRestoreScaffold(
+                userId: widget.userId,
+                onRestored: _reloadStatus,
+                onCancel: _signOutToLogin,
+              );
+            }
+            return _KeyGateMessageScaffold(
+              title: '端末引き継ぎ',
+              message: 'Phase2で実装予定の端末引き継ぎをしますか？',
+              actionLabel: 'OK',
+              secondaryActionLabel: 'キャンセル',
+              onAction: () async => setState(() => _showRestoreForm = true),
+              onSecondaryAction: _signOutToLogin,
+            );
+          case SchedulePrivateKeySetupStatus.backupMissing:
+            return _KeyGateMessageScaffold(
+              title: '端末引き継ぎが必要です',
+              message:
+                  'この端末では暗号化された予定を表示できません。元の端末で引き継ぎ設定を行ってから、もう一度ログインしてください。',
+              actionLabel: 'ログイン画面へ',
+              onAction: _signOutToLogin,
+            );
+          case null:
+            return _KeyGateMessageScaffold(
+              title: '暗号化キーを確認できません',
+              message: '通信状況を確認してから、もう一度ログインしてください。',
+              actionLabel: 'ログイン画面へ',
+              onAction: _signOutToLogin,
+            );
+        }
+      },
+    );
+  }
+}
+
+class _PrivateKeyRestoreScaffold extends ConsumerStatefulWidget {
+  const _PrivateKeyRestoreScaffold({
+    required this.userId,
+    required this.onRestored,
+    required this.onCancel,
+  });
+
+  final String userId;
+  final VoidCallback onRestored;
+  final Future<void> Function() onCancel;
+
+  @override
+  ConsumerState<_PrivateKeyRestoreScaffold> createState() =>
+      _PrivateKeyRestoreScaffoldState();
+}
+
+class _PrivateKeyRestoreScaffoldState
+    extends ConsumerState<_PrivateKeyRestoreScaffold> {
+  final _passwordController = TextEditingController();
+  bool _obscurePassword = true;
+  bool _isSubmitting = false;
+
+  @override
+  void dispose() {
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _restore() async {
+    final password = _passwordController.text;
+    if (password.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('引き継ぎパスワードを入力してください')),
+      );
+      return;
+    }
+
+    setState(() => _isSubmitting = true);
+    try {
+      await ref
+          .read(scheduleEncryptionServiceProvider)
+          .restorePrivateKeyFromBackup(
+            uid: widget.userId,
+            password: password,
+          );
+      widget.onRestored();
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('引き継ぎパスワードが正しくありません')),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _isSubmitting = false);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('端末引き継ぎ')),
+      body: ListView(
+        padding: const EdgeInsets.all(24),
+        children: [
+          const Text(
+            '暗号化された予定を表示するには、元の端末で設定した引き継ぎパスワードが必要です。',
+          ),
+          const SizedBox(height: 24),
+          TextField(
+            controller: _passwordController,
+            obscureText: _obscurePassword,
+            decoration: InputDecoration(
+              labelText: '引き継ぎパスワード',
+              border: const OutlineInputBorder(),
+              suffixIcon: IconButton(
+                tooltip: _obscurePassword ? '表示' : '非表示',
+                icon: Icon(
+                  _obscurePassword ? Icons.visibility : Icons.visibility_off,
+                ),
+                onPressed: () {
+                  setState(() => _obscurePassword = !_obscurePassword);
+                },
+              ),
+            ),
+          ),
+          const SizedBox(height: 24),
+          FilledButton(
+            onPressed: _isSubmitting ? null : _restore,
+            child: _isSubmitting
+                ? const SizedBox.square(
+                    dimension: 20,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Text('復元する'),
+          ),
+          const SizedBox(height: 8),
+          TextButton(
+            onPressed: _isSubmitting ? null : widget.onCancel,
+            child: const Text('キャンセル'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _KeyGateMessageScaffold extends StatelessWidget {
+  const _KeyGateMessageScaffold({
+    required this.title,
+    required this.message,
+    required this.actionLabel,
+    required this.onAction,
+    this.secondaryActionLabel,
+    this.onSecondaryAction,
+  });
+
+  final String title;
+  final String message;
+  final String actionLabel;
+  final Future<void> Function()? onAction;
+  final String? secondaryActionLabel;
+  final Future<void> Function()? onSecondaryAction;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(title)),
+      body: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(message),
+            const SizedBox(height: 24),
+            FilledButton(
+              onPressed: onAction == null ? null : () => onAction!(),
+              child: Text(actionLabel),
+            ),
+            if (secondaryActionLabel != null && onSecondaryAction != null) ...[
+              const SizedBox(height: 8),
+              TextButton(
+                onPressed: () => onSecondaryAction!(),
+                child: Text(secondaryActionLabel!),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/encryption/schedule_private_key_gate.dart
+++ b/lib/presentation/encryption/schedule_private_key_gate.dart
@@ -97,7 +97,7 @@ class _SchedulePrivateKeyGateState
             }
             return _KeyGateMessageScaffold(
               title: '端末引き継ぎ',
-              message: 'Phase2で実装予定の端末引き継ぎをしますか？',
+              message: 'この端末で暗号化された予定を表示するため、端末引き継ぎを行いますか？',
               actionLabel: 'OK',
               secondaryActionLabel: 'キャンセル',
               onAction: () async => setState(() => _showRestoreForm = true),

--- a/lib/presentation/encryption/schedule_private_key_gate.dart
+++ b/lib/presentation/encryption/schedule_private_key_gate.dart
@@ -2,19 +2,21 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-import '../../app/di/providers.dart';
 import '../../application/auth/auth_notifier.dart';
-import '../../domain/entity/schedule_encryption.dart';
+import 'package:lakiite/domain/entity/schedule_encryption.dart';
+import 'package:lakiite/infrastructure/encryption/schedule_encryption_service.dart';
 import '../login/login_page.dart';
 
 class SchedulePrivateKeyGate extends ConsumerStatefulWidget {
   const SchedulePrivateKeyGate({
     super.key,
     required this.userId,
+    required this.encryptionService,
     required this.child,
   });
 
   final String userId;
+  final ScheduleEncryptionService encryptionService;
   final Widget child;
 
   @override
@@ -43,9 +45,7 @@ class _SchedulePrivateKeyGateState
   }
 
   Future<SchedulePrivateKeySetupStatus> _loadStatus() {
-    return ref
-        .read(scheduleEncryptionServiceProvider)
-        .currentUserPrivateKeyStatus(widget.userId);
+    return widget.encryptionService.currentUserPrivateKeyStatus(widget.userId);
   }
 
   Future<void> _signOutToLogin() async {
@@ -90,6 +90,7 @@ class _SchedulePrivateKeyGateState
             if (_showRestoreForm) {
               return _PrivateKeyRestoreScaffold(
                 userId: widget.userId,
+                encryptionService: widget.encryptionService,
                 onRestored: _reloadStatus,
                 onCancel: _signOutToLogin,
               );
@@ -126,11 +127,13 @@ class _SchedulePrivateKeyGateState
 class _PrivateKeyRestoreScaffold extends ConsumerStatefulWidget {
   const _PrivateKeyRestoreScaffold({
     required this.userId,
+    required this.encryptionService,
     required this.onRestored,
     required this.onCancel,
   });
 
   final String userId;
+  final ScheduleEncryptionService encryptionService;
   final VoidCallback onRestored;
   final Future<void> Function() onCancel;
 
@@ -162,12 +165,10 @@ class _PrivateKeyRestoreScaffoldState
 
     setState(() => _isSubmitting = true);
     try {
-      await ref
-          .read(scheduleEncryptionServiceProvider)
-          .restorePrivateKeyFromBackup(
-            uid: widget.userId,
-            password: password,
-          );
+      await widget.encryptionService.restorePrivateKeyFromBackup(
+        uid: widget.userId,
+        password: password,
+      );
       widget.onRestored();
     } catch (_) {
       if (mounted) {

--- a/lib/presentation/encryption/schedule_private_key_gate.dart
+++ b/lib/presentation/encryption/schedule_private_key_gate.dart
@@ -170,6 +170,14 @@ class _PrivateKeyRestoreScaffoldState
         password: password,
       );
       widget.onRestored();
+    } on RestoredPrivateKeyMismatchException {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('保存されている引き継ぎキーが現在の暗号化キーと一致しません'),
+          ),
+        );
+      }
     } catch (_) {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/presentation/list/display_list_palette.dart
+++ b/lib/presentation/list/display_list_palette.dart
@@ -3,8 +3,6 @@ import 'package:flutter/material.dart';
 class DisplayListPalette {
   const DisplayListPalette._();
 
-  static const defaultColorKey = 'blue';
-
   static const entries = [
     DisplayListPaletteEntry(key: 'red', label: 'レッド', color: Colors.red),
     DisplayListPaletteEntry(key: 'green', label: 'グリーン', color: Colors.green),
@@ -20,13 +18,15 @@ class DisplayListPalette {
     DisplayListPaletteEntry(key: 'pink', label: 'ピンク', color: Colors.pink),
   ];
 
+  static final defaultColorKey = entries.first.key;
+
   static Color colorForKey(String colorKey) {
     for (final entry in entries) {
       if (entry.key == colorKey) {
         return entry.color;
       }
     }
-    return Colors.blue;
+    return entries.first.color;
   }
 }
 

--- a/lib/presentation/settings/schedule_key_backup_page.dart
+++ b/lib/presentation/settings/schedule_key_backup_page.dart
@@ -19,6 +19,7 @@ class _ScheduleKeyBackupPageState extends ConsumerState<ScheduleKeyBackupPage> {
   final _passwordController = TextEditingController();
   final _confirmPasswordController = TextEditingController();
   bool _obscurePassword = true;
+  bool _obscureConfirmPassword = true;
   bool _isSubmitting = false;
 
   @override
@@ -89,6 +90,10 @@ class _ScheduleKeyBackupPageState extends ConsumerState<ScheduleKeyBackupPage> {
           const Text(
             '別の端末でも暗号化された予定を表示できるように、秘密キーを引き継ぎパスワードで暗号化して保存します。',
           ),
+          const SizedBox(height: 8),
+          const Text(
+            'すでに設定済みの場合、新しいパスワードで保存すると既存の引き継ぎ設定は上書きされます。',
+          ),
           const SizedBox(height: 24),
           TextField(
             controller: _passwordController,
@@ -97,7 +102,7 @@ class _ScheduleKeyBackupPageState extends ConsumerState<ScheduleKeyBackupPage> {
               labelText: '引き継ぎパスワード',
               border: const OutlineInputBorder(),
               suffixIcon: IconButton(
-                tooltip: _obscurePassword ? '表示' : '非表示',
+                tooltip: _obscurePassword ? '引き継ぎパスワードを表示' : '引き継ぎパスワードを非表示',
                 icon: Icon(
                   _obscurePassword ? Icons.visibility : Icons.visibility_off,
                 ),
@@ -110,10 +115,23 @@ class _ScheduleKeyBackupPageState extends ConsumerState<ScheduleKeyBackupPage> {
           const SizedBox(height: 16),
           TextField(
             controller: _confirmPasswordController,
-            obscureText: _obscurePassword,
-            decoration: const InputDecoration(
+            obscureText: _obscureConfirmPassword,
+            decoration: InputDecoration(
               labelText: '確認用パスワード',
-              border: OutlineInputBorder(),
+              border: const OutlineInputBorder(),
+              suffixIcon: IconButton(
+                tooltip:
+                    _obscureConfirmPassword ? '確認用パスワードを表示' : '確認用パスワードを非表示',
+                icon: Icon(
+                  _obscureConfirmPassword
+                      ? Icons.visibility
+                      : Icons.visibility_off,
+                ),
+                onPressed: () {
+                  setState(
+                      () => _obscureConfirmPassword = !_obscureConfirmPassword);
+                },
+              ),
             ),
           ),
           const SizedBox(height: 24),

--- a/lib/presentation/settings/schedule_key_backup_page.dart
+++ b/lib/presentation/settings/schedule_key_backup_page.dart
@@ -1,0 +1,133 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../app/di/providers.dart';
+import '../../application/auth/auth_notifier.dart';
+import '../../application/auth/auth_state.dart';
+
+class ScheduleKeyBackupPage extends ConsumerStatefulWidget {
+  const ScheduleKeyBackupPage({super.key});
+
+  static const String path = 'schedule-key-backup';
+
+  @override
+  ConsumerState<ScheduleKeyBackupPage> createState() =>
+      _ScheduleKeyBackupPageState();
+}
+
+class _ScheduleKeyBackupPageState extends ConsumerState<ScheduleKeyBackupPage> {
+  final _passwordController = TextEditingController();
+  final _confirmPasswordController = TextEditingController();
+  bool _obscurePassword = true;
+  bool _isSubmitting = false;
+
+  @override
+  void dispose() {
+    _passwordController.dispose();
+    _confirmPasswordController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _save() async {
+    final authState = ref.read(authNotifierProvider).valueOrNull;
+    final userId = authState?.status == AuthStatus.authenticated
+        ? authState?.user?.id
+        : null;
+    if (userId == null) {
+      return;
+    }
+
+    final password = _passwordController.text;
+    final confirmPassword = _confirmPasswordController.text;
+    if (password.isEmpty) {
+      _showSnackBar('引き継ぎパスワードを入力してください');
+      return;
+    }
+    if (password != confirmPassword) {
+      _showSnackBar('確認用パスワードが一致しません');
+      return;
+    }
+
+    setState(() => _isSubmitting = true);
+    try {
+      await ref.read(scheduleEncryptionServiceProvider).createPrivateKeyBackup(
+            uid: userId,
+            password: password,
+          );
+      if (mounted) {
+        Navigator.of(context).pop();
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('端末引き継ぎ設定を保存しました')),
+        );
+      }
+    } catch (_) {
+      if (mounted) {
+        _showSnackBar('端末引き継ぎ設定を保存できませんでした');
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _isSubmitting = false);
+      }
+    }
+  }
+
+  void _showSnackBar(String message) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(message)),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('端末引き継ぎ設定'),
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(24),
+        children: [
+          const Text(
+            '別の端末でも暗号化された予定を表示できるように、秘密キーを引き継ぎパスワードで暗号化して保存します。',
+          ),
+          const SizedBox(height: 24),
+          TextField(
+            controller: _passwordController,
+            obscureText: _obscurePassword,
+            decoration: InputDecoration(
+              labelText: '引き継ぎパスワード',
+              border: const OutlineInputBorder(),
+              suffixIcon: IconButton(
+                tooltip: _obscurePassword ? '表示' : '非表示',
+                icon: Icon(
+                  _obscurePassword ? Icons.visibility : Icons.visibility_off,
+                ),
+                onPressed: () {
+                  setState(() => _obscurePassword = !_obscurePassword);
+                },
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
+          TextField(
+            controller: _confirmPasswordController,
+            obscureText: _obscurePassword,
+            decoration: const InputDecoration(
+              labelText: '確認用パスワード',
+              border: OutlineInputBorder(),
+            ),
+          ),
+          const SizedBox(height: 24),
+          FilledButton(
+            onPressed: _isSubmitting ? null : _save,
+            child: _isSubmitting
+                ? const SizedBox.square(
+                    dimension: 20,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Text('保存'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/settings/schedule_key_backup_page.dart
+++ b/lib/presentation/settings/schedule_key_backup_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../app/di/providers.dart';
 import '../../application/auth/auth_notifier.dart';
 import '../../application/auth/auth_state.dart';
+import '../../domain/entity/schedule_encryption.dart';
 
 class ScheduleKeyBackupPage extends ConsumerStatefulWidget {
   const ScheduleKeyBackupPage({super.key});
@@ -60,6 +61,10 @@ class _ScheduleKeyBackupPageState extends ConsumerState<ScheduleKeyBackupPage> {
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('端末引き継ぎ設定を保存しました')),
         );
+      }
+    } on LocalPrivateKeyMismatchException {
+      if (mounted) {
+        _showSnackBar('この端末の暗号化キーが現在の公開キーと一致しないため保存できません');
       }
     } catch (_) {
       if (mounted) {

--- a/lib/presentation/settings/settings_page.dart
+++ b/lib/presentation/settings/settings_page.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import '../../app/di/providers.dart';
 import '../../application/auth/auth_notifier.dart';
+import '../../application/auth/auth_state.dart';
 import 'edit_name_page.dart';
 import 'edit_email_page.dart';
 import 'edit_search_id_page.dart';
@@ -15,6 +17,11 @@ class SettingsPage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final authState = ref.watch(authNotifierProvider).valueOrNull;
+    final currentUserId = authState?.status == AuthStatus.authenticated
+        ? authState?.user?.id
+        : null;
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('設定'),
@@ -57,7 +64,7 @@ class SettingsPage extends ConsumerWidget {
           ListTile(
             leading: const Icon(Icons.key_outlined),
             title: const Text('端末引き継ぎ設定'),
-            subtitle: const Text('暗号化された予定を別端末で復元'),
+            subtitle: _ScheduleKeyBackupSubtitle(userId: currentUserId),
             trailing: const Icon(Icons.chevron_right),
             onTap: () {
               context.push('/settings/${ScheduleKeyBackupPage.path}');
@@ -317,6 +324,36 @@ class SettingsPage extends ConsumerWidget {
           ),
         ],
       ),
+    );
+  }
+}
+
+class _ScheduleKeyBackupSubtitle extends ConsumerWidget {
+  const _ScheduleKeyBackupSubtitle({required this.userId});
+
+  final String? userId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final uid = userId;
+    if (uid == null) {
+      return const Text('ログイン後に設定できます');
+    }
+
+    final encryptionService = ref.watch(scheduleEncryptionServiceProvider);
+    return FutureBuilder<bool>(
+      future: encryptionService.hasPrivateKeyBackup(uid),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState != ConnectionState.done) {
+          return const Text('暗号化された予定を別端末で復元・確認中...');
+        }
+        if (snapshot.hasError) {
+          return const Text('暗号化された予定を別端末で復元・設定状態を確認できません');
+        }
+
+        final label = snapshot.data == true ? '設定済み' : '未設定';
+        return Text('暗号化された予定を別端末で復元・$label');
+      },
     );
   }
 }

--- a/lib/presentation/settings/settings_page.dart
+++ b/lib/presentation/settings/settings_page.dart
@@ -7,6 +7,7 @@ import 'edit_email_page.dart';
 import 'edit_search_id_page.dart';
 import 'account_deletion_webview_page.dart';
 import 'schedule_digest_settings_page.dart';
+import 'schedule_key_backup_page.dart';
 
 class SettingsPage extends ConsumerWidget {
   const SettingsPage({super.key});
@@ -51,6 +52,15 @@ class SettingsPage extends ConsumerWidget {
             trailing: const Icon(Icons.chevron_right),
             onTap: () {
               context.push('/settings/${ScheduleDigestSettingsPage.path}');
+            },
+          ),
+          ListTile(
+            leading: const Icon(Icons.key_outlined),
+            title: const Text('端末引き継ぎ設定'),
+            subtitle: const Text('暗号化された予定を別端末で復元'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () {
+              context.push('/settings/${ScheduleKeyBackupPage.path}');
             },
           ),
           const Divider(),

--- a/mock/providers/test_providers.dart
+++ b/mock/providers/test_providers.dart
@@ -1,7 +1,10 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lakiite/application/notification/notification_notifier.dart'
     as notification;
+import 'package:lakiite/domain/entity/schedule_encryption.dart';
 import 'package:lakiite/domain/entity/user.dart';
+import 'package:lakiite/infrastructure/encryption/schedule_encryption_service.dart';
 import 'package:lakiite/infrastructure/providers.dart';
 import 'package:lakiite/presentation/presentation_provider.dart';
 import '../repositories/mock_auth_repository.dart';
@@ -69,6 +72,9 @@ class TestProviders {
       storageServiceProvider.overrideWithValue(mockStorageService),
       imageProcessorServiceProvider
           .overrideWithValue(mockImageProcessorService),
+      scheduleEncryptionServiceProvider.overrideWithValue(
+        _ReadyScheduleEncryptionService(),
+      ),
       if (currentUserId != null)
         notification.currentUserIdProvider.overrideWithValue(currentUserId),
     ];
@@ -129,5 +135,14 @@ class TestProviders {
     mockScheduleRepository.setupSampleSchedules();
 
     return _baseOverrides(currentUserId: testUser.id);
+  }
+}
+
+class _ReadyScheduleEncryptionService extends ScheduleEncryptionService {
+  @override
+  Future<SchedulePrivateKeySetupStatus> currentUserPrivateKeyStatus(
+    String uid,
+  ) {
+    return SynchronousFuture(SchedulePrivateKeySetupStatus.ready);
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -249,6 +249,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.7"
+  cryptography:
+    dependency: "direct main"
+    description:
+      name: cryptography
+      sha256: "3eda3029d34ec9095a27a198ac9785630fe525c0eb6a49f3d575272f8e792ef0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.9.0"
   csslib:
     dependency: transitive
     description:
@@ -627,6 +635,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.6.1"
+  flutter_secure_storage:
+    dependency: "direct main"
+    description:
+      name: flutter_secure_storage
+      sha256: "7686b1d6a29985dcbb808c59518226e603e3bfa7c0ddfd1a0d00e4cda77c868e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.3.1"
+  flutter_secure_storage_darwin:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_darwin
+      sha256: "82329fa5cdf343773b1b6897dea959105a29f092454259edff92f9f6637e8149"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.2"
+  flutter_secure_storage_linux:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_linux
+      sha256: a5f35ddab43cf5c8215d2feb4ce1957851f28c5c37e6f04335066a0602087bf5
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
+  flutter_secure_storage_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_platform_interface
+      sha256: "8ceea1223bee3c6ac1a22dabd8feefc550e4729b3675de4b5900f55afcb435d6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
+  flutter_secure_storage_web:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_web
+      sha256: "073a62b3aeb866ab4ce795f960413948e51e5a42a9b0c8333b6daf5bb3208a1c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
+  flutter_secure_storage_windows:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_windows
+      sha256: "3b7c8e068875dfd46719ff57c90d8c459c87f2302ed6b00ff006b3c9fcad1613"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -879,6 +935,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
+  jni:
+    dependency: transitive
+    description:
+      name: jni
+      sha256: c2230682d5bc2362c1c9e8d3c7f406d9cbba23ab3f2e203a025dd47e0fb2e68f
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
+  jni_flutter:
+    dependency: transitive
+    description:
+      name: jni_flutter
+      sha256: "8b59e590786050b1cd866677dddaf76b1ade5e7bc751abe04b86e84d379d3ba6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   js:
     dependency: transitive
     description:
@@ -1023,6 +1095,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_provider:
+    dependency: transitive
+    description:
+      name: path_provider
+      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.5"
+  path_provider_android:
+    dependency: transitive
+    description:
+      name: path_provider_android
+      sha256: "69cbd515a62b94d32a7944f086b2f82b4ac40a1d45bebfc00813a430ab2dabcd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.1"
+  path_provider_foundation:
+    dependency: transitive
+    description:
+      name: path_provider_foundation
+      sha256: "6d13aece7b3f5c5a9731eaf553ff9dcbc2eff41087fd2df587fd0fed9a3eb0c4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.1"
   path_provider_linux:
     dependency: transitive
     description:
@@ -1622,4 +1718,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.9.0 <4.0.0"
-  flutter: ">=3.35.0"
+  flutter: ">=3.35.6"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -65,6 +65,8 @@ dependencies:
   qr_flutter: ^4.1.0
   mobile_scanner: ^7.2.0
   gap: ^3.0.1
+  cryptography: ^2.9.0
+  flutter_secure_storage: ^10.3.1
 
 dev_dependencies:
   flutter_test:

--- a/test/application/list/list_notifier_test.dart
+++ b/test/application/list/list_notifier_test.dart
@@ -6,8 +6,11 @@ import 'package:lakiite/app/di/providers.dart';
 import 'package:lakiite/application/auth/auth_notifier.dart';
 import 'package:lakiite/application/list/list_notifier.dart';
 import 'package:lakiite/domain/entity/list.dart';
+import 'package:lakiite/domain/entity/schedule.dart';
 import 'package:lakiite/domain/entity/user.dart';
 import 'package:lakiite/domain/interfaces/i_list_repository.dart';
+import 'package:lakiite/domain/interfaces/i_schedule_access_grant_repository.dart';
+import 'package:lakiite/domain/interfaces/i_schedule_repository.dart';
 
 import '../../../mock/repositories/mock_auth_repository.dart';
 import '../../../mock/repositories/mock_user_repository.dart';
@@ -21,6 +24,7 @@ class _TrackingListRepository implements IListRepository {
 
   final _listsController = StreamController<List<UserList>>.broadcast();
   int cancelCount = 0;
+  final addedMembers = <({String listId, String userId})>[];
 
   @override
   Stream<List<UserList>> watchUserLists(String ownerId) =>
@@ -30,8 +34,9 @@ class _TrackingListRepository implements IListRepository {
   Stream<UserList?> watchList(String listId) => const Stream<UserList?>.empty();
 
   @override
-  Future<void> addMember(String listId, String userId) =>
-      Future.error(UnimplementedError());
+  Future<void> addMember(String listId, String userId) async {
+    addedMembers.add((listId: listId, userId: userId));
+  }
 
   @override
   Future<UserList> createList({
@@ -64,6 +69,57 @@ class _TrackingListRepository implements IListRepository {
   void dispose() {
     _listsController.close();
   }
+}
+
+class _TrackingScheduleAccessGrantRepository
+    implements IScheduleRepository, IScheduleAccessGrantRepository {
+  final grantRequests = <({String listId, String userId})>[];
+
+  @override
+  Future<void> grantListSchedulesAccessToUser({
+    required String listId,
+    required String userId,
+  }) async {
+    grantRequests.add((listId: listId, userId: userId));
+  }
+
+  @override
+  Future<Schedule> createSchedule(Schedule schedule) =>
+      Future.error(UnimplementedError());
+
+  @override
+  Future<void> deleteSchedule(String scheduleId) =>
+      Future.error(UnimplementedError());
+
+  @override
+  Future<List<Schedule>> getListSchedules(String listId) =>
+      Future.error(UnimplementedError());
+
+  @override
+  Future<List<Schedule>> getUserSchedules(String userId) =>
+      Future.error(UnimplementedError());
+
+  @override
+  Future<void> updateSchedule(Schedule schedule) =>
+      Future.error(UnimplementedError());
+
+  @override
+  Stream<List<Schedule>> watchListSchedules(String listId) =>
+      const Stream.empty();
+
+  @override
+  Stream<Schedule?> watchSchedule(String scheduleId) => const Stream.empty();
+
+  @override
+  Stream<List<Schedule>> watchUserSchedules(String userId) =>
+      const Stream.empty();
+
+  @override
+  Stream<List<Schedule>> watchUserSchedulesForMonth(
+    String userId,
+    DateTime displayMonth,
+  ) =>
+      const Stream.empty();
 }
 
 void main() {
@@ -113,6 +169,30 @@ void main() {
 
       expect(listRepository.cancelCount, 1);
       expect(container.read(listNotifierProvider).hasError, isFalse);
+    });
+
+    test('メンバー追加後に対象ユーザーへリスト予定の閲覧権限を付与する', () async {
+      final scheduleRepository = _TrackingScheduleAccessGrantRepository();
+      final scopedContainer = ProviderContainer(
+        overrides: [
+          listRepositoryProvider.overrideWithValue(listRepository),
+          scheduleRepositoryProvider.overrideWithValue(scheduleRepository),
+        ],
+      );
+      addTearDown(scopedContainer.dispose);
+
+      await scopedContainer
+          .read(listManagerProvider)
+          .addMember('list-id', 'new-user-id');
+
+      expect(
+        listRepository.addedMembers,
+        [(listId: 'list-id', userId: 'new-user-id')],
+      );
+      expect(
+        scheduleRepository.grantRequests,
+        [(listId: 'list-id', userId: 'new-user-id')],
+      );
     });
   });
 }

--- a/test/application/list/list_notifier_test.dart
+++ b/test/application/list/list_notifier_test.dart
@@ -25,6 +25,8 @@ class _TrackingListRepository implements IListRepository {
   final _listsController = StreamController<List<UserList>>.broadcast();
   int cancelCount = 0;
   final addedMembers = <({String listId, String userId})>[];
+  UserList? listToReturn;
+  UserList? updatedList;
 
   @override
   Stream<List<UserList>> watchUserLists(String ownerId) =>
@@ -52,8 +54,7 @@ class _TrackingListRepository implements IListRepository {
   Future<void> deleteList(String listId) => Future.error(UnimplementedError());
 
   @override
-  Future<UserList?> getList(String listId) =>
-      Future.error(UnimplementedError());
+  Future<UserList?> getList(String listId) async => listToReturn;
 
   @override
   Future<List<UserList>> getLists(String ownerId) =>
@@ -64,7 +65,9 @@ class _TrackingListRepository implements IListRepository {
       Future.error(UnimplementedError());
 
   @override
-  Future<void> updateList(UserList list) => Future.error(UnimplementedError());
+  Future<void> updateList(UserList list) async {
+    updatedList = list;
+  }
 
   void dispose() {
     _listsController.close();
@@ -74,6 +77,7 @@ class _TrackingListRepository implements IListRepository {
 class _TrackingScheduleAccessGrantRepository
     implements IScheduleRepository, IScheduleAccessGrantRepository {
   final grantRequests = <({String listId, String userId})>[];
+  final syncRequests = <({UserList beforeList, UserList afterList})>[];
 
   @override
   Future<void> grantListSchedulesAccessToUser({
@@ -81,6 +85,14 @@ class _TrackingScheduleAccessGrantRepository
     required String userId,
   }) async {
     grantRequests.add((listId: listId, userId: userId));
+  }
+
+  @override
+  Future<void> syncListSchedulesAccess({
+    required UserList beforeList,
+    required UserList afterList,
+  }) async {
+    syncRequests.add((beforeList: beforeList, afterList: afterList));
   }
 
   @override
@@ -171,7 +183,15 @@ void main() {
       expect(container.read(listNotifierProvider).hasError, isFalse);
     });
 
-    test('メンバー追加後に対象ユーザーへリスト予定の閲覧権限を付与する', () async {
+    test('メンバー追加後に変更前後のリストで予定公開範囲を同期する', () async {
+      final beforeList = UserList(
+        id: 'list-id',
+        listName: 'list',
+        ownerId: 'owner-id',
+        memberIds: const ['existing-user-id'],
+        createdAt: DateTime(2026, 6, 12),
+      );
+      listRepository.listToReturn = beforeList;
       final scheduleRepository = _TrackingScheduleAccessGrantRepository();
       final scopedContainer = ProviderContainer(
         overrides: [
@@ -189,10 +209,41 @@ void main() {
         listRepository.addedMembers,
         [(listId: 'list-id', userId: 'new-user-id')],
       );
+      expect(scheduleRepository.grantRequests, isEmpty);
+      expect(scheduleRepository.syncRequests.single.beforeList, beforeList);
       expect(
-        scheduleRepository.grantRequests,
-        [(listId: 'list-id', userId: 'new-user-id')],
+        scheduleRepository.syncRequests.single.afterList.memberIds,
+        ['existing-user-id', 'new-user-id'],
       );
+    });
+
+    test('リスト更新後に変更前後のリストで予定公開範囲を同期する', () async {
+      final beforeList = UserList(
+        id: 'list-id',
+        listName: 'before',
+        ownerId: 'owner-id',
+        memberIds: const ['a', 'b'],
+        createdAt: DateTime(2026, 6, 12),
+      );
+      final afterList = beforeList.copyWith(
+        listName: 'after',
+        memberIds: const ['b', 'c'],
+      );
+      listRepository.listToReturn = beforeList;
+      final scheduleRepository = _TrackingScheduleAccessGrantRepository();
+      final scopedContainer = ProviderContainer(
+        overrides: [
+          listRepositoryProvider.overrideWithValue(listRepository),
+          scheduleRepositoryProvider.overrideWithValue(scheduleRepository),
+        ],
+      );
+      addTearDown(scopedContainer.dispose);
+
+      await scopedContainer.read(listManagerProvider).updateList(afterList);
+
+      expect(listRepository.updatedList, afterList);
+      expect(scheduleRepository.syncRequests.single.beforeList, beforeList);
+      expect(scheduleRepository.syncRequests.single.afterList, afterList);
     });
   });
 }

--- a/test/domain/service/schedule_manager_test.dart
+++ b/test/domain/service/schedule_manager_test.dart
@@ -3,7 +3,6 @@ import 'package:lakiite/domain/service/schedule_manager.dart';
 import 'package:lakiite/domain/entity/schedule.dart';
 import 'package:lakiite/domain/entity/user.dart';
 import 'package:lakiite/domain/interfaces/i_schedule_repository.dart';
-import 'package:lakiite/domain/interfaces/i_friend_list_repository.dart';
 import 'package:lakiite/domain/interfaces/i_user_repository.dart';
 import 'package:lakiite/domain/interfaces/i_schedule_interaction_repository.dart';
 import 'package:lakiite/domain/entity/schedule_reaction.dart';
@@ -70,24 +69,6 @@ class MockScheduleRepository implements IScheduleRepository {
   @override
   Stream<Schedule?> watchSchedule(String scheduleId) {
     return Stream.value(null);
-  }
-}
-
-class MockFriendListRepository implements IFriendListRepository {
-  final Map<String, List<String>?> _memberIds = {};
-
-  void setMemberIds(String listId, List<String>? memberIds) {
-    _memberIds[listId] = memberIds;
-  }
-
-  @override
-  Future<List<String>?> getListMemberIds(String listId) async {
-    if (_memberIds.containsKey(listId)) {
-      final result = _memberIds[listId];
-      if (result == null) throw Exception('Network error');
-      return result;
-    }
-    return null;
   }
 }
 
@@ -287,26 +268,23 @@ void main() {
   group('ScheduleManager', () {
     late ScheduleManager scheduleManager;
     late MockScheduleRepository mockScheduleRepo;
-    late MockFriendListRepository mockFriendListRepo;
     late MockUserRepository mockUserRepo;
     late MockScheduleInteractionRepository mockInteractionRepo;
 
     setUp(() {
       mockScheduleRepo = MockScheduleRepository();
-      mockFriendListRepo = MockFriendListRepository();
       mockUserRepo = MockUserRepository();
       mockInteractionRepo = MockScheduleInteractionRepository();
 
       scheduleManager = ScheduleManager(
         mockScheduleRepo,
-        mockFriendListRepo,
         mockUserRepo,
         mockInteractionRepo,
       );
     });
 
     group('createSchedule', () {
-      test('共有リストのメンバーをvisibleToに追加する', () async {
+      test('visibleToはownerのみを初期値として保存する', () async {
         // Arrange
         final user = UserModel.create(
           id: 'owner1',
@@ -331,7 +309,6 @@ void main() {
         );
 
         mockUserRepo.setUser('owner1', user);
-        mockFriendListRepo.setMemberIds('list1', ['user1', 'user2']);
         mockScheduleRepo.setScheduleToReturn(
           schedule.copyWith(id: 'new-schedule-id'),
         );
@@ -343,10 +320,7 @@ void main() {
         expect(result.id, 'new-schedule-id');
         expect(result.ownerDisplayName, 'Owner User'); // ユーザー情報が設定されている
         expect(result.ownerPhotoUrl, 'https://example.com/icon.png');
-        expect(result.visibleTo, contains('owner1'));
-        expect(result.visibleTo, contains('user1'));
-        expect(result.visibleTo, contains('user2'));
-        expect(result.visibleTo.length, 3);
+        expect(result.visibleTo, ['owner1']);
 
         // 基本的な検証（手動モックでは詳細な検証は省略）
         expect(result.id, isNotEmpty);
@@ -439,7 +413,7 @@ void main() {
         }
       });
 
-      test('重複するユーザーIDは1回のみ追加する', () async {
+      test('複数リストを指定してもvisibleToはownerのみになる', () async {
         // Arrange
         final user = UserModel.create(
           id: 'owner1',
@@ -448,11 +422,6 @@ void main() {
         );
 
         mockUserRepo.setUser('owner1', user);
-        mockFriendListRepo.setMemberIds('list1', ['user1', 'user2']);
-        mockFriendListRepo.setMemberIds('list2', [
-          'user2',
-          'user3',
-        ]); // user2が重複
 
         final schedule = Schedule(
           id: '',
@@ -473,9 +442,7 @@ void main() {
         // Act
         final result = await scheduleManager.createSchedule(schedule);
 
-        // Assert - user2は1回のみ
-        expect(result.visibleTo.where((id) => id == 'user2').length, 1);
-        expect(result.visibleTo.length, 4); // owner1, user1, user2, user3
+        expect(result.visibleTo, ['owner1']);
       });
     });
 

--- a/test/domain/service/schedule_recipient_diff_calculator_test.dart
+++ b/test/domain/service/schedule_recipient_diff_calculator_test.dart
@@ -1,0 +1,95 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lakiite/domain/service/schedule_recipient_diff_calculator.dart';
+
+void main() {
+  group('ScheduleRecipientDiffCalculator', () {
+    test('does nothing when changed lists resolve to the same users', () {
+      final diff = ScheduleRecipientDiffCalculator.calculate(
+        ownerId: 'owner',
+        beforeSharedListIds: const ['list-a'],
+        afterSharedListIds: const ['list-a', 'list-b'],
+        membersByListId: const {
+          'list-a': ['a', 'b', 'c'],
+          'list-b': ['a', 'b', 'c'],
+        },
+      );
+
+      expect(diff.addedUserIds, isEmpty);
+      expect(diff.removedUserIds, isEmpty);
+      expect(diff.requiresRewrap, isFalse);
+      expect(diff.requiresRekey, isFalse);
+      expect(diff.hasNoKeyChange, isTrue);
+    });
+
+    test('requires rewrap when users are added without removals', () {
+      final diff = ScheduleRecipientDiffCalculator.calculate(
+        ownerId: 'owner',
+        beforeSharedListIds: const ['list-a'],
+        afterSharedListIds: const ['list-a', 'list-b'],
+        membersByListId: const {
+          'list-a': ['a', 'b', 'c'],
+          'list-b': ['c', 'd'],
+        },
+      );
+
+      expect(diff.addedUserIds, {'d'});
+      expect(diff.removedUserIds, isEmpty);
+      expect(diff.requiresRewrap, isTrue);
+      expect(diff.requiresRekey, isFalse);
+      expect(diff.hasNoKeyChange, isFalse);
+    });
+
+    test('requires rekey when any user is removed', () {
+      final diff = ScheduleRecipientDiffCalculator.calculate(
+        ownerId: 'owner',
+        beforeSharedListIds: const ['list-a', 'list-b'],
+        afterSharedListIds: const ['list-a'],
+        membersByListId: const {
+          'list-a': ['a', 'b', 'c'],
+          'list-b': ['c', 'd'],
+        },
+      );
+
+      expect(diff.addedUserIds, isEmpty);
+      expect(diff.removedUserIds, {'d'});
+      expect(diff.requiresRewrap, isFalse);
+      expect(diff.requiresRekey, isTrue);
+      expect(diff.hasNoKeyChange, isFalse);
+    });
+
+    test('keeps owner in recipients but never treats owner as added', () {
+      final diff = ScheduleRecipientDiffCalculator.calculate(
+        ownerId: 'owner',
+        beforeSharedListIds: const [],
+        afterSharedListIds: const ['list-a'],
+        membersByListId: const {
+          'list-a': ['owner', 'a'],
+        },
+      );
+
+      expect(diff.beforeRecipientIds, {'owner'});
+      expect(diff.afterRecipientIds, {'owner', 'a'});
+      expect(diff.addedUserIds, {'a'});
+      expect(diff.removedUserIds, isEmpty);
+    });
+
+    test('detects member changes when list ids are unchanged', () {
+      final diff = ScheduleRecipientDiffCalculator.calculate(
+        ownerId: 'owner',
+        beforeSharedListIds: const ['list-a'],
+        afterSharedListIds: const ['list-a'],
+        membersByListId: const {
+          'list-a': ['a', 'b', 'c'],
+        },
+        afterMembersByListId: const {
+          'list-a': ['b', 'c', 'd'],
+        },
+      );
+
+      expect(diff.addedUserIds, {'d'});
+      expect(diff.removedUserIds, {'a'});
+      expect(diff.requiresRekey, isTrue);
+      expect(diff.requiresRewrap, isFalse);
+    });
+  });
+}

--- a/test/infrastructure/schedule_cipher_test.dart
+++ b/test/infrastructure/schedule_cipher_test.dart
@@ -86,5 +86,21 @@ void main() {
         throwsA(isA<Exception>()),
       );
     });
+
+    test('encrypts and decrypts comment text with a schedule key', () async {
+      final cipher = ScheduleCipher();
+      final scheduleKey = cipher.newScheduleKey();
+
+      final payload = await cipher.encryptText(
+        text: 'コメント本文',
+        scheduleKey: scheduleKey,
+      );
+
+      expect(payload.cipherText, isNot(contains('コメント本文')));
+      expect(
+        await cipher.decryptText(payload: payload, scheduleKey: scheduleKey),
+        'コメント本文',
+      );
+    });
   });
 }

--- a/test/infrastructure/schedule_cipher_test.dart
+++ b/test/infrastructure/schedule_cipher_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lakiite/domain/entity/schedule_encryption.dart';
+import 'package:lakiite/infrastructure/encryption/schedule_cipher.dart';
+
+void main() {
+  group('ScheduleCipher', () {
+    test('encrypts details once and unwraps the schedule key for each viewer',
+        () async {
+      final cipher = ScheduleCipher();
+      final ownerKeyPair = await cipher.newUserKeyPair();
+      final viewerKeyPair = await cipher.newUserKeyPair();
+      final scheduleKey = cipher.newScheduleKey();
+
+      const details = SchedulePlainDetails(
+        title: '打ち合わせ',
+        description: '次回リリースの確認',
+        location: '会議室A',
+      );
+
+      final encryptedPayload = await cipher.encryptDetails(
+        details: details,
+        scheduleKey: scheduleKey,
+      );
+      final ownerEncryptedKey = await cipher.encryptScheduleKey(
+        scheduleKey: scheduleKey,
+        recipientPublicKey: ownerKeyPair.publicKey,
+        keyVersion: 1,
+      );
+      final viewerEncryptedKey = await cipher.encryptScheduleKey(
+        scheduleKey: scheduleKey,
+        recipientPublicKey: viewerKeyPair.publicKey,
+        keyVersion: 1,
+      );
+
+      final ownerScheduleKey = await cipher.decryptScheduleKey(
+        encryptedKey: ownerEncryptedKey,
+        privateKey: ownerKeyPair,
+      );
+      final viewerScheduleKey = await cipher.decryptScheduleKey(
+        encryptedKey: viewerEncryptedKey,
+        privateKey: viewerKeyPair,
+      );
+
+      expect(
+        await cipher.decryptDetails(
+          payload: encryptedPayload,
+          scheduleKey: ownerScheduleKey,
+        ),
+        isA<SchedulePlainDetails>()
+            .having((value) => value.title, 'title', details.title)
+            .having(
+              (value) => value.description,
+              'description',
+              details.description,
+            )
+            .having((value) => value.location, 'location', details.location),
+      );
+      expect(
+        await cipher.decryptDetails(
+          payload: encryptedPayload,
+          scheduleKey: viewerScheduleKey,
+        ),
+        isA<SchedulePlainDetails>()
+            .having((value) => value.title, 'title', details.title),
+      );
+    });
+
+    test('does not unwrap a schedule key with a different private key',
+        () async {
+      final cipher = ScheduleCipher();
+      final viewerKeyPair = await cipher.newUserKeyPair();
+      final otherKeyPair = await cipher.newUserKeyPair();
+      final scheduleKey = cipher.newScheduleKey();
+
+      final encryptedKey = await cipher.encryptScheduleKey(
+        scheduleKey: scheduleKey,
+        recipientPublicKey: viewerKeyPair.publicKey,
+        keyVersion: 1,
+      );
+
+      expect(
+        cipher.decryptScheduleKey(
+          encryptedKey: encryptedKey,
+          privateKey: otherKeyPair,
+        ),
+        throwsA(isA<Exception>()),
+      );
+    });
+  });
+}

--- a/test/infrastructure/schedule_cipher_test.dart
+++ b/test/infrastructure/schedule_cipher_test.dart
@@ -102,5 +102,47 @@ void main() {
         'コメント本文',
       );
     });
+
+    test('backs up and restores a private key with a transfer password',
+        () async {
+      final cipher = ScheduleCipher();
+      final keyPair = await cipher.newUserKeyPair();
+      const password = 'transfer-password-123';
+
+      final backup = await cipher.encryptPrivateKeyBackup(
+        keyPair: keyPair,
+        password: password,
+        keyVersion: 1,
+      );
+      final restored = await cipher.decryptPrivateKeyBackup(
+        backup: backup,
+        password: password,
+      );
+
+      expect(
+          backup.cipherText, isNot(contains(cipher.privateKeyToJson(keyPair))));
+      expect(restored.bytes, keyPair.bytes);
+      expect(restored.publicKey.bytes, keyPair.publicKey.bytes);
+    });
+
+    test('does not restore a private key backup with a wrong password',
+        () async {
+      final cipher = ScheduleCipher();
+      final keyPair = await cipher.newUserKeyPair();
+
+      final backup = await cipher.encryptPrivateKeyBackup(
+        keyPair: keyPair,
+        password: 'correct-password',
+        keyVersion: 1,
+      );
+
+      expect(
+        cipher.decryptPrivateKeyBackup(
+          backup: backup,
+          password: 'wrong-password',
+        ),
+        throwsA(isA<Exception>()),
+      );
+    });
   });
 }

--- a/test/infrastructure/schedule_cipher_test.dart
+++ b/test/infrastructure/schedule_cipher_test.dart
@@ -125,6 +125,27 @@ void main() {
       expect(restored.publicKey.bytes, keyPair.publicKey.bytes);
     });
 
+    test('detects whether a private key matches a stored public key', () async {
+      final cipher = ScheduleCipher();
+      final keyPair = await cipher.newUserKeyPair();
+      final otherKeyPair = await cipher.newUserKeyPair();
+
+      expect(
+        cipher.publicKeyMatchesPrivateKey(
+          privateKey: keyPair,
+          publicKey: cipher.publicKeyToBase64(keyPair.publicKey),
+        ),
+        isTrue,
+      );
+      expect(
+        cipher.publicKeyMatchesPrivateKey(
+          privateKey: otherKeyPair,
+          publicKey: cipher.publicKeyToBase64(keyPair.publicKey),
+        ),
+        isFalse,
+      );
+    });
+
     test('does not restore a private key backup with a wrong password',
         () async {
       final cipher = ScheduleCipher();

--- a/test/infrastructure/schedule_encryption_service_test.dart
+++ b/test/infrastructure/schedule_encryption_service_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lakiite/domain/entity/schedule_encryption.dart';
+import 'package:lakiite/infrastructure/encryption/schedule_encryption_service.dart';
+
+void main() {
+  group('ScheduleEncryptionService recipient planning', () {
+    test('keeps ready recipients and reports recipients missing public keys',
+        () {
+      const ownerKey = ScheduleUserPublicKey(
+        uid: 'owner',
+        publicKey: 'owner-public-key',
+        keyVersion: 1,
+      );
+      const readyKey = ScheduleUserPublicKey(
+        uid: 'ready-user',
+        publicKey: 'ready-public-key',
+        keyVersion: 1,
+      );
+
+      final plan = ScheduleEncryptionService.planRecipientEncryption(
+        viewerIds: const ['owner', 'ready-user', 'missing-user', 'owner'],
+        publicKeys: const [ownerKey, readyKey],
+      );
+
+      expect(plan.readyUserIds, ['owner', 'ready-user']);
+      expect(plan.missingUserIds, ['missing-user']);
+      expect(plan.publicKeysByUserId, {
+        'owner': ownerKey,
+        'ready-user': readyKey,
+      });
+    });
+
+    test('treats encrypted schedules without a user key as not displayable',
+        () {
+      expect(
+        ScheduleEncryptionService.canDecryptScheduleData(
+          const {
+            'encrypted': true,
+            'encryptedKeys': {
+              'ready-user': {'encryptedScheduleKey': 'value'},
+            },
+          },
+          currentUserId: 'ready-user',
+        ),
+        isTrue,
+      );
+
+      expect(
+        ScheduleEncryptionService.canDecryptScheduleData(
+          const {
+            'encrypted': true,
+            'encryptedKeys': {
+              'ready-user': {'encryptedScheduleKey': 'value'},
+            },
+          },
+          currentUserId: 'missing-user',
+        ),
+        isFalse,
+      );
+    });
+
+    test('keeps unencrypted legacy schedules displayable', () {
+      expect(
+        ScheduleEncryptionService.canDecryptScheduleData(
+          const {'encrypted': false},
+          currentUserId: 'any-user',
+        ),
+        isTrue,
+      );
+    });
+  });
+}

--- a/test/mock/providers/test_providers.dart
+++ b/test/mock/providers/test_providers.dart
@@ -1,9 +1,12 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter/foundation.dart';
 import 'package:lakiite/app/di/providers.dart';
 import 'package:lakiite/application/auth/auth_notifier.dart';
 import 'package:lakiite/application/force_update/force_update_providers.dart';
 import 'package:lakiite/domain/entity/list.dart';
 import 'package:lakiite/domain/entity/notification.dart';
+import 'package:lakiite/domain/entity/schedule_encryption.dart';
+import 'package:lakiite/infrastructure/encryption/schedule_encryption_service.dart';
 import 'package:lakiite/infrastructure/how_to_use_prompt_preferences.dart';
 import '../repository/mock_auth_repository.dart';
 import '../repository/mock_schedule_repository.dart';
@@ -29,6 +32,9 @@ class TestProviders {
         ),
         userRepositoryProvider.overrideWithValue(mockUserRepository),
         forceUpdateFeatureEnabledProvider.overrideWithValue(false),
+        scheduleEncryptionServiceProvider.overrideWithValue(
+          _ReadyScheduleEncryptionService(),
+        ),
         howToUsePromptPreferencesProvider.overrideWithValue(
           const _SeenHowToUsePromptPreferences(),
         ),
@@ -182,6 +188,15 @@ class TestProviders {
     _mockListRepository = null;
     _mockNotificationRepository = null;
     _mockUserRepository = null;
+  }
+}
+
+class _ReadyScheduleEncryptionService extends ScheduleEncryptionService {
+  @override
+  Future<SchedulePrivateKeySetupStatus> currentUserPrivateKeyStatus(
+    String uid,
+  ) {
+    return SynchronousFuture(SchedulePrivateKeySetupStatus.ready);
   }
 }
 

--- a/test/presentation/encryption/schedule_private_key_gate_test.dart
+++ b/test/presentation/encryption/schedule_private_key_gate_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lakiite/domain/entity/schedule_encryption.dart';
+import 'package:lakiite/infrastructure/encryption/schedule_encryption_service.dart';
+import 'package:lakiite/presentation/encryption/schedule_private_key_gate.dart';
+
+void main() {
+  testWidgets('復元した秘密キーが現在の公開キーと一致しない場合は専用メッセージを表示する', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          home: SchedulePrivateKeyGate(
+            userId: 'user-1',
+            encryptionService: _MismatchedRestoreScheduleEncryptionService(),
+            child: const SizedBox.shrink(),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pump();
+    await tester.tap(find.text('OK'));
+    await tester.pump();
+    await tester.enterText(find.byType(TextField), 'testtest');
+    await tester.tap(find.text('復元する'));
+    await tester.pump();
+
+    expect(
+      find.text('保存されている引き継ぎキーが現在の暗号化キーと一致しません'),
+      findsOneWidget,
+    );
+  });
+}
+
+class _MismatchedRestoreScheduleEncryptionService
+    extends ScheduleEncryptionService {
+  @override
+  Future<SchedulePrivateKeySetupStatus> currentUserPrivateKeyStatus(
+    String uid,
+  ) async {
+    return SchedulePrivateKeySetupStatus.restoreAvailable;
+  }
+
+  @override
+  Future<void> restorePrivateKeyFromBackup({
+    required String uid,
+    required String password,
+  }) async {
+    throw const RestoredPrivateKeyMismatchException('user-1');
+  }
+}

--- a/test/presentation/list/display_list_palette_test.dart
+++ b/test/presentation/list/display_list_palette_test.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lakiite/presentation/list/display_list_palette.dart';
+
+void main() {
+  group('DisplayListPalette', () {
+    test('uses the first palette entry as the default color', () {
+      expect(DisplayListPalette.defaultColorKey,
+          DisplayListPalette.entries.first.key);
+    });
+
+    test('falls back to the first palette color for unknown keys', () {
+      expect(DisplayListPalette.colorForKey('unknown'), Colors.red);
+      expect(
+        DisplayListPalette.colorForKey('unknown'),
+        DisplayListPalette.entries.first.color,
+      );
+    });
+  });
+}

--- a/test/presentation/list/list_edit_page_test.dart
+++ b/test/presentation/list/list_edit_page_test.dart
@@ -25,6 +25,7 @@ void main() {
       );
     final initialList = _list(memberIds: const ['member-1']);
     final latestList = _list(memberIds: const ['member-1', 'member-2']);
+    listRepository.listToReturn = latestList;
 
     addTearDown(listController.close);
 
@@ -108,6 +109,7 @@ class _CountingUserRepository extends MockUserRepository {
 
 class _CapturingListRepository implements IListRepository {
   UserList? updatedList;
+  UserList? listToReturn;
 
   @override
   Future<void> updateList(UserList list) async {
@@ -132,8 +134,7 @@ class _CapturingListRepository implements IListRepository {
   Future<void> deleteList(String listId) => Future.error(UnimplementedError());
 
   @override
-  Future<UserList?> getList(String listId) =>
-      Future.error(UnimplementedError());
+  Future<UserList?> getList(String listId) async => listToReturn;
 
   @override
   Future<List<UserList>> getLists(String ownerId) =>

--- a/test/presentation/settings/schedule_key_backup_page_test.dart
+++ b/test/presentation/settings/schedule_key_backup_page_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lakiite/presentation/settings/schedule_key_backup_page.dart';
+
+void main() {
+  Widget buildTestTarget() {
+    return const MaterialApp(home: ScheduleKeyBackupPage());
+  }
+
+  testWidgets('引き継ぎパスワードと確認用パスワードの表示切替は独立している', (tester) async {
+    await tester.pumpWidget(buildTestTarget());
+
+    expect(tester.widget<TextField>(find.byType(TextField).at(0)).obscureText,
+        isTrue);
+    expect(tester.widget<TextField>(find.byType(TextField).at(1)).obscureText,
+        isTrue);
+
+    await tester.tap(find.byTooltip('引き継ぎパスワードを表示'));
+    await tester.pump();
+
+    expect(tester.widget<TextField>(find.byType(TextField).at(0)).obscureText,
+        isFalse);
+    expect(tester.widget<TextField>(find.byType(TextField).at(1)).obscureText,
+        isTrue);
+
+    await tester.tap(find.byTooltip('確認用パスワードを表示'));
+    await tester.pump();
+
+    expect(tester.widget<TextField>(find.byType(TextField).at(0)).obscureText,
+        isFalse);
+    expect(tester.widget<TextField>(find.byType(TextField).at(1)).obscureText,
+        isFalse);
+  });
+
+  testWidgets('既存の引き継ぎパスワードは保存時に上書きされることを表示する', (tester) async {
+    await tester.pumpWidget(buildTestTarget());
+
+    expect(find.textContaining('上書き'), findsOneWidget);
+  });
+}

--- a/test/presentation/settings/settings_page_test.dart
+++ b/test/presentation/settings/settings_page_test.dart
@@ -10,4 +10,21 @@ void main() {
     expect(source, contains("title: const Text('使い方')"));
     expect(source, contains("context.push('/settings/how-to-use')"));
   });
+
+  test('端末引き継ぎ設定の設定状態を表示する', () {
+    final source =
+        File('lib/presentation/settings/settings_page.dart').readAsStringSync();
+
+    expect(source, contains('設定済み'));
+    expect(source, contains('未設定'));
+    expect(source, contains('hasPrivateKeyBackup'));
+  });
+
+  test('端末引き継ぎの案内文に未実装予定の文言を残さない', () {
+    final source =
+        File('lib/presentation/encryption/schedule_private_key_gate.dart')
+            .readAsStringSync();
+
+    expect(source, isNot(contains('Phase2で実装予定')));
+  });
 }


### PR DESCRIPTION
## Summary
- schedules の title / description / location を AES-GCM で暗号化保存するようにしました
- ユーザーごとの X25519 公開鍵で scheduleKey を配布し、秘密鍵は Secure Storage に uid/keyVersion 単位で保存します
- 既存平文 schedule の後方互換表示と、list member 追加時の既存 schedule 鍵配布を追加しました

## Test Plan
- fvm flutter test test/infrastructure/schedule_cipher_test.dart test/domain/service/schedule_manager_test.dart
- fvm flutter analyze（lib/firebase_options.dart 不在による既存エラーのみ）
- git diff --check

Closes #270