### PR TITLE
fix: add app-ads.txt for AdMob

### DIFF
--- a/web/app-ads.txt
+++ b/web/app-ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-6315199114988889, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
## Summary
- Add `web/app-ads.txt` for AdMob app-ads.txt verification
- Publish the production AdMob publisher entry through Firebase Hosting

## Test Plan
- Verified `web/app-ads.txt` content locally
- Pre-commit ran `Flutter analyze`: No issues found
- Pre-push checks passed; no matching presentation/widget tests for this static file change