### PR TITLE
Fix schedule interaction counts and list ordering

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+run_fvm() {
+  env \
+    -u GIT_DIR \
+    -u GIT_WORK_TREE \
+    -u GIT_INDEX_FILE \
+    -u GIT_PREFIX \
+    -u GIT_OBJECT_DIRECTORY \
+    -u GIT_ALTERNATE_OBJECT_DIRECTORIES \
+    fvm "$@"
+}
+
+echo "[pre-commit] Checking staged whitespace..."
+git diff --cached --check
+
+staged_dart_files="$(
+  git diff --cached --name-only --diff-filter=ACMR -- '*.dart' \
+    | grep -vE '(^|/)(.*\.g\.dart|.*\.freezed\.dart|.*\.mocks\.dart)$' || true
+)"
+
+if [ -n "$staged_dart_files" ]; then
+  echo "[pre-commit] Checking Dart formatting for staged Dart files..."
+  # shellcheck disable=SC2086
+  run_fvm dart format --output=none --set-exit-if-changed $staged_dart_files
+else
+  echo "[pre-commit] No staged Dart files to format-check."
+fi
+
+echo "[pre-commit] Running Flutter analyze..."
+run_fvm flutter analyze
+
+if git diff --cached --name-only --diff-filter=ACMR | grep -qE '^(lib|test)/(domain|utils|application|infrastructure)/|^pubspec\.(yaml|lock)$|^analysis_options\.yaml$'; then
+  echo "[pre-commit] Running unit and infrastructure tests..."
+  run_fvm flutter test \
+    test/domain/ \
+    test/utils/ \
+    test/application/ \
+    test/infrastructure/ \
+    --dart-define=FLUTTER_TEST=true
+else
+  echo "[pre-commit] Unit and infrastructure tests skipped: no matching staged changes."
+fi
+
+echo "[pre-commit] Checks passed."

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+run_fvm() {
+  env \
+    -u GIT_DIR \
+    -u GIT_WORK_TREE \
+    -u GIT_INDEX_FILE \
+    -u GIT_PREFIX \
+    -u GIT_OBJECT_DIRECTORY \
+    -u GIT_ALTERNATE_OBJECT_DIRECTORIES \
+    fvm "$@"
+}
+
+if git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' >/dev/null 2>&1; then
+  changed_files="$(git diff --name-only '@{upstream}'...HEAD)"
+elif git rev-parse --verify origin/dev >/dev/null 2>&1; then
+  changed_files="$(git diff --name-only origin/dev...HEAD)"
+else
+  changed_files="$(git diff --name-only HEAD~1...HEAD 2>/dev/null || true)"
+fi
+
+if echo "$changed_files" | grep -qE '^(lib|test/presentation|pubspec\.(yaml|lock)$|analysis_options\.yaml$)'; then
+  echo "[pre-push] Running presentation/widget tests..."
+  run_fvm flutter test test/presentation/ --dart-define=FLUTTER_TEST=true
+else
+  echo "[pre-push] Presentation/widget tests skipped: no matching pushed changes."
+fi
+
+echo "[pre-push] Checks passed."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,24 +1,7 @@
 name: PR Tests
 
 on:
-  pull_request:
-    branches: [main, dev]
-    paths:
-      - "lib/**"
-      - "test/**"
-      - "integration_test/**"
-      - "android/**"
-      - "ios/**"
-      - "assets/**"
-      - "pubspec.yaml"
-      - "pubspec.lock"
-      - "analysis_options.yaml"
-      - "build.yaml"
-      - "firebase.json"
-      - ".firebaserc"
-      - ".github/workflows/ci.yml"
-      - ".github/workflows/deploy_firebase_hosting.yml"
-      - ".github/workflows/firebase_emulator_integration_tests.yml"
+  workflow_dispatch:
 
 env:
   FLUTTER_VERSION: "3.41.5"

