### PR TITLE
Update release draft version from main PR labels

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, edited, labeled, unlabeled]
   workflow_dispatch:
+    inputs:
+      main_pr_number:
+        description: "Main release PR number used to resolve the draft version"
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -40,7 +45,13 @@ jobs:
 
   update_main_pr_draft_version:
     name: Update main PR draft version
-    if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main'
+    needs: update_release_draft
+    if: >-
+      always() &&
+      (
+        (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main') ||
+        (github.event_name == 'workflow_dispatch' && inputs.main_pr_number != '')
+      )
     runs-on: ubuntu-latest
 
     steps:
@@ -48,9 +59,15 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPOSITORY: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.main_pr_number }}
         run: |
           set -euo pipefail
+
+          base_ref="$(gh pr view "$PR_NUMBER" --repo "$REPOSITORY" --json baseRefName --jq '.baseRefName')"
+          if [ "$base_ref" != "main" ]; then
+            echo "::error ::PR #$PR_NUMBER targets $base_ref, but draft version updates require a main PR."
+            exit 1
+          fi
 
           labels="$(gh pr view "$PR_NUMBER" --repo "$REPOSITORY" --json labels --jq '.labels[].name')"
           semver_count="$(printf '%s\n' "$labels" | grep -Ec '^semver:(major|minor|patch|none)$' || true)"

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    types: [opened, reopened, synchronize, edited]
+    types: [opened, reopened, synchronize, edited, labeled, unlabeled]
   workflow_dispatch:
 
 permissions:
@@ -37,3 +37,72 @@ jobs:
           config-name: release-drafter.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  update_main_pr_draft_version:
+    name: Update main PR draft version
+    if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Update draft release version from PR semver label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          labels="$(gh pr view "$PR_NUMBER" --repo "$REPOSITORY" --json labels --jq '.labels[].name')"
+          semver_count="$(printf '%s\n' "$labels" | grep -Ec '^semver:(major|minor|patch|none)$' || true)"
+
+          if [ "$semver_count" -ne 1 ]; then
+            echo "Exactly one semver label is required before draft version can be updated."
+            printf 'Current labels:\n%s\n' "$labels"
+            exit 0
+          fi
+
+          semver_label="$(printf '%s\n' "$labels" | grep -E '^semver:(major|minor|patch|none)$')"
+          if [ "$semver_label" = "semver:none" ]; then
+            echo "semver:none is set. Draft version update skipped."
+            exit 0
+          fi
+
+          latest_tag="$(gh api "repos/$REPOSITORY/releases/latest" --jq '.tag_name')"
+          latest_version="${latest_tag#v}"
+          IFS=. read -r major minor patch <<< "$latest_version"
+
+          case "$semver_label" in
+            semver:major)
+              major=$((major + 1))
+              minor=0
+              patch=0
+              ;;
+            semver:minor)
+              minor=$((minor + 1))
+              patch=0
+              ;;
+            semver:patch)
+              patch=$((patch + 1))
+              ;;
+            *)
+              echo "::error ::Unsupported semver label: $semver_label"
+              exit 1
+              ;;
+          esac
+
+          next_version="$major.$minor.$patch"
+
+          draft_id="$(gh api "repos/$REPOSITORY/releases" --jq '[.[] | select(.draft == true and .target_commitish == "main")][0].id // empty')"
+          if [ -z "$draft_id" ]; then
+            echo "::error ::No draft release targeting main was found."
+            exit 1
+          fi
+
+          gh api \
+            --method PATCH \
+            "repos/$REPOSITORY/releases/$draft_id" \
+            -f "name=v$next_version" \
+            -f "tag_name=v$next_version" \
+            -f "target_commitish=main"
+
+          echo "Updated draft release #$draft_id to v$next_version from $semver_label."

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -55,13 +55,45 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Update draft release version from PR semver label
+      - name: Update draft release from main PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number || inputs.main_pr_number }}
         run: |
           set -euo pipefail
