### PR TITLE
Resolve release PR workflow conflicts

### DIFF
--- a/.github/workflows/deploy_prod_android.yml
+++ b/.github/workflows/deploy_prod_android.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   build:
-    if: |
+    if: >-
       github.event_name == 'workflow_dispatch' ||
       (
         github.event.workflow_run.conclusion == 'success' &&

--- a/.github/workflows/deploy_prod_ios.yml
+++ b/.github/workflows/deploy_prod_ios.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   build:
-    if: |
+    if: >-
       github.event_name == 'workflow_dispatch' ||
       (
         github.event.workflow_run.conclusion == 'success' &&


### PR DESCRIPTION

## Summary
- #282 の `main <- dev` リリースPRで衝突している prod deploy workflow 2ファイルを `main` 側の表現に揃える
- `ci.yml` のローカルhooks化差分は `dev` 側に残し、#282 経由で `main` に反映される状態を維持

## Details
- `.github/workflows/deploy_prod_android.yml`: `if: |` を `if: >-` に戻して `main` と一致
- `.github/workflows/deploy_prod_ios.yml`: `if: |` を `if: >-` に戻して `main` と一致

## Validation
- commit時の `pre-commit` hookで `fvm flutter analyze` が `No issues found!`
- `git merge-tree --write-tree origin/main HEAD` が exit 0 で、#282 相当のmerge conflictが消えることを確認

Refs #282