--- a/README.md
+++ b/README.md
@@ -59,6 +59,16 @@ Engine • revision e85ea0e79c
 Tools • Dart 2.17.6 • DevTools 2.12.2
 ```
 
+### ローカルGit hooks
+
+PR更新ごとのGitHub Actions自動テストは使わず、ローカルGit hooksでコミット・push前に検証する運用です。
+
+```bash
+./scripts/install_git_hooks.sh
+```
+
+詳細は [docs/local_git_hooks.md](docs/local_git_hooks.md) を参照。
+
 ## プロジェクト進行について
 
 ### 全体のタスク管理

--- a/docs/local_git_hooks.md
+++ b/docs/local_git_hooks.md
@@ -1,0 +1,36 @@
+# Local Git Hooks
+
+このリポジトリでは、PR更新ごとのGitHub Actions自動テストを止め、ローカルGit hooksで検証する運用に寄せています。
+
+## セットアップ
+
+```bash
+./scripts/install_git_hooks.sh
+```
+
+このコマンドは `git config core.hooksPath .githooks` を設定します。設定はローカルリポジトリごとに保存されます。
+
+## 実行される検証
+
+`pre-commit`:
+
+- `git diff --cached --check`
+- staged Dart files の `fvm dart format --output=none --set-exit-if-changed`
+- `fvm flutter analyze`
+- `lib` / `test/domain` / `test/utils` / `test/application` / `test/infrastructure` などに変更がある場合の単体・infrastructureテスト
+
+`pre-push`:
+
+- `lib` / `test/presentation` などに変更がある場合の presentation/widget テスト
+
+## GitHub Actions
+
+`.github/workflows/ci.yml` は `workflow_dispatch` の手動実行専用です。PRの `opened` / `synchronize` では自動実行されません。
+
+必要なときだけGitHub UIまたは次のコマンドで実行します。
+
+```bash
+gh workflow run ci.yml --ref <branch-name>
+```
+
+AIエージェント運用では、原則として `--no-verify` でhooksを回避しないでください。

--- a/lib/infrastructure/display_list_repository.dart
+++ b/lib/infrastructure/display_list_repository.dart
@@ -27,6 +27,19 @@ class DisplayListRepository implements IDisplayListRepository {
     return fallback ?? DateTime.now();
   }
 
+  static List<DisplayList> sortByName(Iterable<DisplayList> displayLists) {
+    final sortedDisplayLists = [...displayLists];
+    sortedDisplayLists.sort((a, b) {
+      final nameComparison =
+          a.name.trim().toLowerCase().compareTo(b.name.trim().toLowerCase());
+      if (nameComparison != 0) {
+        return nameComparison;
+      }
+      return a.id.compareTo(b.id);
+    });
+    return sortedDisplayLists;
+  }
+
   Map<String, dynamic> _toFirestore(DisplayList displayList) {
     return {
       'name': displayList.name,
@@ -56,7 +69,7 @@ class DisplayListRepository implements IDisplayListRepository {
     final snapshot = await _collection(ownerId)
         .orderBy('createdAt', descending: false)
         .get();
-    return snapshot.docs.map(_fromFirestore).toList();
+    return sortByName(snapshot.docs.map(_fromFirestore));
   }
 
   @override
@@ -64,7 +77,7 @@ class DisplayListRepository implements IDisplayListRepository {
     return _collection(ownerId)
         .orderBy('createdAt', descending: false)
         .snapshots()
-        .map((snapshot) => snapshot.docs.map(_fromFirestore).toList());
+        .map((snapshot) => sortByName(snapshot.docs.map(_fromFirestore)));
   }
 
   @override

--- a/lib/infrastructure/list_repository.dart
+++ b/lib/infrastructure/list_repository.dart
@@ -19,6 +19,21 @@ class ListRepository implements IListRepository {
     return fallback ?? DateTime.now();
   }
 
+  static List<UserList> sortByName(Iterable<UserList> lists) {
+    final sortedLists = [...lists];
+    sortedLists.sort((a, b) {
+      final nameComparison = a.listName
+          .trim()
+          .toLowerCase()
+          .compareTo(b.listName.trim().toLowerCase());
+      if (nameComparison != 0) {
+        return nameComparison;
+      }
+      return a.id.compareTo(b.id);
+    });
+    return sortedLists;
+  }
+
   Map<String, dynamic> _toFirestore(UserList list) {
     final data = list.toJson();
     if (data['createdAt'] != null) {
@@ -42,7 +57,7 @@ class ListRepository implements IListRepository {
         .collection('lists')
         .where('ownerId', isEqualTo: ownerId)
         .get();
-    return snapshot.docs.map(_fromFirestore).toList();
+    return sortByName(snapshot.docs.map(_fromFirestore));
   }
 
   @override
@@ -102,7 +117,7 @@ class ListRepository implements IListRepository {
         .collection('lists')
         .where('ownerId', isEqualTo: ownerId)
         .snapshots()
-        .map((snapshot) => snapshot.docs.map(_fromFirestore).toList());
+        .map((snapshot) => sortByName(snapshot.docs.map(_fromFirestore)));
   }
 
   @override

--- a/lib/presentation/widgets/reaction_icon_widget.dart
+++ b/lib/presentation/widgets/reaction_icon_widget.dart
@@ -88,49 +88,49 @@ class ReactionIconWidget extends StatelessWidget {
     // リアクションの種類に基づいて表示を切り替え
     if (hasGoing && hasThinking) {
       // 両方のリアクションがある場合は重なり合ったアイコンを表示
-      return Stack(
-        children: [
-          Positioned(
-            right: 2,
-            child: Text(
-              '🤔',
-              style: TextStyle(
-                fontSize: iconSize,
-              ),
+      return SizedBox.square(
+        dimension: iconSize * 1.5,
+        child: Stack(
+          alignment: Alignment.center,
+          clipBehavior: Clip.none,
+          children: [
+            Transform.translate(
+              offset: Offset(iconSize * 0.2, iconSize * 0.1),
+              child: _emoji('🤔'),
             ),
-          ),
-          Positioned(
-            top: -1,
-            left: -2,
-            child: Text(
-              '🙋',
-              style: TextStyle(
-                fontSize: iconSize,
-              ),
+            Transform.translate(
+              offset: Offset(-iconSize * 0.2, iconSize * 0.1),
+              child: _emoji('🙋'),
             ),
-          ),
-        ],
+          ],
+        ),
       );
     } else if (hasGoing) {
       // 「行きます！」のみの場合
       return Center(
-        child: Text(
-          '🙋',
-          style: TextStyle(
-            fontSize: iconSize,
-          ),
-        ),
+        child: _emoji('🙋'),
       );
     } else {
       // 「考え中！」のみの場合（defaultはこちら）
       return Center(
-        child: Text(
-          '🤔',
-          style: TextStyle(
-            fontSize: iconSize,
-          ),
-        ),
+        child: _emoji('🤔'),
       );
     }
+  }
+
+  Widget _emoji(String value) {
+    return Text(
+      value,
+      textAlign: TextAlign.center,
+      strutStyle: StrutStyle(
+        fontSize: iconSize,
+        height: 1,
+        forceStrutHeight: true,
+      ),
+      style: TextStyle(
+        fontSize: iconSize,
+        height: 1,
+      ),
+    );
   }
 }

--- a/lib/presentation/widgets/schedule_tile.dart
+++ b/lib/presentation/widgets/schedule_tile.dart
@@ -11,6 +11,7 @@ import 'package:lakiite/presentation/calendar/schedule_detail_page.dart';
 import 'package:lakiite/presentation/calendar/widgets/schedule_ownership_style.dart';
 import 'package:lakiite/application/schedule/schedule_interaction_notifier.dart';
 import 'package:lakiite/presentation/widgets/reaction_icon_widget.dart';
+import 'package:lakiite/presentation/widgets/schedule_tile_interaction_counts.dart';
 
 /// 予定タイルを表示するウィジェット
 ///
@@ -235,73 +236,74 @@ class ScheduleTile extends ConsumerWidget {
                 ),
               ],
               // インタラクションセクション（リアクションとコメント）
-              Row(
-                mainAxisAlignment: MainAxisAlignment.end,
-                children: [
-                  // リアクション表示部分
-                  if (schedule.reactionCount > 0)
-                    // リアクションアイコンをタップすると詳細ページに遷移（または指定されたコールバックを実行）
-                    GestureDetector(
-                      onTap: onReactionTap ??
-                          () {
-                            Navigator.of(context).push(
-                              MaterialPageRoute(
-                                builder: (context) =>
-                                    ScheduleDetailPage(schedule: schedule),
-                              ),
-                            );
-                          },
-                      child: Consumer(
-                        builder: (context, ref, _) {
-                          // 予定のインタラクション情報（リアクション、コメント）を取得
-                          final interactionState = ref.watch(
-                            scheduleInteractionNotifierProvider(schedule.id),
-                          );
+              Consumer(
+                builder: (context, ref, _) {
+                  final interactionState = ref.watch(
+                    scheduleInteractionNotifierProvider(schedule.id),
+                  );
+                  final counts = ScheduleTileInteractionCounts.resolve(
+                    schedule: schedule,
+                    interactionState: interactionState,
+                  );
 
-                          // リアクションアイコンを表示
-                          return SizedBox(
+                  return Row(
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    children: [
+                      // リアクション表示部分
+                      if (counts.reactionCount > 0)
+                        // リアクションアイコンをタップすると詳細ページに遷移（または指定されたコールバックを実行）
+                        GestureDetector(
+                          onTap: onReactionTap ??
+                              () {
+                                Navigator.of(context).push(
+                                  MaterialPageRoute(
+                                    builder: (context) =>
+                                        ScheduleDetailPage(schedule: schedule),
+                                  ),
+                                );
+                              },
+                          child: SizedBox(
                             width: 30,
                             height: 30,
                             child: ReactionIconWidget.fromReactionCounts(
-                              interactionState.reactionCounts,
-                              isLoading: interactionState.isLoading ||
-                                  interactionState.error != null,
+                              counts.reactionCounts,
+                              isLoading: counts.isLoading,
                             ),
-                          );
-                        },
+                          ),
+                        )
+                      else
+                        // リアクションがない場合はデフォルトのピープルアイコンを表示
+                        Icon(
+                          Icons.people,
+                          size: 16,
+                          color: Theme.of(context).primaryColor,
+                        ),
+                      const SizedBox(width: 4),
+                      // リアクション数を表示
+                      Text(
+                        '${counts.reactionCount}',
+                        style: TextStyle(
+                          color: counts.reactionCount > 0
+                              ? Colors.grey
+                              : Theme.of(context).primaryColor,
+                          fontWeight: FontWeight.bold,
+                        ),
                       ),
-                    )
-                  else
-                    // リアクションがない場合はデフォルトのピープルアイコンを表示
-                    Icon(
-                      Icons.people,
-                      size: 16,
-                      color: Theme.of(context).primaryColor,
-                    ),
-                  const SizedBox(width: 4),
-                  // リアクション数を表示
-                  Text(
-                    '${schedule.reactionCount}',
-                    style: TextStyle(
-                      color: schedule.reactionCount > 0
-                          ? Colors.grey
-                          : Theme.of(context).primaryColor,
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                  const SizedBox(width: 16),
-                  // コメントアイコン
-                  Icon(Icons.comment, size: 16, color: Colors.blue[400]),
-                  const SizedBox(width: 4),
-                  // コメント数を表示
-                  Text(
-                    '${schedule.commentCount}',
-                    style: TextStyle(
-                      color: Colors.blue[400],
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                ],
+                      const SizedBox(width: 16),
+                      // コメントアイコン
+                      Icon(Icons.comment, size: 16, color: Colors.blue[400]),
+                      const SizedBox(width: 4),
+                      // コメント数を表示
+                      Text(
+                        '${counts.commentCount}',
+                        style: TextStyle(
+                          color: Colors.blue[400],
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ],
+                  );
+                },
               ),
             ],
           ),

--- a/lib/presentation/widgets/schedule_tile_interaction_counts.dart
+++ b/lib/presentation/widgets/schedule_tile_interaction_counts.dart
@@ -1,0 +1,42 @@
+import 'package:lakiite/application/schedule/schedule_interaction_state.dart';
+import 'package:lakiite/domain/entity/schedule.dart';
+import 'package:lakiite/domain/entity/schedule_reaction.dart';
+
+class ScheduleTileInteractionCounts {
+  const ScheduleTileInteractionCounts({
+    required this.reactionCounts,
+    required this.reactionCount,
+    required this.commentCount,
+    required this.isLoading,
+  });
+
+  factory ScheduleTileInteractionCounts.resolve({
+    required Schedule schedule,
+    required ScheduleInteractionState interactionState,
+  }) {
+    final hasLiveInteractions =
+        !interactionState.isLoading && interactionState.error == null;
+    final liveReactionCounts = hasLiveInteractions
+        ? interactionState.reactionCounts
+        : const <ReactionType, int>{};
+
+    return ScheduleTileInteractionCounts(
+      reactionCounts: liveReactionCounts,
+      reactionCount: hasLiveInteractions
+          ? liveReactionCounts.values.fold<int>(
+              0,
+              (sum, count) => sum + count,
+            )
+          : schedule.reactionCount,
+      commentCount: hasLiveInteractions
+          ? interactionState.commentCount
+          : schedule.commentCount,
+      isLoading: !hasLiveInteractions,
+    );
+  }
+
+  final Map<ReactionType, int> reactionCounts;
+  final int reactionCount;
+  final int commentCount;
+  final bool isLoading;
+}

--- a/scripts/install_git_hooks.sh
+++ b/scripts/install_git_hooks.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+if [ ! -d ".githooks" ]; then
+  echo ".githooks directory was not found."
+  exit 1
+fi
+
+chmod +x .githooks/pre-commit .githooks/pre-push
+git config core.hooksPath .githooks
+
+echo "Git hooks installed."
+echo "pre-commit: whitespace, format, analyze, unit/infrastructure tests when relevant"
+echo "pre-push: presentation/widget tests when relevant"

--- a/test/infrastructure/display_list_repository_test.dart
+++ b/test/infrastructure/display_list_repository_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lakiite/domain/entity/display_list.dart';
+import 'package:lakiite/infrastructure/display_list_repository.dart';
+
+void main() {
+  group('DisplayListRepository', () {
+    group('sortByName', () {
+      test('nameの昇順に並べる', () {
+        final displayLists = [
+          _displayList(id: '3', name: 'Zoo'),
+          _displayList(id: '2', name: 'apple'),
+          _displayList(id: '1', name: 'Family'),
+        ];
+
+        final result = DisplayListRepository.sortByName(displayLists);
+
+        expect(result.map((list) => list.id), ['2', '1', '3']);
+      });
+
+      test('同名の場合はid順に並べる', () {
+        final displayLists = [
+          _displayList(id: 'b', name: 'Family'),
+          _displayList(id: 'a', name: 'Family'),
+        ];
+
+        final result = DisplayListRepository.sortByName(displayLists);
+
+        expect(result.map((list) => list.id), ['a', 'b']);
+      });
+    });
+  });
+}
+
+DisplayList _displayList({
+  required String id,
+  required String name,
+}) {
+  return DisplayList(
+    id: id,
+    name: name,
+    ownerId: 'owner',
+    colorKey: 'red',
+    memberIds: const [],
+    createdAt: DateTime(2026, 6, 14),
+    updatedAt: DateTime(2026, 6, 14),
+  );
+}

--- a/test/infrastructure/list_repository_test.dart
+++ b/test/infrastructure/list_repository_test.dart
@@ -1,5 +1,6 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lakiite/domain/entity/list.dart';
 import 'package:lakiite/infrastructure/list_repository.dart';
 
 void main() {
@@ -39,5 +40,43 @@ void main() {
         expect(result, fallback);
       });
     });
+
+    group('sortByName', () {
+      test('listNameの昇順に並べる', () {
+        final lists = [
+          _list(id: '3', listName: 'Zoo'),
+          _list(id: '2', listName: 'apple'),
+          _list(id: '1', listName: 'Family'),
+        ];
+
+        final result = ListRepository.sortByName(lists);
+
+        expect(result.map((list) => list.id), ['2', '1', '3']);
+      });
+
+      test('同名の場合はid順に並べる', () {
+        final lists = [
+          _list(id: 'b', listName: 'Family'),
+          _list(id: 'a', listName: 'Family'),
+        ];
+
+        final result = ListRepository.sortByName(lists);
+
+        expect(result.map((list) => list.id), ['a', 'b']);
+      });
+    });
   });
+}
+
+UserList _list({
+  required String id,
+  required String listName,
+}) {
+  return UserList(
+    id: id,
+    listName: listName,
+    ownerId: 'owner',
+    memberIds: const [],
+    createdAt: DateTime(2026, 6, 14),
+  );
 }

--- a/test/presentation/widgets/reaction_icon_widget_test.dart
+++ b/test/presentation/widgets/reaction_icon_widget_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lakiite/presentation/widgets/reaction_icon_widget.dart';
+
+void main() {
+  testWidgets('両方のリアクションがある場合は中央基準で重ねて表示する', (tester) async {
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: ReactionIconWidget(
+          hasGoing: true,
+          hasThinking: true,
+        ),
+      ),
+    );
+
+    final stack = tester.widget<Stack>(find.byType(Stack));
+
+    expect(stack.alignment, Alignment.center);
+    expect(stack.clipBehavior, Clip.none);
+    expect(find.byType(Positioned), findsNothing);
+    expect(find.byType(Transform), findsNWidgets(2));
+    expect(find.text('🙋'), findsOneWidget);
+    expect(find.text('🤔'), findsOneWidget);
+
+    final thinkingTransform = tester.widget<Transform>(find.ancestor(
+      of: find.text('🤔'),
+      matching: find.byType(Transform),
+    ));
+    final goingTransform = tester.widget<Transform>(find.ancestor(
+      of: find.text('🙋'),
+      matching: find.byType(Transform),
+    ));
+
+    final thinkingOffset =
+        MatrixUtils.getAsTranslation(thinkingTransform.transform);
+    final goingOffset = MatrixUtils.getAsTranslation(goingTransform.transform);
+
+    expect(thinkingOffset!.dy, goingOffset!.dy);
+  });
+}

--- a/test/presentation/widgets/schedule_tile_interaction_counts_test.dart
+++ b/test/presentation/widgets/schedule_tile_interaction_counts_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lakiite/application/schedule/schedule_interaction_state.dart';
+import 'package:lakiite/domain/entity/schedule_comment.dart';
+import 'package:lakiite/domain/entity/schedule_reaction.dart';
+import 'package:lakiite/presentation/widgets/schedule_tile_interaction_counts.dart';
+
+import '../../mock/base_mock.dart';
+
+void main() {
+  test('ライブなインタラクション状態がScheduleの古いcountより優先される', () {
+    final schedule = BaseMock.createTestSchedule().copyWith(
+      reactionCount: 0,
+      commentCount: 0,
+    );
+    final interactionState = ScheduleInteractionState(
+      reactions: [
+        _reaction(id: 'reaction-1', userId: 'user-1'),
+        _reaction(
+          id: 'reaction-2',
+          userId: 'user-2',
+          type: ReactionType.thinking,
+        ),
+      ],
+      comments: [
+        _comment(id: 'comment-1'),
+        _comment(id: 'comment-2'),
+        _comment(id: 'comment-3'),
+      ],
+    );
+
+    final counts = ScheduleTileInteractionCounts.resolve(
+      schedule: schedule,
+      interactionState: interactionState,
+    );
+
+    expect(counts.reactionCount, 2);
+    expect(counts.commentCount, 3);
+    expect(counts.reactionCounts[ReactionType.going], 1);
+    expect(counts.reactionCounts[ReactionType.thinking], 1);
+    expect(counts.isLoading, isFalse);
+  });
+
+  test('インタラクション状態が未取得の場合はScheduleのcountを使う', () {
+    final schedule = BaseMock.createTestSchedule().copyWith(
+      reactionCount: 4,
+      commentCount: 5,
+    );
+    const interactionState = ScheduleInteractionState(isLoading: true);
+
+    final counts = ScheduleTileInteractionCounts.resolve(
+      schedule: schedule,
+      interactionState: interactionState,
+    );
+
+    expect(counts.reactionCount, 4);
+    expect(counts.commentCount, 5);
+    expect(counts.reactionCounts, isEmpty);
+    expect(counts.isLoading, isTrue);
+  });
+}
+
+ScheduleReaction _reaction({
+  required String id,
+  required String userId,
+  ReactionType type = ReactionType.going,
+}) {
+  return ScheduleReaction(
+    id: id,
+    userId: userId,
+    type: type,
+    createdAt: DateTime(2026, 6, 14),
+  );
+}
+
+ScheduleComment _comment({required String id}) {
+  return ScheduleComment(
+    id: id,
+    userId: 'comment-user',
+    content: 'コメント',
+    createdAt: DateTime(2026, 6, 14),
+  );
+}


### PR DESCRIPTION

## Summary
- タイムラインとプロフィールの予定カードで、コメント数とリアクション数を live interaction stream から表示するように変更
- Androidで 🙋 と 🤔 が並ぶときの縦位置を揃えるように調整
- 通常リストと表示用リストを名前順で返すように整理
- PR更新ごとの重い `PR Tests` Actionsを停止し、ローカルGit hooksでcommit/push前検証を行う運用を追加

## Root Cause
- 予定カードは `Schedule` の `reactionCount` / `commentCount` フィールドを参照しており、サブコレクション更新だけでは表示が更新されませんでした。
- Androidでは絵文字フォントのベースライン差に加えて、🙋 側へ上方向オフセットが入っていました。
- リスト取得はFirestore取得順のままで、名前順ソートがありませんでした。
- AIエージェント開発ではPR更新ごとに重いActionsが走ると待ち時間が大きいため、検証をローカルhookへ寄せる必要がありました。

## Validation
- `fvm dart format --set-exit-if-changed lib/infrastructure/display_list_repository.dart lib/infrastructure/list_repository.dart lib/presentation/widgets/reaction_icon_widget.dart lib/presentation/widgets/schedule_tile.dart lib/presentation/widgets/schedule_tile_interaction_counts.dart test/infrastructure/list_repository_test.dart test/infrastructure/display_list_repository_test.dart test/presentation/widgets/reaction_icon_widget_test.dart test/presentation/widgets/schedule_tile_interaction_counts_test.dart`
- `git diff --check`
- `fvm flutter test test/presentation/widgets/schedule_tile_interaction_counts_test.dart test/presentation/widgets/reaction_icon_widget_test.dart test/infrastructure/list_repository_test.dart test/infrastructure/display_list_repository_test.dart`
- `fvm flutter analyze`
- Android実機 CPH2013 / dev flavor / Firebase project `lakiite-flutter-app-dev` で起動確認
- `./scripts/install_git_hooks.sh` で `core.hooksPath=.githooks` 設定を確認
- commit時に `pre-commit` hookが起動し、`fvm flutter analyze` が `No issues found!` で通過
- push時に `pre-push` hookが起動し、今回の設定/docs差分ではwidget testが条件スキップされることを確認
- 最新HEAD `e42a9ae` では `PR Tests` workflowが自動起動せず、`Release Drafter` のAutolabelのみ実行されることを確認

Closes #278
Closes #279
Closes #280
