### PR TITLE
Create release draft when missing

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -231,20 +231,31 @@ jobs:
             fi
           } > "$body_file"
 
+          body="$(cat "$body_file")"
           draft_id="$(gh api "repos/$REPOSITORY/releases" --jq '[.[] | select(.draft == true and .target_commitish == "main")] | sort_by(.updated_at) | reverse | .[0].id // empty')"
           if [ -z "$draft_id" ]; then
-            echo "::error ::No draft release targeting main was found."
-            exit 1
+            draft_id="$(
+              gh api \
+                --method POST \
+                "repos/$REPOSITORY/releases" \
+                -f "name=v$next_version" \
+                -f "tag_name=v$next_version" \
+                -f "target_commitish=main" \
+                -f "body=$body" \
+                -F "draft=true" \
+                --jq ".id"
+            )"
+            echo "Created draft release #$draft_id for v$next_version from $semver_label."
+          else
+            gh api \
+              --method PATCH \
+              "repos/$REPOSITORY/releases/$draft_id" \
+              -f "name=v$next_version" \
+              -f "tag_name=v$next_version" \
+              -f "target_commitish=main" \
+              -f "body=$body"
+            echo "Updated draft release #$draft_id to v$next_version from $semver_label."
           fi
-
-          body="$(cat "$body_file")"
-          gh api \
-            --method PATCH \
-            "repos/$REPOSITORY/releases/$draft_id" \
-            -f "name=v$next_version" \
-            -f "tag_name=v$next_version" \
-            -f "target_commitish=main" \
-            -f "body=$body"
 
           duplicate_draft_ids="$(
             gh api "repos/$REPOSITORY/releases" --jq ".[] | select(.draft == true and .target_commitish == \"main\" and .id != $draft_id) | .id"
@@ -254,5 +265,3 @@ jobs:
             gh api --method DELETE "repos/$REPOSITORY/releases/$duplicate_draft_id"
             echo "Deleted duplicate draft release #$duplicate_draft_id."
           done <<< "$duplicate_draft_ids"
-
-          echo "Updated draft release #$draft_id to v$next_version from $semver_label."


### PR DESCRIPTION
## Summary
- Create a main-targeted draft release automatically when the release PR draft update job cannot find one
- Keep the existing behavior of updating the latest main-targeted draft release when it exists
- Prevent the recurring `No draft release targeting main was found` failure after a release is published

## Root cause
PR #306 failed in Release Drafter because v2.1.0 had already been published and no next draft release targeting `main` existed.

## Immediate recovery
- Created the missing v2.1.1 draft release
- Reran the failed Release Drafter run for PR #306; it now passes

## Test Plan
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release-drafter.yml`
- `git diff --check`
- pre-commit `flutter analyze` passed