### PR TITLE
Fix manual prod deploy version override

### DIFF
--- a/.github/actions/resolve-release-version/action.yml
+++ b/.github/actions/resolve-release-version/action.yml
@@ -1,6 +1,12 @@
 name: Resolve Release Version
 description: Resolve the next app version from Release Drafter labels.
 
+inputs:
+  version:
+    description: Explicit SemVer version without the leading v.
+    required: false
+    default: ""
+
 outputs:
   version:
     description: SemVer version without the leading v.
@@ -87,12 +93,16 @@ runs:
         set -euo pipefail
 
         base_version="$(awk '/^version:/ { print $2; exit }' pubspec.yaml | cut -d '+' -f 1)"
+        input_version="${{ inputs.version }}"
         drafter_version="${{ steps.release_drafter.outputs.resolved_version }}"
         semver_label="${{ steps.release_pr.outputs.semver_label }}"
         latest_version="${{ steps.release_pr.outputs.latest_version }}"
         version="$drafter_version"
 
-        if [ -n "$semver_label" ] && [ -n "$latest_version" ]; then
+        if [ -n "$input_version" ]; then
+          version="${input_version#v}"
+          echo "Using explicit release version input: $version"
+        elif [ -n "$semver_label" ] && [ -n "$latest_version" ]; then
           version="$(python3 - "$latest_version" "$semver_label" <<'PY'
         import sys
 

--- a/.github/workflows/deploy_prod_android.yml
+++ b/.github/workflows/deploy_prod_android.yml
@@ -6,6 +6,11 @@ on:
     types: [completed]
     branches: [main]
   workflow_dispatch:
+    inputs:
+      version:
+        description: "App version to deploy, for example 2.0.0"
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -28,6 +33,7 @@ jobs:
       - uses: actions/checkout@v5.0.1
         with:
           fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref }}
 
       - name: Setup CI
         uses: ./.github/actions/setup
@@ -48,6 +54,7 @@ jobs:
 
       - name: Restore Firebase config files
         run: |
+          mkdir -p android/app/src/prod
           echo "${{ secrets.PROD_GOOGLE_SERVICES_JSON_BASE64 }}" | base64 -d > android/app/src/prod/google-services.json
           echo "${{ secrets.PROD_GOOGLESERVICE_INFO_PLIST_BASE64 }}" | base64 -d > ios/Runner/GoogleService-Info-Prod.plist
           echo "${{ secrets.PROD_FIREBASE_OPTIONS_DART_BASE64 }}" | base64 -d > lib/firebase_options.dart
@@ -141,6 +148,8 @@ jobs:
       - name: Resolve release version
         id: release_version
         uses: ./.github/actions/resolve-release-version
+        with:
+          version: ${{ github.event_name == 'workflow_dispatch' && inputs.version || '' }}
 
       - name: Calculate Build Number
         id: calculate_build_number

--- a/.github/workflows/deploy_prod_ios.yml
+++ b/.github/workflows/deploy_prod_ios.yml
@@ -6,6 +6,11 @@ on:
     types: [completed]
     branches: [main]
   workflow_dispatch:
+    inputs:
+      version:
+        description: "App version to deploy, for example 2.0.0"
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -28,6 +33,7 @@ jobs:
       - uses: actions/checkout@v5.0.1
         with:
           fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref }}
 
       - name: Check Xcode version
         run: |
@@ -40,6 +46,7 @@ jobs:
 
       - name: Restore Firebase config files
         run: |
+          mkdir -p ios/Runner/Firebase/Prod
           echo "${{ secrets.PROD_GOOGLESERVICE_INFO_PLIST_BASE64 }}" | base64 -d > ios/Runner/Firebase/Prod/GoogleService-Info.plist
           cp ios/Runner/Firebase/Prod/GoogleService-Info.plist ios/Runner/GoogleService-Info.plist
           echo "${{ secrets.PROD_FIREBASE_OPTIONS_DART_BASE64 }}" | base64 -d > lib/firebase_options.dart
@@ -96,6 +103,8 @@ jobs:
       - name: Resolve release version
         id: release_version
         uses: ./.github/actions/resolve-release-version
+        with:
+          version: ${{ github.event_name == 'workflow_dispatch' && inputs.version || '' }}
 
       - name: flutter build ipa
         run: |


### PR DESCRIPTION
## Summary
- Create missing Firebase config directories before restoring prod config files from secrets
- Checkout the Release Drafter workflow_run head SHA for automatic prod deploys
- Add optional workflow_dispatch version input for prod Android/iOS deploys
- Prefer explicit version input in resolve-release-version so v2.0.0 can be deployed without rewriting release notes

## Validation
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "OK #{f}" }' .github/workflows/deploy_prod_android.yml .github/workflows/deploy_prod_ios.yml .github/actions/resolve-release-version/action.yml
- git diff --check
- fvm flutter analyze
- commit hook: fvm flutter analyze