+
+          has_label() {
+            printf '%s\n' "$1" | grep -Fxq "$2"
+          }
+
+          append_pr_summary() {
+            local included_pr="$1"
+            local category_file="$2"
+            local summary
+
+            summary="$(
+              gh pr view "$included_pr" --repo "$REPOSITORY" --json body --jq '.body // ""' |
+                awk '
+                  /^##[[:space:]]+Summary[[:space:]]*$/ { capture = 1; next }
+                  capture && /^##[[:space:]]+/ { capture = 0 }
+                  capture { print }
+                ' |
+                sed '/^[[:space:]]*$/d'
+            )"
+
+            if [ -z "$summary" ]; then
+              local title
+              title="$(gh pr view "$included_pr" --repo "$REPOSITORY" --json title --jq '.title')"
+              printf -- '- %s (#%s)\n' "$title" "$included_pr" >> "$category_file"
+              return
+            fi
+
+            while IFS= read -r line; do
+              line="${line#- }"
+              printf -- '- %s (#%s)\n' "$line" "$included_pr" >> "$category_file"
+            done <<< "$summary"
+          }
 
           base_ref="$(gh pr view "$PR_NUMBER" --repo "$REPOSITORY" --json baseRefName --jq '.baseRefName')"
           if [ "$base_ref" != "main" ]; then
@@ -109,17 +141,118 @@ jobs:
 
           next_version="$major.$minor.$patch"
 
-          draft_id="$(gh api "repos/$REPOSITORY/releases" --jq '[.[] | select(.draft == true and .target_commitish == "main")][0].id // empty')"
+          tmp_dir="$(mktemp -d)"
+          trap 'rm -rf "$tmp_dir"' EXIT
+
+          breaking_file="$tmp_dir/breaking.md"
+          features_file="$tmp_dir/features.md"
+          fixes_file="$tmp_dir/fixes.md"
+          security_file="$tmp_dir/security.md"
+          performance_file="$tmp_dir/performance.md"
+          refactoring_file="$tmp_dir/refactoring.md"
+          tests_file="$tmp_dir/tests.md"
+          docs_file="$tmp_dir/docs.md"
+          ci_file="$tmp_dir/ci.md"
+          other_file="$tmp_dir/other.md"
+          contributors_file="$tmp_dir/contributors.txt"
+
+          included_prs="$(
+            gh api "repos/$REPOSITORY/pulls/$PR_NUMBER/commits" --paginate --jq '.[].commit.message' |
+              sed -nE 's/^Merge pull request #([0-9]+) .*/\1/p' |
+              awk '!seen[$0]++'
+          )"
+
+          if [ -z "$included_prs" ]; then
+            included_prs="$PR_NUMBER"
+          fi
+
+          while IFS= read -r included_pr; do
+            [ -n "$included_pr" ] || continue
+
+            pr_labels="$(gh pr view "$included_pr" --repo "$REPOSITORY" --json labels --jq '.labels[].name')"
+            pr_author="$(gh pr view "$included_pr" --repo "$REPOSITORY" --json author --jq '.author.login')"
+            printf '@%s\n' "$pr_author" >> "$contributors_file"
+
+            if has_label "$pr_labels" "skip-changelog" || has_label "$pr_labels" "semver:none"; then
+              continue
+            elif has_label "$pr_labels" "breaking-change"; then
+              append_pr_summary "$included_pr" "$breaking_file"
+            elif has_label "$pr_labels" "type:feature" ||
+              has_label "$pr_labels" "enhancement" ||
+              has_label "$pr_labels" "1 : ストーリー - story"; then
+              append_pr_summary "$included_pr" "$features_file"
+            elif has_label "$pr_labels" "type:fix" ||
+              has_label "$pr_labels" "3 : バグ - bug"; then
+              append_pr_summary "$included_pr" "$fixes_file"
+            elif has_label "$pr_labels" "type:security"; then
+              append_pr_summary "$included_pr" "$security_file"
+            elif has_label "$pr_labels" "type:performance"; then
+              append_pr_summary "$included_pr" "$performance_file"
+            elif has_label "$pr_labels" "type:refactor"; then
+              append_pr_summary "$included_pr" "$refactoring_file"
+            elif has_label "$pr_labels" "type:test"; then
+              append_pr_summary "$included_pr" "$tests_file"
+            elif has_label "$pr_labels" "type:docs" ||
+              has_label "$pr_labels" "0 : 書類 - documentation"; then
+              append_pr_summary "$included_pr" "$docs_file"
+            elif has_label "$pr_labels" "type:ci" ||
+              has_label "$pr_labels" "type:chore" ||
+              has_label "$pr_labels" "環境構築"; then
+              append_pr_summary "$included_pr" "$ci_file"
+            else
+              append_pr_summary "$included_pr" "$other_file"
+            fi
+          done <<< "$included_prs"
+
+          body_file="$tmp_dir/body.md"
+          {
+            printf '## Changes\n\n'
+
+            if [ -s "$breaking_file" ]; then printf '### Breaking Changes\n'; cat "$breaking_file"; printf '\n'; fi
+            if [ -s "$features_file" ]; then printf '### Features\n'; cat "$features_file"; printf '\n'; fi
+            if [ -s "$fixes_file" ]; then printf '### Fixes\n'; cat "$fixes_file"; printf '\n'; fi
+            if [ -s "$security_file" ]; then printf '### Security\n'; cat "$security_file"; printf '\n'; fi
+            if [ -s "$performance_file" ]; then printf '### Performance\n'; cat "$performance_file"; printf '\n'; fi
+            if [ -s "$refactoring_file" ]; then printf '### Refactoring\n'; cat "$refactoring_file"; printf '\n'; fi
+            if [ -s "$tests_file" ]; then printf '### Tests\n'; cat "$tests_file"; printf '\n'; fi
+            if [ -s "$docs_file" ]; then printf '### Documentation\n'; cat "$docs_file"; printf '\n'; fi
+            if [ -s "$ci_file" ]; then printf '### CI and Maintenance\n'; cat "$ci_file"; printf '\n'; fi
+            if [ -s "$other_file" ]; then printf '### Other Changes\n'; cat "$other_file"; printf '\n'; fi
+
+            if ! find "$tmp_dir" -name '*.md' ! -name 'body.md' -size +0c | grep -q .; then
+              printf -- '- No user-facing changes\n\n'
+            fi
+
+            printf '## Contributors\n\n'
+            if [ -s "$contributors_file" ]; then
+              sort -u "$contributors_file"
+            else
+              printf 'No contributors\n'
+            fi
+          } > "$body_file"
+
+          draft_id="$(gh api "repos/$REPOSITORY/releases" --jq '[.[] | select(.draft == true and .target_commitish == "main")] | sort_by(.updated_at) | reverse | .[0].id // empty')"
           if [ -z "$draft_id" ]; then
             echo "::error ::No draft release targeting main was found."
             exit 1
           fi
 
