### PR TITLE
fix: use invite domains for iOS Airbridge config

### DIFF
--- a/airbridge.dev.json
+++ b/airbridge.dev.json
@@ -1,6 +1,6 @@
 {
   "autoDetermineTrackingAuthorizationTimeoutInSecond": 0,
   "trackingLinkCustomDomains": [
-    "lakiite-dev.inoworl.com"
+    "invite.lakiite-dev.inoworl.com"
   ]
 }

--- a/airbridge.prod.json
+++ b/airbridge.prod.json
@@ -1,6 +1,6 @@
 {
   "autoDetermineTrackingAuthorizationTimeoutInSecond": 0,
   "trackingLinkCustomDomains": [
-    "lakiite.inoworl.com"
+    "invite.lakiite.inoworl.com"
   ]
 }


### PR DESCRIPTION
## Summary
- Update iOS Airbridge SDK config files to use invite custom domains.
- Align root `airbridge.dev.json` / `airbridge.prod.json` with Android flavor assets.

## Why
- Android already used `invite.lakiite*.inoworl.com`, but iOS copied root `airbridge.<env>.json` during Xcode build.
- The root iOS config still pointed at old custom domains, so iOS could open the app but Airbridge SDK did not resolve the invite link payload correctly.

## Test Plan
- `fvm flutter test test/domain/deep_link/friend_invite_deep_link_test.dart`
- pre-commit `flutter analyze`
- pre-push hook passed
