### PR TITLE
fix: remove broad Android media permissions

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -8,10 +8,7 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.VIBRATE" />
-    <!-- 写真とカメラの権限 -->
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
+    <!-- カメラの権限。画像選択は Android Photo Picker を使うため、写真/動画の広範アクセス権限は宣言しない。 -->
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-feature android:name="android.hardware.camera" android:required="false" />
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'dart:io';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:image_picker_android/image_picker_android.dart';
+import 'package:image_picker_platform_interface/image_picker_platform_interface.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'application/force_update/force_update_providers.dart';
@@ -45,6 +47,12 @@ Future<void> startApp([
   // iOS でのプラットフォームビュー問題を予防
   if (Platform.isIOS) {
     await _resetPlatformViews();
+  }
+
+  // Android では写真/動画への広範アクセス権限を使わず、ユーザーが選択した画像だけを扱う。
+  final imagePickerImplementation = ImagePickerPlatform.instance;
+  if (imagePickerImplementation is ImagePickerAndroid) {
+    imagePickerImplementation.useAndroidPhotoPicker = true;
   }
 
   // 環境設定の初期化

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -851,7 +851,7 @@ packages:
     source: hosted
     version: "1.1.2"
   image_picker_android:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: image_picker_android
       sha256: "82652a75e3dd667a91187769a6a2cc81bd8c111bbead698d8e938d2b63e5e89a"
@@ -891,7 +891,7 @@ packages:
     source: hosted
     version: "0.2.1+2"
   image_picker_platform_interface:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: image_picker_platform_interface
       sha256: "886d57f0be73c4b140004e78b9f28a8914a09e50c2d816bdd0520051a71236a0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,8 @@ dependencies:
 
   # Media & Assets
   image_picker: ^1.0.7
+  image_picker_android: ^0.8.12+21
+  image_picker_platform_interface: ^2.10.1
   image_cropper: ^9.1.0
   flutter_image_compress: ^2.1.0
   path: ^1.8.3

--- a/test/utils/android_admob_app_id_config_test.dart
+++ b/test/utils/android_admob_app_id_config_test.dart
@@ -28,6 +28,26 @@ void main() {
     );
   });
 
+  test('AndroidManifest does not request broad photo or video permissions', () {
+    final manifest = File(manifestPath).readAsStringSync();
+
+    const disallowedPermissions = [
+      'android.permission.READ_MEDIA_IMAGES',
+      'android.permission.READ_MEDIA_VIDEO',
+      'android.permission.READ_EXTERNAL_STORAGE',
+      'android.permission.WRITE_EXTERNAL_STORAGE',
+    ];
+
+    for (final permission in disallowedPermissions) {
+      expect(
+        manifest,
+        isNot(contains(permission)),
+        reason:
+            'Use Android Photo Picker for user-selected media instead of broad storage access.',
+      );
+    }
+  });
+
   test('Android flavors use matching AdMob app ids', () {
     final devAdMobAppId = _readDartDefine(
       'dart_define/dev_dart_define.json',


### PR DESCRIPTION
## Summary
- Remove broad Android photo/storage permissions from the main Android manifest
- Enable Android Photo Picker for image_picker on Android
- Add a manifest regression test to keep broad media/storage permissions out of Android builds

## Validation
- fvm flutter analyze
- fvm flutter test test/utils/android_admob_app_id_config_test.dart
- fvm flutter build apk --debug --flavor prod --dart-define=FLAVOR=production
- Verified prodDebug/prodRelease generated manifests do not contain READ_MEDIA_IMAGES, READ_MEDIA_VIDEO, READ_EXTERNAL_STORAGE, or WRITE_EXTERNAL_STORAGE
- Pre-commit hook passed analyze and unit/infrastructure tests
- Pre-push hook passed presentation/widget tests

## Note
- fvm flutter build appbundle --release --flavor prod --dart-define=FLAVOR=production reached prodRelease manifest generation, then failed at :app:signProdReleaseBundle with a NullPointerException during signing/finalization. The generated release manifests were still checked for the removed permissions.