### PR TITLE
feat: 友人招待の共有リンクを追加

### DIFF
--- a/lib/presentation/friend/friend_invite_share_content.dart
+++ b/lib/presentation/friend/friend_invite_share_content.dart
@@ -1,0 +1,34 @@
+import '../../config/app_config.dart';
+
+class FriendInviteShareContent {
+  const FriendInviteShareContent({
+    required this.url,
+    required this.message,
+  });
+
+  final Uri url;
+  final String message;
+
+  static FriendInviteShareContent create({
+    required String searchId,
+    required Environment environment,
+  }) {
+    final normalizedSearchId = searchId.trim();
+    if (normalizedSearchId.isEmpty) {
+      throw ArgumentError.value(searchId, 'searchId', '検索IDが空です');
+    }
+
+    final airbridgeAppName =
+        environment == Environment.production ? 'lakiite' : 'lakiitedev';
+    final url = Uri.https(
+      '$airbridgeAppName.airbridge.io',
+      '/friend/search',
+      {'searchId': normalizedSearchId},
+    );
+
+    return FriendInviteShareContent(
+      url: url,
+      message: 'LaKiiteで友人になりましょう。\n$url',
+    );
+  }
+}

--- a/lib/presentation/friend/friend_search_page.dart
+++ b/lib/presentation/friend/friend_search_page.dart
@@ -2,10 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gap/gap.dart';
 import 'package:qr_flutter/qr_flutter.dart';
+import 'package:share_plus/share_plus.dart';
 
 import '../../application/auth/auth_notifier.dart' as auth;
+import '../../config/app_config.dart';
 import '../widgets/notification_badge.dart';
 import '../notification/notification_list_page.dart';
+import 'friend_invite_share_content.dart';
 import 'friend_search_qr_scanner_page.dart';
 import 'friend_search_view_model.dart';
 
@@ -73,6 +76,25 @@ class _FriendSearchPageState extends ConsumerState<FriendSearchPage> {
           ],
         );
       },
+    );
+  }
+
+  Future<void> _shareFriendInvite(String searchId) async {
+    final content = FriendInviteShareContent.create(
+      searchId: searchId,
+      environment: AppConfig.instance.environment,
+    );
+    final renderBox = context.findRenderObject() as RenderBox?;
+    final sharePositionOrigin = renderBox == null
+        ? null
+        : renderBox.localToGlobal(Offset.zero) & renderBox.size;
+
+    await SharePlus.instance.share(
+      ShareParams(
+        text: content.message,
+        subject: 'LaKiiteに招待',
+        sharePositionOrigin: sharePositionOrigin,
+      ),
     );
   }
 
@@ -163,6 +185,17 @@ class _FriendSearchPageState extends ConsumerState<FriendSearchPage> {
                   ),
                 ),
               ],
+            ),
+            const Gap(12),
+            SizedBox(
+              width: double.infinity,
+              child: OutlinedButton.icon(
+                onPressed: currentSearchId == null
+                    ? null
+                    : () => _shareFriendInvite(currentSearchId),
+                icon: const Icon(Icons.ios_share),
+                label: const Text('友人を招待する'),
+              ),
             ),
             const Gap(20),
             if (state.isLoading)

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1311,6 +1311,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.6.4"
+  share_plus:
+    dependency: "direct main"
+    description:
+      name: share_plus
+      sha256: "223873d106614442ea6f20db5a038685cc5b32a2fba81cdecaefbbae0523f7fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "12.0.2"
+  share_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: share_plus_platform_interface
+      sha256: "88023e53a13429bd65d8e85e11a9b484f49d4c190abbd96c7932b74d6927cc9a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.0"
   shared_preferences:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -69,6 +69,7 @@ dependencies:
   gap: ^3.0.1
   cryptography: ^2.9.0
   flutter_secure_storage: ^10.3.1
+  share_plus: ^12.0.2
 
 dev_dependencies:
   flutter_test:

