### PR TITLE
Fix prod deploy Firebase config restore paths

### DIFF
--- a/.github/workflows/deploy_prod_android.yml
+++ b/.github/workflows/deploy_prod_android.yml
@@ -28,6 +28,7 @@ jobs:
       - uses: actions/checkout@v5.0.1
         with:
           fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
 
       - name: Setup CI
         uses: ./.github/actions/setup
@@ -48,6 +49,7 @@ jobs:
 
       - name: Restore Firebase config files
         run: |
+          mkdir -p android/app/src/prod
           echo "${{ secrets.PROD_GOOGLE_SERVICES_JSON_BASE64 }}" | base64 -d > android/app/src/prod/google-services.json
           echo "${{ secrets.PROD_GOOGLESERVICE_INFO_PLIST_BASE64 }}" | base64 -d > ios/Runner/GoogleService-Info-Prod.plist
           echo "${{ secrets.PROD_FIREBASE_OPTIONS_DART_BASE64 }}" | base64 -d > lib/firebase_options.dart

--- a/.github/workflows/deploy_prod_ios.yml
+++ b/.github/workflows/deploy_prod_ios.yml
@@ -28,6 +28,7 @@ jobs:
       - uses: actions/checkout@v5.0.1
         with:
           fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
 
       - name: Check Xcode version
         run: |
@@ -40,6 +41,7 @@ jobs:
 
       - name: Restore Firebase config files
         run: |
+          mkdir -p ios/Runner/Firebase/Prod
           echo "${{ secrets.PROD_GOOGLESERVICE_INFO_PLIST_BASE64 }}" | base64 -d > ios/Runner/Firebase/Prod/GoogleService-Info.plist
           cp ios/Runner/Firebase/Prod/GoogleService-Info.plist ios/Runner/GoogleService-Info.plist
           echo "${{ secrets.PROD_FIREBASE_OPTIONS_DART_BASE64 }}" | base64 -d > lib/firebase_options.dart


### PR DESCRIPTION
## Summary
- Create prod Firebase config directories before decoding secrets in Android and iOS prod deploy workflows
- Checkout the workflow_run head SHA so prod deploy builds the release-triggering commit instead of defaulting to the repository default branch

## Root Cause
Prod deploy failed before version resolution because the generated Firebase config target directories are not tracked by git after Firebase config files were removed from repository history.

## Validation
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "OK #{f}" }' .github/workflows/deploy_prod_android.yml .github/workflows/deploy_prod_ios.yml
- git diff --check
- commit hook: fvm flutter analyze
