### PR TITLE
style: 友人検索画面の招待導線を拡大

### DIFF
--- a/lib/presentation/friend/friend_search_page.dart
+++ b/lib/presentation/friend/friend_search_page.dart
@@ -133,6 +133,18 @@ class _FriendSearchPageState extends ConsumerState<FriendSearchPage> {
     final currentUser = ref.watch(auth.authNotifierProvider).value?.user;
     final currentSearchId = currentUser?.searchId.toString();
     final currentDisplayName = currentUser?.displayName;
+    final qrButtonStyle = OutlinedButton.styleFrom(
+      minimumSize: const Size.fromHeight(54),
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+      textStyle: Theme.of(context).textTheme.titleSmall,
+      iconSize: 24,
+    );
+    final inviteButtonStyle = OutlinedButton.styleFrom(
+      minimumSize: const Size.fromHeight(58),
+      padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 16),
+      textStyle: Theme.of(context).textTheme.titleSmall,
+      iconSize: 24,
+    );
 
     return Scaffold(
       appBar: AppBar(
@@ -158,8 +170,10 @@ class _FriendSearchPageState extends ConsumerState<FriendSearchPage> {
           children: [
             TextField(
               controller: searchController,
+              style: Theme.of(context).textTheme.bodyLarge,
               decoration: InputDecoration(
                 labelText: '検索IDを入力',
+                labelStyle: Theme.of(context).textTheme.bodyLarge,
                 suffixIcon: IconButton(
                   icon: const Icon(Icons.search),
                   onPressed: () {
@@ -174,6 +188,7 @@ class _FriendSearchPageState extends ConsumerState<FriendSearchPage> {
               children: [
                 Expanded(
                   child: OutlinedButton.icon(
+                    style: qrButtonStyle,
                     onPressed: currentSearchId == null
                         ? null
                         : () => _showSearchIdQr(currentSearchId),
@@ -184,6 +199,7 @@ class _FriendSearchPageState extends ConsumerState<FriendSearchPage> {
                 const Gap(12),
                 Expanded(
                   child: OutlinedButton.icon(
+                    style: qrButtonStyle,
                     onPressed: () => _openQrScanner(viewModel),
                     icon: const Icon(Icons.qr_code_scanner),
                     label: const Text('QRを読み取る'),
@@ -195,6 +211,7 @@ class _FriendSearchPageState extends ConsumerState<FriendSearchPage> {
             SizedBox(
               width: double.infinity,
               child: OutlinedButton.icon(
+                style: inviteButtonStyle,
                 onPressed: currentSearchId == null
                     ? null
                     : () => _shareFriendInvite(
@@ -208,8 +225,9 @@ class _FriendSearchPageState extends ConsumerState<FriendSearchPage> {
             const Gap(8),
             Text(
               'アプリをまだ使っていない人にも、すでに使っている人にも、フレンド追加の招待を送れます。',
-              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                     color: Colors.grey[700],
+                    height: 1.45,
                   ),
             ),
             const Gap(20),


### PR DESCRIPTION
## Summary
- 友人検索画面の検索入力テキストを少し大きく調整
- QR関連ボタンと「友人をアプリに招待する」ボタンの高さ・文字・アイコンサイズを拡大
- 招待ボタン下の説明文を bodyMedium に上げ、読みやすい行間に調整

## Test Plan
- fvm dart format lib/presentation/friend/friend_search_page.dart
- fvm flutter test test/presentation/friend/friend_search_page_test.dart
- fvm flutter analyze
- git diff --check
- pre-commit: Dart format / Flutter analyze
- pre-push: presentation/widget tests