### PR TITLE
fix: Airbridge invite custom domains

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -131,7 +131,7 @@ android {
                     airbridgeUrlScheme: "lakiitedev",
                     airbridgePrimaryHost: "lakiitedev.airbridge.io",
                     airbridgeShortHost: "lakiitedev.abr.ge",
-                    airbridgeCustomHost: "lakiite-dev.inoworl.com"
+                    airbridgeCustomHost: "invite.lakiite-dev.inoworl.com"
             ]
             versionNameSuffix "-dev"
         }
@@ -146,7 +146,7 @@ android {
                     airbridgeUrlScheme: "lakiite",
                     airbridgePrimaryHost: "lakiite.airbridge.io",
                     airbridgeShortHost: "lakiite.abr.ge",
-                    airbridgeCustomHost: "lakiite.inoworl.com"
+                    airbridgeCustomHost: "invite.lakiite.inoworl.com"
             ]
         }
     }

--- a/android/app/src/dev/assets/airbridge.json
+++ b/android/app/src/dev/assets/airbridge.json
@@ -1,6 +1,6 @@
 {
   "autoDetermineTrackingAuthorizationTimeoutInSecond": 0,
   "trackingLinkCustomDomains": [
-    "lakiite-dev.inoworl.com"
+    "invite.lakiite-dev.inoworl.com"
   ]
 }

--- a/android/app/src/prod/assets/airbridge.json
+++ b/android/app/src/prod/assets/airbridge.json
@@ -1,6 +1,6 @@
 {
   "autoDetermineTrackingAuthorizationTimeoutInSecond": 0,
   "trackingLinkCustomDomains": [
-    "lakiite.inoworl.com"
+    "invite.lakiite.inoworl.com"
   ]
 }

--- a/ios/Runner/Runner-Dev.entitlements
+++ b/ios/Runner/Runner-Dev.entitlements
@@ -6,7 +6,7 @@
 	<array>
 		<string>applinks:lakiitedev.airbridge.io</string>
 		<string>applinks:lakiitedev.abr.ge</string>
-		<string>applinks:lakiite-dev.inoworl.com</string>
+		<string>applinks:invite.lakiite-dev.inoworl.com</string>
 	</array>
 	<key>aps-environment</key>
 	<string>development</string>

--- a/ios/Runner/Runner-Prod-Debug.entitlements
+++ b/ios/Runner/Runner-Prod-Debug.entitlements
@@ -6,7 +6,7 @@
 	<array>
 		<string>applinks:lakiite.airbridge.io</string>
 		<string>applinks:lakiite.abr.ge</string>
-		<string>applinks:lakiite.inoworl.com</string>
+		<string>applinks:invite.lakiite.inoworl.com</string>
 	</array>
 	<key>aps-environment</key>
 	<string>development</string>

--- a/ios/Runner/Runner.entitlements
+++ b/ios/Runner/Runner.entitlements
@@ -6,7 +6,7 @@
 	<array>
 		<string>applinks:lakiite.airbridge.io</string>
 		<string>applinks:lakiite.abr.ge</string>
-		<string>applinks:lakiite.inoworl.com</string>
+		<string>applinks:invite.lakiite.inoworl.com</string>
 	</array>
 	<key>aps-environment</key>
 	<string>production</string>

--- a/lib/domain/deep_link/friend_invite_deep_link.dart
+++ b/lib/domain/deep_link/friend_invite_deep_link.dart
@@ -7,8 +7,8 @@ class FriendInviteDeepLink {
     'lakiite.abr.ge',
     'lakiitedev.airbridge.io',
     'lakiitedev.abr.ge',
-    'lakiite.inoworl.com',
-    'lakiite-dev.inoworl.com',
+    'invite.lakiite.inoworl.com',
+    'invite.lakiite-dev.inoworl.com',
   };
   static const Set<String> _nestedDeepLinkKeys = {
     'airbridge_deeplink',
@@ -102,8 +102,8 @@ class FriendInviteDeepLink {
       final path = candidate.startsWith('/') ? candidate : '/$candidate';
       yield 'https://lakiitedev.airbridge.io$path';
       yield 'https://lakiite.airbridge.io$path';
-      yield 'https://lakiite-dev.inoworl.com$path';
-      yield 'https://lakiite.inoworl.com$path';
+      yield 'https://invite.lakiite-dev.inoworl.com$path';
+      yield 'https://invite.lakiite.inoworl.com$path';
     }
   }
 

--- a/test/domain/deep_link/friend_invite_deep_link_test.dart
+++ b/test/domain/deep_link/friend_invite_deep_link_test.dart
@@ -61,7 +61,7 @@ void main() {
 
     test('Airbridge custom domainのURLから検索IDを抽出する', () {
       final deepLink = FriendInviteDeepLink.tryParse(
-        'https://lakiite-dev.inoworl.com/friend/search?searchId=Pj5I7M58',
+        'https://invite.lakiite-dev.inoworl.com/friend/search?searchId=Pj5I7M58',
       );
 
       expect(deepLink?.searchId, 'Pj5I7M58');
@@ -87,7 +87,7 @@ void main() {
 
     test('Airbridge custom domainのnested path deep linkから検索IDを抽出する', () {
       final deepLink = FriendInviteDeepLink.tryParse(
-        'https://lakiite-dev.inoworl.com/friend_xfrhk82o08rg1555q'
+        'https://invite.lakiite-dev.inoworl.com/friend_xfrhk82o08rg1555q'
         '?deep_link=%2Ffriend%2Fsearch%3FsearchId%3DPj5I7M58',
       );
 
@@ -95,7 +95,8 @@ void main() {
     });
 
     test('Airbridge custom domainの短縮リンク本体はSDK解決待ちリンクとして判定する', () {
-      const link = 'https://lakiite-dev.inoworl.com/friend_e3oe2ol2ohordcvbm';
+      const link =
+          'https://invite.lakiite-dev.inoworl.com/friend_e3oe2ol2ohordcvbm';
 
       expect(FriendInviteDeepLink.tryParse(link), isNull);
       expect(FriendInviteDeepLink.isSupportedAirbridgeLink(link), isTrue);


### PR DESCRIPTION
## Summary
- Switch Airbridge custom domains to invite.lakiite.inoworl.com / invite.lakiite-dev.inoworl.com
- Update iOS associated domains and Android Airbridge custom host settings
- Update friend invite deep link parsing/tests for invite custom domains

## Verification
- fvm flutter test test/domain/deep_link/friend_invite_deep_link_test.dart
- pre-commit: Flutter analyze and unit/infrastructure tests passed
- pre-push: presentation/widget tests passed

## Console / DNS notes
- ConoHa DNS added CNAME invite.lakiite -> lakiite-n1bx.custom-domain.airbridge.io
- ConoHa DNS added CNAME invite.lakiite-dev -> lakiitedev-y9it.custom-domain.airbridge.io
- Airbridge custom domains are created, but status is still Pending until DNS propagation is fully visible to Airbridge.
- Keep old lakiite.inoworl.com / lakiite-dev.inoworl.com Airbridge domains until invite.* becomes Available and display domain is switched.