+          body="$(cat "$body_file")"
           gh api \
             --method PATCH \
             "repos/$REPOSITORY/releases/$draft_id" \
             -f "name=v$next_version" \
             -f "tag_name=v$next_version" \
-            -f "target_commitish=main"
+            -f "target_commitish=main" \
+            -f "body=$body"
+
+          duplicate_draft_ids="$(
+            gh api "repos/$REPOSITORY/releases" --jq ".[] | select(.draft == true and .target_commitish == \"main\" and .id != $draft_id) | .id"
+          )"
+          while IFS= read -r duplicate_draft_id; do
+            [ -n "$duplicate_draft_id" ] || continue
+            gh api --method DELETE "repos/$REPOSITORY/releases/$duplicate_draft_id"
+            echo "Deleted duplicate draft release #$duplicate_draft_id."
+          done <<< "$duplicate_draft_ids"
 
           echo "Updated draft release #$draft_id to v$next_version from $semver_label."


### PR DESCRIPTION

## Summary
- `Release Drafter` workflowでmain向けPRの `labeled` / `unlabeled` を拾うようにする
- main向けPRに付いた `semver:*` ラベルから最新published release基準で次versionを計算する
- draft releaseの `name` / `tag_name` をActions経由で更新する

## Why
#282 は `semver:major` が付いているため、最新published release `v1.1.0` から `v2.0.0` を期待するが、Release Drafterのdraft更新はPRラベル変更で走らず、ドラフトが `v1.1.1` のままだった。

## Validation
- Ruby YAML parserでworkflow jobsを読み込み確認
- 追加run script部分を `bash -n` で確認
- ローカルversion計算で `1.1.0 + semver:major => 2.0.0` を確認
- `git diff --check`
- commit時の `pre-commit` hookで `fvm flutter analyze` が `No issues found!`

Refs #282
