### PR TITLE
Clarify device handover backup settings

### DIFF
--- a/lib/presentation/settings/schedule_key_backup_page.dart
+++ b/lib/presentation/settings/schedule_key_backup_page.dart
@@ -22,6 +22,8 @@ class _ScheduleKeyBackupPageState extends ConsumerState<ScheduleKeyBackupPage> {
   bool _obscurePassword = true;
   bool _obscureConfirmPassword = true;
   bool _isSubmitting = false;
+  String? _backupStatusUserId;
+  Future<bool>? _backupStatusFuture;
 
   @override
   void dispose() {
@@ -83,73 +85,120 @@ class _ScheduleKeyBackupPageState extends ConsumerState<ScheduleKeyBackupPage> {
     );
   }
 
+  Future<bool> _loadBackupStatus(String? userId) {
+    if (userId == null) {
+      _backupStatusUserId = null;
+      _backupStatusFuture = Future.value(false);
+      return _backupStatusFuture!;
+    }
+
+    if (_backupStatusFuture == null || _backupStatusUserId != userId) {
+      _backupStatusUserId = userId;
+      _backupStatusFuture =
+          ref.read(scheduleEncryptionServiceProvider).hasPrivateKeyBackup(
+                userId,
+              );
+    }
+    return _backupStatusFuture!;
+  }
+
   @override
   Widget build(BuildContext context) {
+    final authState = ref.watch(authNotifierProvider).valueOrNull;
+    final userId = authState?.status == AuthStatus.authenticated
+        ? authState?.user?.id
+        : null;
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('端末引き継ぎ設定'),
       ),
-      body: ListView(
-        padding: const EdgeInsets.all(24),
-        children: [
-          const Text(
-            '別の端末でも暗号化された予定を表示できるように、秘密キーを引き継ぎパスワードで暗号化して保存します。',
-          ),
-          const SizedBox(height: 8),
-          const Text(
-            'すでに設定済みの場合、新しいパスワードで保存すると既存の引き継ぎ設定は上書きされます。',
-          ),
-          const SizedBox(height: 24),
-          TextField(
-            controller: _passwordController,
-            obscureText: _obscurePassword,
-            decoration: InputDecoration(
-              labelText: '引き継ぎパスワード',
-              border: const OutlineInputBorder(),
-              suffixIcon: IconButton(
-                tooltip: _obscurePassword ? '引き継ぎパスワードを表示' : '引き継ぎパスワードを非表示',
-                icon: Icon(
-                  _obscurePassword ? Icons.visibility : Icons.visibility_off,
-                ),
-                onPressed: () {
-                  setState(() => _obscurePassword = !_obscurePassword);
-                },
+      body: FutureBuilder<bool>(
+        future: _loadBackupStatus(userId),
+        builder: (context, snapshot) {
+          final hasBackup = snapshot.data ?? false;
+          final isLoading = snapshot.connectionState != ConnectionState.done;
+          final statusLabel = isLoading
+              ? '確認中'
+              : hasBackup
+                  ? '設定済み'
+                  : '未設定';
+          final description = hasBackup
+              ? 'このアカウントには端末引き継ぎ設定が保存されています。新しいパスワードで保存すると、別端末で復元するときに使うパスワードも新しいものに変わります。'
+              : '別の端末でも暗号化された予定を表示できるように、秘密キーを引き継ぎパスワードで暗号化して保存します。';
+          final passwordLabel = hasBackup ? '新しい引き継ぎパスワード' : '引き継ぎパスワード';
+          final buttonLabel = hasBackup ? '引き継ぎパスワードを更新' : '保存';
+
+          return ListView(
+            padding: const EdgeInsets.all(24),
+            children: [
+              Text(
+                '状態: $statusLabel',
+                style: Theme.of(context).textTheme.titleMedium,
               ),
-            ),
-          ),
-          const SizedBox(height: 16),
-          TextField(
-            controller: _confirmPasswordController,
-            obscureText: _obscureConfirmPassword,
-            decoration: InputDecoration(
-              labelText: '確認用パスワード',
-              border: const OutlineInputBorder(),
-              suffixIcon: IconButton(
-                tooltip:
-                    _obscureConfirmPassword ? '確認用パスワードを表示' : '確認用パスワードを非表示',
-                icon: Icon(
-                  _obscureConfirmPassword
-                      ? Icons.visibility
-                      : Icons.visibility_off,
-                ),
-                onPressed: () {
-                  setState(
-                      () => _obscureConfirmPassword = !_obscureConfirmPassword);
-                },
+              const SizedBox(height: 8),
+              Text(description),
+              const SizedBox(height: 8),
+              const Text(
+                '復元パスワードはアプリ内で確認できません。別端末で復元するときに必要になるため、忘れないように保管してください。',
               ),
-            ),
-          ),
-          const SizedBox(height: 24),
-          FilledButton(
-            onPressed: _isSubmitting ? null : _save,
-            child: _isSubmitting
-                ? const SizedBox.square(
-                    dimension: 20,
-                    child: CircularProgressIndicator(strokeWidth: 2),
-                  )
-                : const Text('保存'),
-          ),
-        ],
+              const SizedBox(height: 24),
+              TextField(
+                controller: _passwordController,
+                obscureText: _obscurePassword,
+                decoration: InputDecoration(
+                  labelText: passwordLabel,
+                  border: const OutlineInputBorder(),
+                  suffixIcon: IconButton(
+                    tooltip:
+                        _obscurePassword ? '引き継ぎパスワードを表示' : '引き継ぎパスワードを非表示',
+                    icon: Icon(
+                      _obscurePassword
+                          ? Icons.visibility
+                          : Icons.visibility_off,
+                    ),
+                    onPressed: () {
+                      setState(() => _obscurePassword = !_obscurePassword);
+                    },
+                  ),
+                ),
+              ),
+              const SizedBox(height: 16),
+              TextField(
+                controller: _confirmPasswordController,
+                obscureText: _obscureConfirmPassword,
+                decoration: InputDecoration(
+                  labelText: '確認用パスワード',
+                  border: const OutlineInputBorder(),
+                  suffixIcon: IconButton(
+                    tooltip: _obscureConfirmPassword
+                        ? '確認用パスワードを表示'
+                        : '確認用パスワードを非表示',
+                    icon: Icon(
+                      _obscureConfirmPassword
+                          ? Icons.visibility
+                          : Icons.visibility_off,
+                    ),
+                    onPressed: () {
+                      setState(() =>
+                          _obscureConfirmPassword = !_obscureConfirmPassword);
+                    },
+                  ),
+                ),
+              ),
+              const SizedBox(height: 24),
+              FilledButton(
+                onPressed: _isSubmitting ? null : _save,
+                child: _isSubmitting
+                    ? const SizedBox.square(
+                        dimension: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : Text(buttonLabel),
+              ),
+            ],
+          );
+        },
       ),
     );
   }

--- a/test/presentation/settings/schedule_key_backup_page_test.dart
+++ b/test/presentation/settings/schedule_key_backup_page_test.dart
@@ -1,10 +1,30 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lakiite/app/di/providers.dart';
+import 'package:lakiite/application/auth/auth_notifier.dart';
+import 'package:lakiite/application/auth/auth_state.dart';
+import 'package:lakiite/infrastructure/encryption/schedule_encryption_service.dart';
 import 'package:lakiite/presentation/settings/schedule_key_backup_page.dart';
 
+import '../../mock/base_mock.dart';
+
 void main() {
-  Widget buildTestTarget() {
-    return const MaterialApp(home: ScheduleKeyBackupPage());
+  Widget buildTestTarget({bool hasBackup = false}) {
+    final user = BaseMock.createTestUser();
+    return ProviderScope(
+      overrides: [
+        authNotifierProvider.overrideWith(
+          () => _StubAuthNotifier(AuthState.authenticated(user)),
+        ),
+        scheduleEncryptionServiceProvider.overrideWithValue(
+          _StubScheduleEncryptionService(hasBackup: hasBackup),
+        ),
+      ],
+      child: const MaterialApp(home: ScheduleKeyBackupPage()),
+    );
   }
 
   testWidgets('引き継ぎパスワードと確認用パスワードの表示切替は独立している', (tester) async {
@@ -33,8 +53,41 @@ void main() {
   });
 
   testWidgets('既存の引き継ぎパスワードは保存時に上書きされることを表示する', (tester) async {
-    await tester.pumpWidget(buildTestTarget());
+    await tester.pumpWidget(buildTestTarget(hasBackup: true));
+    await tester.pump();
 
-    expect(find.textContaining('上書き'), findsOneWidget);
+    expect(find.text('状態: 設定済み'), findsOneWidget);
+    expect(find.text('新しい引き継ぎパスワード'), findsOneWidget);
+    expect(find.text('引き継ぎパスワードを更新'), findsOneWidget);
+    expect(find.textContaining('新しいパスワードで保存'), findsOneWidget);
   });
+
+  testWidgets('引き継ぎパスワードが未設定の場合は未設定として表示する', (tester) async {
+    await tester.pumpWidget(buildTestTarget());
+    await tester.pump();
+
+    expect(find.text('状態: 未設定'), findsOneWidget);
+    expect(find.text('引き継ぎパスワード'), findsOneWidget);
+    expect(find.text('保存'), findsOneWidget);
+  });
+}
+
+class _StubAuthNotifier extends AuthNotifier {
+  _StubAuthNotifier(this._state);
+
+  final AuthState _state;
+
+  @override
+  FutureOr<AuthState> build() => _state;
+}
+
+class _StubScheduleEncryptionService extends ScheduleEncryptionService {
+  _StubScheduleEncryptionService({required this.hasBackup});
+
+  final bool hasBackup;
+
+  @override
+  Future<bool> hasPrivateKeyBackup(String uid) async {
+    return hasBackup;
+  }
 }

--- a/web/how-to-use.html
+++ b/web/how-to-use.html
@@ -180,6 +180,7 @@
             <button class="tab" type="button" role="tab" aria-selected="false" aria-controls="lists" id="tab-lists">リストの使い方</button>
             <button class="tab" type="button" role="tab" aria-selected="false" aria-controls="create" id="tab-create">予定作成</button>
             <button class="tab" type="button" role="tab" aria-selected="false" aria-controls="check" id="tab-check">予定の確認</button>
+            <button class="tab" type="button" role="tab" aria-selected="false" aria-controls="handover" id="tab-handover">端末引き継ぎ</button>
             <button class="tab" type="button" role="tab" aria-selected="false" aria-controls="notifications" id="tab-notifications">通知設定</button>
         </nav>
 
@@ -267,6 +268,31 @@
                 <p>予定にはリアクションやコメントを追加できます。参加できるか、確認したか、補足したいことがあるかをやり取りするために使います。</p>
 
                 <p class="tip">予定の内容を変更した場合は、共有相手にも更新後の内容が表示されます。重要な変更をしたときは、コメントでも補足しておくと伝わりやすくなります。</p>
+            </section>
+
+            <section class="panel" id="handover" role="tabpanel" aria-labelledby="tab-handover">
+                <h2>端末引き継ぎ</h2>
+                <p class="summary">暗号化された予定を別の端末でも開くには、元の端末で端末引き継ぎ設定を保存し、復元パスワードを控えておく必要があります。</p>
+
+                <h3>引き継ぎ前に行うこと</h3>
+                <ol>
+                    <li>元の端末で設定画面を開きます。</li>
+                    <li>「端末引き継ぎ設定」を選びます。</li>
+                    <li>復元パスワードを入力し、確認用にも同じパスワードを入力します。</li>
+                    <li>保存すると、予定を開くための秘密キーが復元パスワードで暗号化されて保存されます。</li>
+                </ol>
+
+                <h3>別端末で復元する</h3>
+                <ol>
+                    <li>新しい端末で同じアカウントにログインします。</li>
+                    <li>端末引き継ぎ画面が表示されたら、元の端末で設定した復元パスワードを入力します。</li>
+                    <li>復元が完了すると、暗号化された予定を新しい端末でも表示できます。</li>
+                </ol>
+
+                <h3>復元パスワードを変更する</h3>
+                <p>端末引き継ぎ設定が保存済みの場合でも、新しい復元パスワードで保存できます。保存すると既存の引き継ぎ設定は上書きされ、次回から別端末で復元するときは新しい復元パスワードが必要になります。</p>
+
+                <p class="tip">復元パスワードはアプリ内で確認できません。端末引き継ぎ設定をしていない場合や復元パスワードを忘れた場合、別端末では暗号化された予定を開けません。</p>
             </section>
 
             <section class="panel" id="notifications" role="tabpanel" aria-labelledby="tab-notifications">


### PR DESCRIPTION
## Summary
- Show whether the device handover backup is already configured on the settings screen
- Change the configured-state copy, password label, and button text to make password updates explicit
- Add device handover instructions to the web usage guide, including restore password requirements and overwrite behavior

## Validation
- fvm flutter test test/presentation/settings/schedule_key_backup_page_test.dart test/presentation/encryption/schedule_private_key_gate_test.dart
- fvm flutter analyze
- pre-push presentation/widget tests passed
