### PR TITLE
[codex] 友達QRを招待リンク化しsearchId予約に対応

### DIFF
--- a/lib/infrastructure/user_repository.dart
+++ b/lib/infrastructure/user_repository.dart
@@ -40,6 +40,24 @@ class UserRepository implements IUserRepository {
     return json;
   }
 
+  DocumentReference<Map<String, dynamic>> _searchIdReservationRef(
+    UserId searchId,
+  ) {
+    return _firestore.collection('reservedSearchIds').doc(searchId.value);
+  }
+
+  Map<String, dynamic> _toSearchIdReservation({
+    required String ownerUid,
+    required UserId searchId,
+  }) {
+    return {
+      'ownerUid': ownerUid,
+      'searchId': searchId.value,
+      'source': 'client',
+      'reservedAt': FieldValue.serverTimestamp(),
+    };
+  }
+
   @override
   Future<UserModel?> getUser(String id) async {
     try {
@@ -112,6 +130,7 @@ class UserRepository implements IUserRepository {
       // ドキュメントの参照を取得
       final userRef = _firestore.collection('users').doc(user.id);
       final privateRef = userRef.collection('private').doc('profile');
+      final searchIdReservationRef = _searchIdReservationRef(user.searchId);
 
       // トランザクションでユーザーデータを作成
       await _firestore.runTransaction((transaction) async {
@@ -120,6 +139,19 @@ class UserRepository implements IUserRepository {
         if (docSnapshot.exists) {
           throw Exception('ユーザーデータが既に存在します');
         }
+        final reservationSnapshot =
+            await transaction.get(searchIdReservationRef);
+        if (reservationSnapshot.exists) {
+          throw Exception('このsearchIdは既に使用されています');
+        }
+
+        transaction.set(
+          searchIdReservationRef,
+          _toSearchIdReservation(
+            ownerUid: user.id,
+            searchId: user.searchId,
+          ),
+        );
 
         // 公開情報を親ドキュメントに保存
         transaction.set(userRef, _toFirestorePublic(user.publicProfile));
@@ -146,6 +178,29 @@ class UserRepository implements IUserRepository {
       final privateRef = userRef.collection('private').doc('profile');
 
       await _firestore.runTransaction((transaction) async {
+        final currentUserSnapshot = await transaction.get(userRef);
+        if (!currentUserSnapshot.exists) {
+          throw Exception('ユーザーが見つかりません');
+        }
+
+        final currentSearchId =
+            currentUserSnapshot.data()?['searchId'] as String?;
+        if (currentSearchId != user.searchId.value) {
+          final searchIdReservationRef = _searchIdReservationRef(user.searchId);
+          final reservationSnapshot =
+              await transaction.get(searchIdReservationRef);
+          if (reservationSnapshot.exists) {
+            throw Exception('このsearchIdは既に使用されています');
+          }
+          transaction.set(
+            searchIdReservationRef,
+            _toSearchIdReservation(
+              ownerUid: user.id,
+              searchId: user.searchId,
+            ),
+          );
+        }
+
         // 公開情報を更新
         transaction.update(userRef, _toFirestorePublic(user.publicProfile));
 
@@ -239,11 +294,17 @@ class UserRepository implements IUserRepository {
 
   @override
   Future<bool> isUserIdUnique(UserId userId) async {
-    final snapshot = await _firestore
+    final reservationSnapshot = await _searchIdReservationRef(userId).get();
+    if (reservationSnapshot.exists) {
+      return false;
+    }
+
+    final userSnapshot = await _firestore
         .collection('users')
         .where('searchId', isEqualTo: userId.value)
+        .limit(1)
         .get();
-    return snapshot.docs.isEmpty;
+    return userSnapshot.docs.isEmpty;
   }
 
   @override

--- a/lib/presentation/friend/friend_search_page.dart
+++ b/lib/presentation/friend/friend_search_page.dart
@@ -111,17 +111,40 @@ class _FriendSearchPageState extends ConsumerState<FriendSearchPage> {
             children: [
               SizedBox.square(
                 dimension: qrSize,
-                child: QrImageView(
-                  data: inviteUrl.toString(),
-                  version: QrVersions.auto,
-                  backgroundColor: Colors.white,
+                child: Stack(
+                  alignment: Alignment.center,
+                  children: [
+                    QrImageView(
+                      data: inviteUrl.toString(),
+                      version: QrVersions.auto,
+                      errorCorrectionLevel: QrErrorCorrectLevel.H,
+                      backgroundColor: Colors.white,
+                    ),
+                    Container(
+                      key: const ValueKey('friend-search-qr-center-icon'),
+                      width: qrSize * 0.22,
+                      height: qrSize * 0.22,
+                      padding: EdgeInsets.all(qrSize * 0.025),
+                      decoration: BoxDecoration(
+                        color: Colors.white,
+                        borderRadius: BorderRadius.circular(qrSize * 0.045),
+                      ),
+                      child: ClipRRect(
+                        borderRadius: BorderRadius.circular(qrSize * 0.03),
+                        child: Image.asset(
+                          'assets/icon/icon.png',
+                          fit: BoxFit.cover,
+                        ),
+                      ),
+                    ),
+                  ],
                 ),
               ),
               const Gap(12),
-              SelectableText(
-                inviteUrl.toString(),
+              Text(
+                'QRコードを友達に読み込んでもらうと、フレンド追加できます',
                 textAlign: TextAlign.center,
-                style: Theme.of(context).textTheme.bodySmall,
+                style: Theme.of(context).textTheme.bodyMedium,
               ),
             ],
           ),

--- a/lib/presentation/friend/friend_search_page.dart
+++ b/lib/presentation/friend/friend_search_page.dart
@@ -67,7 +67,33 @@ class _FriendSearchPageState extends ConsumerState<FriendSearchPage> {
     );
   }
 
-  Future<void> _showSearchIdQr(String searchId) async {
+  Future<void> _showSearchIdQr() async {
+    Uri inviteUrl;
+    try {
+      inviteUrl =
+          await ref.read(friendInviteLinkServiceProvider).createInviteLink();
+    } on FriendInviteLinkException catch (error) {
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(error.message)),
+      );
+      return;
+    } catch (_) {
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('招待リンクの生成に失敗しました')),
+      );
+      return;
+    }
+
+    if (!mounted) {
+      return;
+    }
+
     await showDialog<void>(
       context: context,
       builder: (context) {
@@ -75,17 +101,29 @@ class _FriendSearchPageState extends ConsumerState<FriendSearchPage> {
         final qrSize = [
           280.0,
           screenSize.width - 96.0,
-          screenSize.height - 192.0,
+          screenSize.height - 240.0,
         ].reduce((value, element) => value < element ? value : element);
 
         return AlertDialog(
-          content: SizedBox.square(
-            dimension: qrSize,
-            child: QrImageView(
-              data: searchId,
-              version: QrVersions.auto,
-              backgroundColor: Colors.white,
-            ),
+          title: const Text('友達追加QR'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              SizedBox.square(
+                dimension: qrSize,
+                child: QrImageView(
+                  data: inviteUrl.toString(),
+                  version: QrVersions.auto,
+                  backgroundColor: Colors.white,
+                ),
+              ),
+              const Gap(12),
+              SelectableText(
+                inviteUrl.toString(),
+                textAlign: TextAlign.center,
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+            ],
           ),
           actions: [
             TextButton(
@@ -274,7 +312,7 @@ class _FriendSearchPageState extends ConsumerState<FriendSearchPage> {
                     style: qrButtonStyle,
                     onPressed: currentSearchId == null
                         ? null
-                        : () => _showSearchIdQr(currentSearchId),
+                        : () => _showSearchIdQr(),
                     icon: const Icon(Icons.qr_code),
                     label: const Text('自分のQR'),
                   ),

--- a/lib/presentation/friend/friend_search_qr_scanner_page.dart
+++ b/lib/presentation/friend/friend_search_qr_scanner_page.dart
@@ -1,6 +1,55 @@
 import 'package:flutter/material.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
 
+String? extractFriendSearchIdFromQrValue(String rawValue) {
+  final trimmedValue = rawValue.trim();
+  if (trimmedValue.isEmpty) {
+    return null;
+  }
+
+  final directSearchId = _validFriendSearchId(trimmedValue);
+  if (directSearchId != null) {
+    return directSearchId;
+  }
+
+  final uri = Uri.tryParse(trimmedValue);
+  if (uri == null) {
+    return null;
+  }
+
+  final querySearchId = _validFriendSearchId(uri.queryParameters['searchId']);
+  if (querySearchId != null) {
+    return querySearchId;
+  }
+
+  for (final nestedKey in const ['deep_link', 'deeplink_url']) {
+    final nestedValue = uri.queryParameters[nestedKey];
+    if (nestedValue == null || nestedValue.trim().isEmpty) {
+      continue;
+    }
+
+    final nestedSearchId = extractFriendSearchIdFromQrValue(nestedValue);
+    if (nestedSearchId != null) {
+      return nestedSearchId;
+    }
+  }
+
+  return null;
+}
+
+String? _validFriendSearchId(String? searchId) {
+  if (searchId == null) {
+    return null;
+  }
+
+  final trimmedSearchId = searchId.trim();
+  if (!RegExp(r'^[a-zA-Z0-9]{8}$').hasMatch(trimmedSearchId)) {
+    return null;
+  }
+
+  return trimmedSearchId;
+}
+
 class FriendSearchQrScannerPage extends StatefulWidget {
   const FriendSearchQrScannerPage({super.key});
 
@@ -49,18 +98,7 @@ class _FriendSearchQrScannerPageState extends State<FriendSearchQrScannerPage> {
   }
 
   String? _extractSearchId(String rawValue) {
-    final trimmedValue = rawValue.trim();
-    final uri = Uri.tryParse(trimmedValue);
-    final querySearchId = uri?.queryParameters['searchId'];
-    final searchId = querySearchId?.trim().isNotEmpty == true
-        ? querySearchId!.trim()
-        : trimmedValue;
-
-    if (!RegExp(r'^[a-zA-Z0-9]{8}$').hasMatch(searchId)) {
-      return null;
-    }
-
-    return searchId;
+    return extractFriendSearchIdFromQrValue(rawValue);
   }
 
   void _showInvalidQrMessage() {

--- a/mock/repositories/mock_user_repository.dart
+++ b/mock/repositories/mock_user_repository.dart
@@ -6,6 +6,7 @@ import 'package:lakiite/domain/value/user_id.dart';
 class MockUserRepository implements IUserRepository {
   final Map<String, UserModel> _users = {};
   final Map<String, String> _searchIdToId = {};
+  final Set<String> _reservedSearchIds = {};
   bool _shouldFailGet = false;
   bool _shouldFailCreate = false;
   bool _shouldFailUpdate = false;
@@ -30,11 +31,13 @@ class MockUserRepository implements IUserRepository {
   void addTestUser(UserModel user) {
     _users[user.id] = user;
     _searchIdToId[user.searchId.toString()] = user.id;
+    _reservedSearchIds.add(user.searchId.toString());
   }
 
   void clearUsers() {
     _users.clear();
     _searchIdToId.clear();
+    _reservedSearchIds.clear();
   }
 
   @override
@@ -67,9 +70,13 @@ class MockUserRepository implements IUserRepository {
     if (_shouldFailCreate) {
       throw Exception('ユーザー作成に失敗しました');
     }
+    if (_reservedSearchIds.contains(user.searchId.toString())) {
+      throw Exception('このsearchIdは既に使用されています');
+    }
 
     _users[user.id] = user;
     _searchIdToId[user.searchId.toString()] = user.id;
+    _reservedSearchIds.add(user.searchId.toString());
   }
 
   @override
@@ -79,9 +86,20 @@ class MockUserRepository implements IUserRepository {
     if (_shouldFailUpdate) {
       throw Exception('ユーザー更新に失敗しました');
     }
+    final currentUser = _users[user.id];
+    final currentSearchId = currentUser?.searchId.toString();
+    final nextSearchId = user.searchId.toString();
+    if (currentSearchId != nextSearchId &&
+        _reservedSearchIds.contains(nextSearchId)) {
+      throw Exception('このsearchIdは既に使用されています');
+    }
 
+    if (currentSearchId != null && currentSearchId != nextSearchId) {
+      _searchIdToId.remove(currentSearchId);
+    }
     _users[user.id] = user;
-    _searchIdToId[user.searchId.toString()] = user.id;
+    _searchIdToId[nextSearchId] = user.id;
+    _reservedSearchIds.add(nextSearchId);
   }
 
   @override
@@ -114,7 +132,7 @@ class MockUserRepository implements IUserRepository {
   @override
   Future<bool> isUserIdUnique(UserId userId) async {
     await Future.delayed(const Duration(milliseconds: 100));
-    return !_searchIdToId.containsKey(userId.toString());
+    return !_reservedSearchIds.contains(userId.toString());
   }
 
   @override

--- a/test/mock/repository/mock_user_repository.dart
+++ b/test/mock/repository/mock_user_repository.dart
@@ -6,6 +6,7 @@ import '../base_mock.dart';
 
 class MockUserRepository extends BaseMock implements IUserRepository {
   final Map<String, UserModel> _users = {};
+  final Set<String> _reservedSearchIds = {};
   final List<String> _friendConnections = [];
   bool _shouldFailGet = false;
   bool _shouldFailCreate = false;
@@ -35,6 +36,7 @@ class MockUserRepository extends BaseMock implements IUserRepository {
 
   void addTestUser(UserModel user) {
     _users[user.id] = user;
+    _reservedSearchIds.add(user.searchId.toString());
   }
 
   void addFriendConnection(String userId1, String userId2) {
@@ -46,6 +48,7 @@ class MockUserRepository extends BaseMock implements IUserRepository {
 
   void clearUsers() {
     _users.clear();
+    _reservedSearchIds.clear();
     _friendConnections.clear();
   }
 
@@ -83,8 +86,12 @@ class MockUserRepository extends BaseMock implements IUserRepository {
     if (_users.containsKey(user.id)) {
       throw Exception('ユーザーは既に存在します');
     }
+    if (_reservedSearchIds.contains(user.searchId.toString())) {
+      throw Exception('このsearchIdは既に使用されています');
+    }
 
     _users[user.id] = user;
+    _reservedSearchIds.add(user.searchId.toString());
   }
 
   @override
@@ -98,8 +105,16 @@ class MockUserRepository extends BaseMock implements IUserRepository {
     if (!_users.containsKey(user.id)) {
       throw Exception('ユーザーが見つかりません');
     }
+    final currentUser = _users[user.id];
+    final currentSearchId = currentUser?.searchId.toString();
+    final nextSearchId = user.searchId.toString();
+    if (currentSearchId != nextSearchId &&
+        _reservedSearchIds.contains(nextSearchId)) {
+      throw Exception('このsearchIdは既に使用されています');
+    }
 
     _users[user.id] = user;
+    _reservedSearchIds.add(nextSearchId);
   }
 
   @override
@@ -145,7 +160,7 @@ class MockUserRepository extends BaseMock implements IUserRepository {
   Future<bool> isUserIdUnique(UserId userId) async {
     await Future.delayed(const Duration(milliseconds: 150));
 
-    return !_users.values.any((user) => user.searchId == userId);
+    return !_reservedSearchIds.contains(userId.toString());
   }
 
   @override

--- a/test/presentation/friend/friend_search_page_test.dart
+++ b/test/presentation/friend/friend_search_page_test.dart
@@ -65,7 +65,7 @@ void main() {
       );
     }
 
-    testWidgets('自分のQRには招待リンクURLを表示する', (tester) async {
+    testWidgets('自分のQRには案内文と中央アイコンを表示しURLは表示しない', (tester) async {
       tester.view.physicalSize = const Size(390, 640);
       tester.view.devicePixelRatio = 1;
       addTearDown(() {
@@ -110,7 +110,13 @@ void main() {
       await tester.tap(find.text('自分のQR'));
       await tester.pumpAndSettle();
 
-      expect(find.text(inviteLink.toString()), findsOneWidget);
+      expect(
+        find.text('QRコードを友達に読み込んでもらうと、フレンド追加できます'),
+        findsOneWidget,
+      );
+      expect(find.byKey(const ValueKey('friend-search-qr-center-icon')),
+          findsOneWidget);
+      expect(find.text(inviteLink.toString()), findsNothing);
       expect(find.text('@${currentUser.searchId}'), findsNothing);
     });
 

--- a/test/presentation/friend/friend_search_page_test.dart
+++ b/test/presentation/friend/friend_search_page_test.dart
@@ -10,6 +10,8 @@ import 'package:lakiite/application/notification/notification_notifier.dart'
     as notification;
 import 'package:lakiite/domain/entity/notification.dart' as domain;
 import 'package:lakiite/domain/entity/user.dart';
+import 'package:lakiite/domain/interfaces/i_friend_invite_link_service.dart';
+import 'package:lakiite/infrastructure/providers.dart' as infrastructure;
 import 'package:lakiite/presentation/friend/friend_search_page.dart';
 
 import '../../mock/repository/mock_notification_repository.dart';
@@ -37,6 +39,15 @@ class _MutableAuthNotifier extends auth.AuthNotifier {
   }
 }
 
+class _StubFriendInviteLinkService implements IFriendInviteLinkService {
+  _StubFriendInviteLinkService(this.inviteLink);
+
+  final Uri inviteLink;
+
+  @override
+  Future<Uri> createInviteLink() async => inviteLink;
+}
+
 void main() {
   group('FriendSearchPage', () {
     UserModel userWithFriends(UserModel user, List<String> friendIds) {
@@ -54,7 +65,7 @@ void main() {
       );
     }
 
-    testWidgets('自分の検索ID QR表示とQR読み取りボタンを表示する', (tester) async {
+    testWidgets('自分のQRには招待リンクURLを表示する', (tester) async {
       tester.view.physicalSize = const Size(390, 640);
       tester.view.devicePixelRatio = 1;
       addTearDown(() {
@@ -66,6 +77,9 @@ void main() {
         id: 'current-user-id',
         name: '現在ユーザー',
         displayName: '現在ユーザー',
+      );
+      final inviteLink = Uri.parse(
+        'https://lakiite-dev.inoworl.com/friend_cached',
       );
 
       await tester.pumpWidget(
@@ -81,6 +95,9 @@ void main() {
             notification.unreadNotificationCountByTypeProvider.overrideWith(
               (ref, domain.NotificationType type) => Stream.value(0),
             ),
+            infrastructure.friendInviteLinkServiceProvider.overrideWithValue(
+              _StubFriendInviteLinkService(inviteLink),
+            ),
           ],
           child: const MaterialApp(home: FriendSearchPage()),
         ),
@@ -93,7 +110,7 @@ void main() {
       await tester.tap(find.text('自分のQR'));
       await tester.pumpAndSettle();
 
-      expect(find.text('自分の検索ID'), findsNothing);
+      expect(find.text(inviteLink.toString()), findsOneWidget);
       expect(find.text('@${currentUser.searchId}'), findsNothing);
     });
 

--- a/test/presentation/friend/friend_search_qr_scanner_page_test.dart
+++ b/test/presentation/friend/friend_search_qr_scanner_page_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lakiite/presentation/friend/friend_search_qr_scanner_page.dart';
+
+void main() {
+  group('extractFriendSearchIdFromQrValue', () {
+    test('Airbridge招待リンクURLから検索IDを抽出する', () {
+      final searchId = extractFriendSearchIdFromQrValue(
+        'https://lakiite-dev.inoworl.com/friend_cached?searchId=Pj5I7M58',
+      );
+
+      expect(searchId, 'Pj5I7M58');
+    });
+
+    test('nested deep linkを含むAirbridge招待リンクURLから検索IDを抽出する', () {
+      final searchId = extractFriendSearchIdFromQrValue(
+        'https://lakiite-dev.inoworl.com/friend_cached'
+        '?deep_link=%2Ffriend%2Fsearch%3FsearchId%3DPj5I7M58',
+      );
+
+      expect(searchId, 'Pj5I7M58');
+    });
+
+    test('検索ID単体も後方互換として受け付ける', () {
+      expect(extractFriendSearchIdFromQrValue('Pj5I7M58'), 'Pj5I7M58');
+    });
+  });
+}


### PR DESCRIPTION
## 概要
- 自分のQRコードを searchId 文字列ではなく、Airbridge 友達招待リンクURLで生成するようにしました。
- 友達招待リンク生成とQR生成のどちらから作られても、Functions側の共通キャッシュを通って2回目以降は同じリンクを再利用できる構成にしています。
- QR読み取りは searchId 単体の後方互換を残しつつ、招待リンクURLや nested deeplink から `searchId` を抽出できるようにしました。
- 新規登録・searchId変更時に `reservedSearchIds/{searchId}` を transaction で作成し、一度使われた searchId を再利用不可にしました。

## 関連PR
- Firebase Commons: https://github.com/Inoworl/LaKiite-firebase-commons/pull/36

## 補足
- このPRは Firebase Commons 側の Rules / Functions 変更とセットです。
- dev には Firebase Commons 側で backfill と rules deploy 済みです。
- 本番適用時は、本番 backfill apply -> rules deploy -> Flutter app release の順で進める必要があります。

## 検証
- `fvm dart format lib/infrastructure/user_repository.dart mock/repositories/mock_user_repository.dart test/mock/repository/mock_user_repository.dart`
- `fvm dart format lib/presentation/friend/friend_search_page.dart lib/presentation/friend/friend_search_qr_scanner_page.dart test/presentation/friend/friend_search_page_test.dart test/presentation/friend/friend_search_qr_scanner_page_test.dart`
- `fvm flutter test test/presentation/friend/friend_search_page_test.dart test/presentation/friend/friend_search_qr_scanner_page_test.dart test/presentation/friend/friend_invite_share_content_test.dart`（14 passed）
- `fvm flutter analyze`（No issues found）
- pre-commit: `fvm flutter analyze`（No issues found）+ 全体テスト（244 passed / 1 skipped）
- pre-push: presentation/widget tests（167 passed）