### PR TITLE
fix: refresh schedule key backup status after save

### DIFF
--- a/lib/app/di/providers.dart
+++ b/lib/app/di/providers.dart
@@ -35,6 +35,12 @@ final scheduleEncryptionServiceProvider =
   return ScheduleEncryptionService();
 });
 
+final schedulePrivateKeyBackupExistsProvider =
+    FutureProvider.autoDispose.family<bool, String>((ref, uid) {
+  final encryptionService = ref.watch(scheduleEncryptionServiceProvider);
+  return encryptionService.hasPrivateKeyBackup(uid);
+});
+
 /// Firebase 認証状態の変化を監視し、repository のセッション境界を提供する。
 final repositorySessionKeyProvider = StreamProvider.autoDispose<String?>((ref) {
   final firebaseAuth = ref.watch(firebaseAuthProvider);

--- a/lib/presentation/settings/schedule_key_backup_page.dart
+++ b/lib/presentation/settings/schedule_key_backup_page.dart
@@ -22,8 +22,6 @@ class _ScheduleKeyBackupPageState extends ConsumerState<ScheduleKeyBackupPage> {
   bool _obscurePassword = true;
   bool _obscureConfirmPassword = true;
   bool _isSubmitting = false;
-  String? _backupStatusUserId;
-  Future<bool>? _backupStatusFuture;
 
   @override
   void dispose() {
@@ -58,6 +56,7 @@ class _ScheduleKeyBackupPageState extends ConsumerState<ScheduleKeyBackupPage> {
             uid: userId,
             password: password,
           );
+      ref.invalidate(schedulePrivateKeyBackupExistsProvider(userId));
       if (mounted) {
         Navigator.of(context).pop();
         ScaffoldMessenger.of(context).showSnackBar(
@@ -85,120 +84,100 @@ class _ScheduleKeyBackupPageState extends ConsumerState<ScheduleKeyBackupPage> {
     );
   }
 
-  Future<bool> _loadBackupStatus(String? userId) {
-    if (userId == null) {
-      _backupStatusUserId = null;
-      _backupStatusFuture = Future.value(false);
-      return _backupStatusFuture!;
-    }
-
-    if (_backupStatusFuture == null || _backupStatusUserId != userId) {
-      _backupStatusUserId = userId;
-      _backupStatusFuture =
-          ref.read(scheduleEncryptionServiceProvider).hasPrivateKeyBackup(
-                userId,
-              );
-    }
-    return _backupStatusFuture!;
-  }
-
   @override
   Widget build(BuildContext context) {
     final authState = ref.watch(authNotifierProvider).valueOrNull;
     final userId = authState?.status == AuthStatus.authenticated
         ? authState?.user?.id
         : null;
+    final backupStatus = userId == null
+        ? const AsyncValue<bool>.data(false)
+        : ref.watch(schedulePrivateKeyBackupExistsProvider(userId));
+    final hasBackup = backupStatus.valueOrNull ?? false;
+    final isLoading = backupStatus.isLoading;
+    final hasError = backupStatus.hasError;
+    final statusLabel = isLoading
+        ? '確認中'
+        : hasError
+            ? '確認できません'
+            : hasBackup
+                ? '設定済み'
+                : '未設定';
+    final description = hasBackup
+        ? 'このアカウントには端末引き継ぎ設定が保存されています。新しいパスワードで保存すると、別端末で復元するときに使うパスワードも新しいものに変わります。'
+        : '別の端末でも暗号化された予定を表示できるように、秘密キーを引き継ぎパスワードで暗号化して保存します。';
+    final passwordLabel = hasBackup ? '新しい引き継ぎパスワード' : '引き継ぎパスワード';
+    final buttonLabel = hasBackup ? '引き継ぎパスワードを更新' : '保存';
 
     return Scaffold(
       appBar: AppBar(
         title: const Text('端末引き継ぎ設定'),
       ),
-      body: FutureBuilder<bool>(
-        future: _loadBackupStatus(userId),
-        builder: (context, snapshot) {
-          final hasBackup = snapshot.data ?? false;
-          final isLoading = snapshot.connectionState != ConnectionState.done;
-          final statusLabel = isLoading
-              ? '確認中'
-              : hasBackup
-                  ? '設定済み'
-                  : '未設定';
-          final description = hasBackup
-              ? 'このアカウントには端末引き継ぎ設定が保存されています。新しいパスワードで保存すると、別端末で復元するときに使うパスワードも新しいものに変わります。'
-              : '別の端末でも暗号化された予定を表示できるように、秘密キーを引き継ぎパスワードで暗号化して保存します。';
-          final passwordLabel = hasBackup ? '新しい引き継ぎパスワード' : '引き継ぎパスワード';
-          final buttonLabel = hasBackup ? '引き継ぎパスワードを更新' : '保存';
-
-          return ListView(
-            padding: const EdgeInsets.all(24),
-            children: [
-              Text(
-                '状態: $statusLabel',
-                style: Theme.of(context).textTheme.titleMedium,
-              ),
-              const SizedBox(height: 8),
-              Text(description),
-              const SizedBox(height: 8),
-              const Text(
-                '復元パスワードはアプリ内で確認できません。別端末で復元するときに必要になるため、忘れないように保管してください。',
-              ),
-              const SizedBox(height: 24),
-              TextField(
-                controller: _passwordController,
-                obscureText: _obscurePassword,
-                decoration: InputDecoration(
-                  labelText: passwordLabel,
-                  border: const OutlineInputBorder(),
-                  suffixIcon: IconButton(
-                    tooltip:
-                        _obscurePassword ? '引き継ぎパスワードを表示' : '引き継ぎパスワードを非表示',
-                    icon: Icon(
-                      _obscurePassword
-                          ? Icons.visibility
-                          : Icons.visibility_off,
-                    ),
-                    onPressed: () {
-                      setState(() => _obscurePassword = !_obscurePassword);
-                    },
-                  ),
+      body: ListView(
+        padding: const EdgeInsets.all(24),
+        children: [
+          Text(
+            '状態: $statusLabel',
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          const SizedBox(height: 8),
+          Text(description),
+          const SizedBox(height: 8),
+          const Text(
+            '復元パスワードはアプリ内で確認できません。別端末で復元するときに必要になるため、忘れないように保管してください。',
+          ),
+          const SizedBox(height: 24),
+          TextField(
+            controller: _passwordController,
+            obscureText: _obscurePassword,
+            decoration: InputDecoration(
+              labelText: passwordLabel,
+              border: const OutlineInputBorder(),
+              suffixIcon: IconButton(
+                tooltip: _obscurePassword ? '引き継ぎパスワードを表示' : '引き継ぎパスワードを非表示',
+                icon: Icon(
+                  _obscurePassword ? Icons.visibility : Icons.visibility_off,
                 ),
+                onPressed: () {
+                  setState(() => _obscurePassword = !_obscurePassword);
+                },
               ),
-              const SizedBox(height: 16),
-              TextField(
-                controller: _confirmPasswordController,
-                obscureText: _obscureConfirmPassword,
-                decoration: InputDecoration(
-                  labelText: '確認用パスワード',
-                  border: const OutlineInputBorder(),
-                  suffixIcon: IconButton(
-                    tooltip: _obscureConfirmPassword
-                        ? '確認用パスワードを表示'
-                        : '確認用パスワードを非表示',
-                    icon: Icon(
-                      _obscureConfirmPassword
-                          ? Icons.visibility
-                          : Icons.visibility_off,
-                    ),
-                    onPressed: () {
-                      setState(() =>
-                          _obscureConfirmPassword = !_obscureConfirmPassword);
-                    },
-                  ),
+            ),
+          ),
+          const SizedBox(height: 16),
+          TextField(
+            controller: _confirmPasswordController,
+            obscureText: _obscureConfirmPassword,
+            decoration: InputDecoration(
+              labelText: '確認用パスワード',
+              border: const OutlineInputBorder(),
+              suffixIcon: IconButton(
+                tooltip:
+                    _obscureConfirmPassword ? '確認用パスワードを表示' : '確認用パスワードを非表示',
+                icon: Icon(
+                  _obscureConfirmPassword
+                      ? Icons.visibility
+                      : Icons.visibility_off,
                 ),
+                onPressed: () {
+                  setState(
+                    () => _obscureConfirmPassword = !_obscureConfirmPassword,
+                  );
+                },
               ),
-              const SizedBox(height: 24),
-              FilledButton(
-                onPressed: _isSubmitting ? null : _save,
-                child: _isSubmitting
-                    ? const SizedBox.square(
-                        dimension: 20,
-                        child: CircularProgressIndicator(strokeWidth: 2),
-                      )
-                    : Text(buttonLabel),
-              ),
-            ],
-          );
-        },
+            ),
+          ),
+          const SizedBox(height: 24),
+          FilledButton(
+            onPressed: _isSubmitting ? null : _save,
+            child: _isSubmitting
+                ? const SizedBox.square(
+                    dimension: 20,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : Text(buttonLabel),
+          ),
+        ],
       ),
     );
   }

--- a/lib/presentation/settings/settings_page.dart
+++ b/lib/presentation/settings/settings_page.dart
@@ -340,20 +340,15 @@ class _ScheduleKeyBackupSubtitle extends ConsumerWidget {
       return const Text('ログイン後に設定できます');
     }
 
-    final encryptionService = ref.watch(scheduleEncryptionServiceProvider);
-    return FutureBuilder<bool>(
-      future: encryptionService.hasPrivateKeyBackup(uid),
-      builder: (context, snapshot) {
-        if (snapshot.connectionState != ConnectionState.done) {
-          return const Text('暗号化された予定を別端末で復元・確認中...');
-        }
-        if (snapshot.hasError) {
-          return const Text('暗号化された予定を別端末で復元・設定状態を確認できません');
-        }
+    final backupStatus = ref.watch(schedulePrivateKeyBackupExistsProvider(uid));
+    if (backupStatus.isLoading) {
+      return const Text('暗号化された予定を別端末で復元・確認中...');
+    }
+    if (backupStatus.hasError) {
+      return const Text('暗号化された予定を別端末で復元・設定状態を確認できません');
+    }
 
-        final label = snapshot.data == true ? '設定済み' : '未設定';
-        return Text('暗号化された予定を別端末で復元・$label');
-      },
-    );
+    final label = backupStatus.valueOrNull == true ? '設定済み' : '未設定';
+    return Text('暗号化された予定を別端末で復元・$label');
   }
 }

--- a/test/presentation/settings/schedule_key_backup_page_test.dart
+++ b/test/presentation/settings/schedule_key_backup_page_test.dart
@@ -27,6 +27,44 @@ void main() {
     );
   }
 
+  Widget buildRefreshTestTarget(_StubScheduleEncryptionService service) {
+    final user = BaseMock.createTestUser();
+    return ProviderScope(
+      overrides: [
+        authNotifierProvider.overrideWith(
+          () => _StubAuthNotifier(AuthState.authenticated(user)),
+        ),
+        scheduleEncryptionServiceProvider.overrideWithValue(service),
+      ],
+      child: MaterialApp(
+        home: Consumer(
+          builder: (context, ref, _) {
+            final backupStatus = ref.watch(
+              schedulePrivateKeyBackupExistsProvider(user.id),
+            );
+            return Scaffold(
+              body: Column(
+                children: [
+                  Text('parent: ${backupStatus.valueOrNull == true}'),
+                  FilledButton(
+                    onPressed: () {
+                      Navigator.of(context).push(
+                        MaterialPageRoute<void>(
+                          builder: (_) => const ScheduleKeyBackupPage(),
+                        ),
+                      );
+                    },
+                    child: const Text('open'),
+                  ),
+                ],
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
   testWidgets('引き継ぎパスワードと確認用パスワードの表示切替は独立している', (tester) async {
     await tester.pumpWidget(buildTestTarget());
 
@@ -70,6 +108,23 @@ void main() {
     expect(find.text('引き継ぎパスワード'), findsOneWidget);
     expect(find.text('保存'), findsOneWidget);
   });
+
+  testWidgets('保存後に引き継ぎ設定状態を再取得する', (tester) async {
+    final service = _StubScheduleEncryptionService(hasBackup: false);
+    await tester.pumpWidget(buildRefreshTestTarget(service));
+    await tester.pump();
+
+    expect(find.text('parent: false'), findsOneWidget);
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byType(TextField).at(0), 'new-password');
+    await tester.enterText(find.byType(TextField).at(1), 'new-password');
+    await tester.tap(find.text('保存'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('parent: true'), findsOneWidget);
+  });
 }
 
 class _StubAuthNotifier extends AuthNotifier {
@@ -84,10 +139,18 @@ class _StubAuthNotifier extends AuthNotifier {
 class _StubScheduleEncryptionService extends ScheduleEncryptionService {
   _StubScheduleEncryptionService({required this.hasBackup});
 
-  final bool hasBackup;
+  bool hasBackup;
 
   @override
   Future<bool> hasPrivateKeyBackup(String uid) async {
     return hasBackup;
+  }
+
+  @override
+  Future<void> createPrivateKeyBackup({
+    required String uid,
+    required String password,
+  }) async {
+    hasBackup = true;
   }
 }

--- a/test/presentation/settings/settings_page_test.dart
+++ b/test/presentation/settings/settings_page_test.dart
@@ -17,7 +17,7 @@ void main() {
 
     expect(source, contains('設定済み'));
     expect(source, contains('未設定'));
-    expect(source, contains('hasPrivateKeyBackup'));
+    expect(source, contains('schedulePrivateKeyBackupExistsProvider'));
   });
 
   test('端末引き継ぎの案内文に未実装予定の文言を残さない', () {


### PR DESCRIPTION
## Summary
- Added a shared Riverpod provider for the schedule private key backup status.
- Updated the settings list and handoff setup page to read the same status source.
- Invalidated the status provider after saving a handoff password so the UI refreshes from `未設定` to `設定済み`.

## Root Cause
The handoff setup state was read through one-shot futures. After saving the encrypted private key backup, the app did not invalidate or reload that status, so the UI could continue showing the stale `未設定` state even after the save completed.

## Firestore Rules
The latest `dev` branch already includes rules for `users/{uid}/encryption/current`. I deployed dev rules to `lakiite-flutter-app-dev`; Firebase reported the latest Firestore rules were already up to date and released successfully.

## Test Plan
- `fvm flutter test test/presentation/settings/schedule_key_backup_page_test.dart test/presentation/settings/settings_page_test.dart`
- `fvm flutter analyze`
- `firebase emulators:exec --only firestore --project demo-test "npm test -- --runInBand tests/users.test.js"`
- pre-push presentation/widget tests: 155 passed