--- a/test/presentation/friend/friend_invite_share_content_test.dart
+++ b/test/presentation/friend/friend_invite_share_content_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lakiite/config/app_config.dart';
+import 'package:lakiite/presentation/friend/friend_invite_share_content.dart';
+
+void main() {
+  group('FriendInviteShareContent', () {
+    test('developmentではlakiitedevのAirbridge招待リンクを作る', () {
+      final content = FriendInviteShareContent.create(
+        searchId: 'Pj5I7M58',
+        environment: Environment.development,
+      );
+
+      expect(
+        content.url,
+        Uri.parse(
+          'https://lakiitedev.airbridge.io/friend/search?searchId=Pj5I7M58',
+        ),
+      );
+      expect(content.message, contains('LaKiite'));
+      expect(content.message, contains(content.url.toString()));
+    });
+
+    test('productionではlakiiteのAirbridge招待リンクを作る', () {
+      final content = FriendInviteShareContent.create(
+        searchId: 'Pj5I7M58',
+        environment: Environment.production,
+      );
+
+      expect(
+        content.url,
+        Uri.parse(
+          'https://lakiite.airbridge.io/friend/search?searchId=Pj5I7M58',
+        ),
+      );
+      expect(content.message, contains(content.url.toString()));
+    });
+
+    test('検索IDはtrimしてURL queryに入れる', () {
+      final content = FriendInviteShareContent.create(
+        searchId: ' Pj5I7M58 ',
+        environment: Environment.development,
+      );
+
+      expect(content.url.queryParameters['searchId'], 'Pj5I7M58');
+      expect(content.message, contains('Pj5I7M58'));
+    });
+  });
+}

--- a/test/presentation/friend/friend_search_page_test.dart
+++ b/test/presentation/friend/friend_search_page_test.dart
@@ -84,6 +84,35 @@ void main() {
       expect(find.text('@${currentUser.searchId}'), findsNothing);
     });
 
+    testWidgets('ログインユーザーの検索IDがある場合は友人招待ボタンを表示する', (tester) async {
+      final currentUser = UserModel.create(
+        id: 'current-user-id',
+        name: '現在ユーザー',
+        displayName: '現在ユーザー',
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            auth.authNotifierProvider.overrideWith(
+              () => _StubAuthNotifier(AuthState.authenticated(currentUser)),
+            ),
+            userRepositoryProvider.overrideWithValue(MockUserRepository()),
+            notificationRepositoryProvider.overrideWithValue(
+              MockNotificationRepository(),
+            ),
+            notification.unreadNotificationCountByTypeProvider.overrideWith(
+              (ref, domain.NotificationType type) => Stream.value(0),
+            ),
+          ],
+          child: const MaterialApp(home: FriendSearchPage()),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('友人を招待する'), findsOneWidget);
+    });
+
     testWidgets('フレンド追加済みユーザー検索では申請ボタンを無効化する', (tester) async {
       final friend = UserModel.create(
         id: 'friend-user-id',


### PR DESCRIPTION
## Summary
- 友達検索画面のQR導線下に「友人を招待する」ボタンを追加
- 自身の検索IDを含むAirbridge招待URLと招待文を共有シートへ渡す処理を追加
- dev/prod環境に応じて `lakiitedev.airbridge.io` / `lakiite.airbridge.io` を切り替える生成ロジックとテストを追加

## Context
Refs #294

PR #294で追加されたAirbridge Deep Link受け口に対して、今回はユーザーが自身の検索ID入りリンクをLINEなどに共有する送信側の導線を追加します。

## Test Plan
- `fvm flutter test test/presentation/friend/friend_invite_share_content_test.dart test/presentation/friend/friend_search_page_test.dart`
- `fvm flutter analyze`
- pre-commit: Dart format, Flutter analyze, unit/infrastructure tests
- pre-push: presentation/widget tests