### PR TITLE
Serialize release draft updates

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -52,6 +52,9 @@ jobs:
         (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main') ||
         (github.event_name == 'workflow_dispatch' && inputs.main_pr_number != '')
       )
+    concurrency:
+      group: release-drafter-main-pr-${{ github.event_name == 'pull_request' && github.event.pull_request.number || inputs.main_pr_number }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary
- serialize release drafter updates per main release PR
- prevent duplicate v2.1.1 draft releases when labels and PR events trigger concurrently

## Verification
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release-drafter.yml
- git diff --check